### PR TITLE
[ODS-4370] Bring in MetaEd artifacts for release version change

### DIFF
--- a/Application/EdFi.Ods.Standard/Artifacts/Metadata/ApiModel.json
+++ b/Application/EdFi.Ods.Standard/Artifacts/Metadata/ApiModel.json
@@ -1,5 +1,5 @@
 {
-  "odsApiVersion": "4.0.0",
+  "odsApiVersion": "5.0.0",
   "schemaDefinition": {
     "logicalName": "Ed-Fi",
     "physicalName": "edfi",

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Ed-Fi-Core.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Ed-Fi-Core.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" xmlns:ann="http://ed-fi.org/annotation" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:import namespace="http://ed-fi.org/annotation" schemaLocation="SchemaAnnotation.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-AssessmentMetadata.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-AssessmentMetadata.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-Descriptors.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-Descriptors.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-EducationOrgCalendar.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-EducationOrgCalendar.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-EducationOrganization.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-EducationOrganization.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-Finance.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-Finance.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-MasterSchedule.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-MasterSchedule.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-Parent.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-Parent.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-PostSecondaryEvent.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-PostSecondaryEvent.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StaffAssociation.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StaffAssociation.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-Standards.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-Standards.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-Student.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-Student.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentAssessment.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentAssessment.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentAttendance.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentAttendance.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentCohort.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentCohort.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentDiscipline.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentDiscipline.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentEnrollment.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentEnrollment.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentGrade.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentGrade.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentGradebook.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentGradebook.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentIntervention.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentIntervention.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentProgram.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentProgram.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentTranscript.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-StudentTranscript.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-Survey.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/Interchange-Survey.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.2.0-c" targetNamespace="http://ed-fi.org/3.2.0-c" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>

--- a/Application/EdFi.Ods.Standard/Artifacts/Schemas/SchemaAnnotation.xsd
+++ b/Application/EdFi.Ods.Standard/Artifacts/Schemas/SchemaAnnotation.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- (c)2020 Ed-Fi Alliance, LLC. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/annotation" targetNamespace="http://ed-fi.org/annotation" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1.00">
   <xs:simpleType name="DatabaseKey">
     <xs:annotation>


### PR DESCRIPTION
Updates Core and Extensions based on MetaEd v2.2.1-dev.7, which includes bumping to v5.0.0 and removing the copyright header from the xsds.