### PR TITLE
[ODS-2980] Vendor access to multiple namespace prefixes

### DIFF
--- a/Application/EdFi.Ods.Security/Claims/ClaimsIdentityProvider.cs
+++ b/Application/EdFi.Ods.Security/Claims/ClaimsIdentityProvider.cs
@@ -55,22 +55,25 @@ namespace EdFi.Ods.Security.Claims
             var resourceClaimsByClaimName = resourceClaims.GroupBy(c => c.ResourceClaim.ClaimName);
 
             // Create a list of resource claims to be issued.
-            var claims = (from grouping in resourceClaimsByClaimName
-                let claimValue = new EdFiResourceClaimValue
-                {
-                    Actions = grouping.Select(
-                            x => new ResourceAction(
-                                x.Action.ActionUri,
-                                x.AuthorizationStrategyOverride == null
-                                    ? null
-                                    : x.AuthorizationStrategyOverride.AuthorizationStrategyName,
-                                x.ValidationRuleSetNameOverride))
-                        .ToArray(),
-                    EducationOrganizationIds = educationOrganizationIds.ToList()
-                }
-                select JsonClaimHelper.CreateClaim(grouping.Key, claimValue)).ToList();
-
-            // Create Identity Claims
+            var claims = resourceClaimsByClaimName.Select(
+                    g => new
+                    {
+                        ClaimName = g.Key,
+                        ClaimValue = new EdFiResourceClaimValue
+                        {
+                            Actions = g.Select(
+                                    x => new ResourceAction(
+                                        x.Action.ActionUri,
+                                        x.AuthorizationStrategyOverride == null
+                                            ? null
+                                            : x.AuthorizationStrategyOverride.AuthorizationStrategyName,
+                                        x.ValidationRuleSetNameOverride))
+                                .ToArray(),
+                            EducationOrganizationIds = educationOrganizationIds.ToList()
+                        }
+                    })
+                .Select(x => JsonClaimHelper.CreateClaim(x.ClaimName, x.ClaimValue))
+                .ToList();
 
             // NamespacePrefixes
             nonEmptyNamespacePrefixes.ForEach(

--- a/Application/EdFi.Ods.Security/Claims/ClaimsIdentityProvider.cs
+++ b/Application/EdFi.Ods.Security/Claims/ClaimsIdentityProvider.cs
@@ -2,8 +2,7 @@
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
- 
-using System;
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
@@ -48,47 +47,39 @@ namespace EdFi.Ods.Security.Claims
             IEnumerable<string> namespacePrefixes,
             IReadOnlyList<string> assignedProfileNames)
         {
-            var filteredNamespacePrefixes = namespacePrefixes.Where(np => !string.IsNullOrWhiteSpace(np))
-                                                             .ToList();
+            var filteredNamespacePrefixes = namespacePrefixes.Where(np => !string.IsNullOrWhiteSpace(np)).ToList();
 
             var resourceClaims = _securityRepository.GetClaimsForClaimSet(claimSetName);
 
             // Group the resource claims by name to combine actions (and by claim set name if multiple claim sets are supported in the future)
-            var resourceClaimsByClaimName =
-                from c in resourceClaims
-                group c by c.ResourceClaim.ClaimName
-                into g
+            var resourceClaimsByClaimName = from c in resourceClaims
+                group c by c.ResourceClaim.ClaimName into g
                 select g;
 
             // Create a list of resource claims to be issued.
             var claims = (from grouping in resourceClaimsByClaimName
-                          let claimValue = new EdFiResourceClaimValue
-                                           {
-                                               Actions = grouping.Select(
-                                                                      x =>
-                                                                          new ResourceAction(
-                                                                              x.Action.ActionUri,
-                                                                              x.AuthorizationStrategyOverride == null
-                                                                                  ? null
-                                                                                  : x.AuthorizationStrategyOverride.AuthorizationStrategyName,
-                                                                              x.ValidationRuleSetNameOverride))
-                                                                 .ToArray(),
-                                               EducationOrganizationIds = educationOrganizationIds.ToList()
-                                           }
-                          select JsonClaimHelper.CreateClaim(grouping.Key, claimValue))
-               .ToList();
+                let claimValue = new EdFiResourceClaimValue
+                {
+                    Actions = grouping.Select(
+                            x => new ResourceAction(
+                                x.Action.ActionUri,
+                                x.AuthorizationStrategyOverride == null
+                                    ? null
+                                    : x.AuthorizationStrategyOverride.AuthorizationStrategyName,
+                                x.ValidationRuleSetNameOverride))
+                        .ToArray(),
+                    EducationOrganizationIds = educationOrganizationIds.ToList()
+                }
+                select JsonClaimHelper.CreateClaim(grouping.Key, claimValue)).ToList();
 
             // Create Identity Claims
 
             // NamespacePrefixes
             filteredNamespacePrefixes.ForEach(
-                namespacePrefix =>
-                    claims.Add(new Claim(EdFiOdsApiClaimTypes.NamespacePrefix, namespacePrefix)));
+                namespacePrefix => claims.Add(new Claim(EdFiOdsApiClaimTypes.NamespacePrefix, namespacePrefix)));
 
             // Add Assigned Profile names
-            assignedProfileNames.ForEach(
-                profileName =>
-                    claims.Add(new Claim(EdFiOdsApiClaimTypes.Profile, profileName)));
+            assignedProfileNames.ForEach(profileName => claims.Add(new Claim(EdFiOdsApiClaimTypes.Profile, profileName)));
 
             return new ClaimsIdentity(claims, EdFiAuthenticationTypes.OAuth);
         }

--- a/Application/EdFi.Ods.Security/Claims/ClaimsIdentityProvider.cs
+++ b/Application/EdFi.Ods.Security/Claims/ClaimsIdentityProvider.cs
@@ -52,9 +52,7 @@ namespace EdFi.Ods.Security.Claims
             var resourceClaims = _securityRepository.GetClaimsForClaimSet(claimSetName);
 
             // Group the resource claims by name to combine actions (and by claim set name if multiple claim sets are supported in the future)
-            var resourceClaimsByClaimName = from c in resourceClaims
-                group c by c.ResourceClaim.ClaimName into g
-                select g;
+            var resourceClaimsByClaimName = resourceClaims.GroupBy(c => c.ResourceClaim.ClaimName);
 
             // Create a list of resource claims to be issued.
             var claims = (from grouping in resourceClaimsByClaimName

--- a/Application/EdFi.Ods.Security/Claims/ClaimsIdentityProvider.cs
+++ b/Application/EdFi.Ods.Security/Claims/ClaimsIdentityProvider.cs
@@ -47,7 +47,7 @@ namespace EdFi.Ods.Security.Claims
             IEnumerable<string> namespacePrefixes,
             IReadOnlyList<string> assignedProfileNames)
         {
-            var filteredNamespacePrefixes = namespacePrefixes.Where(np => !string.IsNullOrWhiteSpace(np)).ToList();
+            var nonEmptyNamespacePrefixes = namespacePrefixes.Where(np => !string.IsNullOrWhiteSpace(np)).ToList();
 
             var resourceClaims = _securityRepository.GetClaimsForClaimSet(claimSetName);
 
@@ -75,7 +75,7 @@ namespace EdFi.Ods.Security.Claims
             // Create Identity Claims
 
             // NamespacePrefixes
-            filteredNamespacePrefixes.ForEach(
+            nonEmptyNamespacePrefixes.ForEach(
                 namespacePrefix => claims.Add(new Claim(EdFiOdsApiClaimTypes.NamespacePrefix, namespacePrefix)));
 
             // Add Assigned Profile names

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Security/Authorization/NamespaceBasedAuthorizationTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Security/Authorization/NamespaceBasedAuthorizationTests.cs
@@ -26,6 +26,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Security.Authorization
 
             var claims = new List<Claim>
                          {
+                             new Claim(EdFiOdsApiClaimTypes.NamespacePrefix, string.Empty),
                              new Claim(EdFiOdsApiClaimTypes.NamespacePrefix, string.Empty)
                          };
 
@@ -47,8 +48,8 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Security.Authorization
                     .WaitSafely());
 
             exception.Message.ShouldBe(
-                "Access to the resource could not be authorized because the caller did not have a NamespacePrefix claim ('"
-                + EdFiOdsApiClaimTypes.NamespacePrefix + "') or the claim value was empty.");
+                "Access to the resource could not be authorized because the caller did not have any NamespacePrefix claims ('"
+                + EdFiOdsApiClaimTypes.NamespacePrefix + "') or the claim values were all empty.");
 
             //Assert
         }
@@ -61,7 +62,8 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Security.Authorization
 
             var claims = new List<Claim>
                          {
-                             new Claim(EdFiOdsApiClaimTypes.NamespacePrefix, @"uri://ed-fi.org/")
+                             new Claim(EdFiOdsApiClaimTypes.NamespacePrefix, @"uri://ed-fi.org/"),
+                             new Claim(EdFiOdsApiClaimTypes.NamespacePrefix, @"uri://ed-fi-2.org/")
                          };
 
             ClaimsPrincipal principal = new ClaimsPrincipal(new ClaimsIdentity(claims, EdFiAuthenticationTypes.OAuth));
@@ -94,7 +96,8 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Security.Authorization
 
             var claims = new List<Claim>
                          {
-                             new Claim(EdFiOdsApiClaimTypes.NamespacePrefix, @"uri://ed-fi.org/")
+                             new Claim(EdFiOdsApiClaimTypes.NamespacePrefix, @"uri://ed-fi.org/"),
+                             new Claim(EdFiOdsApiClaimTypes.NamespacePrefix, @"uri://ed-fi-2.org/")
                          };
 
             ClaimsPrincipal principal = new ClaimsPrincipal(new ClaimsIdentity(claims, EdFiAuthenticationTypes.OAuth));
@@ -122,7 +125,8 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Security.Authorization
 
             var claims = new List<Claim>
                          {
-                             new Claim(EdFiOdsApiClaimTypes.NamespacePrefix, @"uri://ed-fi.org/")
+                             new Claim(EdFiOdsApiClaimTypes.NamespacePrefix, @"uri://ed-fi.org/"),
+                             new Claim(EdFiOdsApiClaimTypes.NamespacePrefix, @"uri://ed-fi-2.org/")
                          };
 
             ClaimsPrincipal principal = new ClaimsPrincipal(new ClaimsIdentity(claims, EdFiAuthenticationTypes.OAuth));
@@ -142,7 +146,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Security.Authorization
                         new List<Claim>(), new EdFiAuthorizationContext(principal, new[] {resource}, action, data), CancellationToken.None)
                         .WaitSafely());
 
-            exception.Message.ShouldBe("Access to the resource item with namespace 'uri://www.TEST.org/' could not be authorized based on the caller's NamespacePrefix claim of 'uri://ed-fi.org/'.");
+            exception.Message.ShouldBe("Access to the resource item with namespace 'uri://www.TEST.org/' could not be authorized based on the caller's NamespacePrefix claims: 'uri://ed-fi.org/', 'uri://ed-fi-2.org/'.");
             //Assert
         }
 
@@ -172,8 +176,8 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Security.Authorization
                         .WaitSafely());
 
             exception.Message.ShouldBe(
-                "Access to the resource could not be authorized because the caller did not have a NamespacePrefix claim ('"
-                + EdFiOdsApiClaimTypes.NamespacePrefix + "') or the claim value was empty.");
+                "Access to the resource could not be authorized because the caller did not have any NamespacePrefix claims ('"
+                + EdFiOdsApiClaimTypes.NamespacePrefix + "') or the claim values were all empty.");
 
             //Assert
         }


### PR DESCRIPTION
This PR implements support for multiple prefixes for the standard data management resources.

It does not add support for multiple namespaces in Composite authorization.