### PR TITLE
[ODS-4332] InstanceYear Api Support

### DIFF
--- a/Application/EdFi.Common/Configuration/ApiConfigurationConstants.cs
+++ b/Application/EdFi.Common/Configuration/ApiConfigurationConstants.cs
@@ -9,6 +9,7 @@ namespace EdFi.Common.Configuration
     {
         public const string Sandbox = "sandbox";
         public const string YearSpecific = "yearspecific";
+        public const string InstanceYearSpecific = "instanceyearspecific";
         public const string SharedInstance = "sharedinstance";
         public const string DistrictSpecific = "districtspecific";
 

--- a/Application/EdFi.Common/Configuration/ApiMode.cs
+++ b/Application/EdFi.Common/Configuration/ApiMode.cs
@@ -9,6 +9,7 @@ namespace EdFi.Common.Configuration
     {
         public static readonly ApiMode Sandbox = new ApiMode(ApiConfigurationConstants.Sandbox, "Sandbox");
         public static readonly ApiMode YearSpecific = new ApiMode(ApiConfigurationConstants.YearSpecific, "Year Specific");
+        public static readonly ApiMode InstanceYearSpecific = new ApiMode(ApiConfigurationConstants.InstanceYearSpecific, "Instance Year Specific");
         public static readonly ApiMode SharedInstance = new ApiMode(ApiConfigurationConstants.SharedInstance, "Shared Instance");
         public static readonly ApiMode DistrictSpecific = new ApiMode(ApiConfigurationConstants.DistrictSpecific, "District Specific");
 

--- a/Application/EdFi.Ods.Api/Caching/InstanceSecurityRepositoryCache.cs
+++ b/Application/EdFi.Ods.Api/Caching/InstanceSecurityRepositoryCache.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using System.Data.Entity;
+using System.Linq;
+using System.Threading;
+using EdFi.Common;
+using EdFi.Common.Utils;
+using EdFi.Ods.Api.Extensions;
+using EdFi.Ods.Common.Caching;
+using EdFi.Security.DataAccess.Caching;
+using EdFi.Security.DataAccess.Contexts;
+
+namespace EdFi.Ods.Api.Caching
+{
+    //NOTE: This class is placed in EdFi.Ods.Api to remove cyclic dependency on MemoryCacheProvider etc.
+    public class InstanceSecurityRepositoryCache : IInstanceSecurityRepositoryCache
+    {
+        // This exists as a place to put a global singleton of the SecurityRepository Cache.
+        public static Func<IInstanceSecurityRepositoryCache> GetCache = () => null;
+
+        private const int DatabaseSynchronizationExpirationSeconds = 3600; // seconds in an hour
+        private const string InitializedKeyPrefix = "SecurityRepositoriesCache.Initialized";
+        private const string LastSyncedKey = "SecurityRepositoriesCache.LastSynced";
+        private const string EdFiOdsApi = "Ed-Fi ODS API";
+
+        private readonly object _cacheInitializationLocker = new object();
+
+        private readonly ReaderWriterLockSlim _cacheLock = new ReaderWriterLockSlim();
+        private readonly ISecurityContextFactory _securityContextFactory;
+        private readonly ICacheProvider _cacheProvider;
+
+        public InstanceSecurityRepositoryCache(ISecurityContextFactory securityContextFactory, ICacheProvider cacheProvider)
+        {
+            _securityContextFactory = Preconditions.ThrowIfNull(securityContextFactory, nameof(securityContextFactory));
+            _cacheProvider = Preconditions.ThrowIfNull(cacheProvider, nameof(cacheProvider));
+        }
+
+        #region Cache Code
+        private void EnsureCacheInitialized(string instanceId)
+        {
+            object initializedAsObject;
+
+            string cacheKey = GetCurrentCacheInitializedKey(instanceId);
+
+            if (!_cacheProvider.TryGetCachedObject(cacheKey, out initializedAsObject))
+            {
+                // Make sure there is only one cache set being initialized at a time
+                lock (_cacheInitializationLocker)
+                {
+                    if (!_cacheProvider.TryGetCachedObject(cacheKey, out initializedAsObject))
+                    {
+                        TryRefreshCache(instanceId, force: true);
+
+                        _cacheProvider.SetCachedObject(cacheKey, true);
+                    }
+                }
+            }
+        }
+
+        private bool HasLastDatabaseSynchronizationExpired(string instanceId)
+        {
+            var currentTime = SystemClock.Now();
+
+            if (!_cacheProvider.TryGetCachedObject(GetLastSynchedKey(instanceId), out object lastSynced))
+            {
+                lastSynced = DateTime.MinValue;
+            }
+
+            var totalSeconds = (currentTime - (DateTime)lastSynced).TotalSeconds;
+            return totalSeconds > DatabaseSynchronizationExpirationSeconds;
+        }
+
+        private string GetCurrentCacheInitializedKey(string instanceId)
+        {
+            return InitializedKeyPrefix + "." + instanceId;
+        }
+
+        private string GetLastSynchedKey(string instanceId)
+        {
+            return LastSyncedKey + "." + instanceId;
+        }
+
+        private bool TryRefreshCache(string instanceId, bool force = false)
+        {
+
+            if (force || HasLastDatabaseSynchronizationExpired(instanceId))
+            {
+                _cacheLock.EnterUpgradeableReadLock();
+
+                try
+                {
+                    if (force || HasLastDatabaseSynchronizationExpired(instanceId))
+                    {
+                        _cacheLock.EnterWriteLock();
+
+                        try
+                        {
+
+                            LoadSecurityConfigurationFromDatabaseAndAddToCache(instanceId);
+
+                            _cacheProvider.SetCachedObject(GetLastSynchedKey(instanceId), SystemClock.Now());
+                        }
+                        finally
+                        {
+                            _cacheLock.ExitWriteLock();
+                        }
+                    }
+
+                    return true;
+                }
+                finally
+                {
+                    _cacheLock.ExitUpgradeableReadLock();
+                }
+            }
+
+            return false;
+        }
+
+        private void LoadSecurityConfigurationFromDatabaseAndAddToCache(string instanceId)
+        {
+            using (var context = _securityContextFactory.CreateContext())
+            {
+                var application =
+                    context.Applications.First(
+                        app => app.ApplicationName.Equals(EdFiOdsApi, StringComparison.InvariantCultureIgnoreCase));
+
+                var actions = context.Actions.ToList();
+
+                var claimSets = context.ClaimSets.Include(cs => cs.Application)
+                                       .ToList();
+
+                var resourceClaims = context.ResourceClaims.Include(rc => rc.Application)
+                                            .Include(rc => rc.ParentResourceClaim)
+                                            .Where(rc => rc.Application.ApplicationId.Equals(application.ApplicationId))
+                                            .ToList();
+
+                var authorizationStrategies = context.AuthorizationStrategies.Include(auth => auth.Application)
+                                                     .Where(auth => auth.Application.ApplicationId.Equals(application.ApplicationId))
+                                                     .ToList();
+
+                var claimSetResourceClaims = context.ClaimSetResourceClaims.Include(csrc => csrc.Action)
+                                                    .Include(csrc => csrc.ClaimSet)
+                                                    .Include(csrc => csrc.ResourceClaim)
+                                                    .Where(csrc => csrc.ResourceClaim.Application.ApplicationId.Equals(application.ApplicationId))
+                                                    .ToList();
+
+                var resourceClaimAuthorizationMetadata =
+                    context.ResourceClaimAuthorizationMetadatas.Include(rcas => rcas.Action)
+                           .Include(rcas => rcas.AuthorizationStrategy)
+                           .Include(rcas => rcas.ResourceClaim)
+                           .Where(rcas => rcas.ResourceClaim.Application.ApplicationId.Equals(application.ApplicationId))
+                           .ToList();
+
+                var repo = new InstanceSecurityRepositoryCacheObject(
+                    application,
+                    actions,
+                    claimSets,
+                    resourceClaims,
+                    authorizationStrategies,
+                    claimSetResourceClaims,
+                    resourceClaimAuthorizationMetadata);
+
+                _cacheProvider.SetCachedObject(instanceId, repo);
+            }
+        }
+
+        private bool TryGetCachedRepo(string lookupKey, out InstanceSecurityRepositoryCacheObject securityRepositoryCacheObject)
+        {
+            _cacheLock.EnterReadLock();
+
+            try
+            {
+                return CacheProviderExtensions.TryGetCachedObject(_cacheProvider, lookupKey, out securityRepositoryCacheObject);
+            }
+            finally
+            {
+                _cacheLock.ExitReadLock();
+            }
+        }
+        #endregion
+
+        public InstanceSecurityRepositoryCacheObject GetSecurityRepository(string instanceId)
+        {
+            EnsureCacheInitialized(instanceId);
+            TryRefreshCache(instanceId); //NOTE: To refresh if cache expired
+            if (!TryGetCachedRepo(instanceId, out InstanceSecurityRepositoryCacheObject repositoryCacheObject))
+            {
+                throw new InvalidOperationException("Expected InstanceSecurityRepositoryCacheObject not found even after ensuring cache was initialized");
+            }
+            return repositoryCacheObject;
+        }
+    }
+}

--- a/Application/EdFi.Ods.Api/Constants/RouteConstants.cs
+++ b/Application/EdFi.Ods.Api/Constants/RouteConstants.cs
@@ -21,5 +21,10 @@ namespace EdFi.Ods.Api.Constants
         {
             get => @"{schoolYearFromRoute:regex(^\d{{4}}$)}/";
         }
+
+        public static string InstanceIdFromRoute
+        {
+            get => @"{instanceIdFromRoute:regex(^[[A-Za-z0-9-]]+$)}/";
+        }
     }
 }

--- a/Application/EdFi.Ods.Api/Container/Modules/InstanceYearSpecificModule.cs
+++ b/Application/EdFi.Ods.Api/Container/Modules/InstanceYearSpecificModule.cs
@@ -1,0 +1,62 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Autofac;
+using Autofac.Core;
+using EdFi.Common.Configuration;
+using EdFi.Ods.Api.Caching;
+using EdFi.Ods.Api.Conventions;
+using EdFi.Ods.Api.Filters;
+using EdFi.Ods.Common.Caching;
+using EdFi.Ods.Common.Configuration;
+using EdFi.Ods.Common.Container;
+using EdFi.Ods.Common.Context;
+using EdFi.Ods.Common.Database;
+using EdFi.Security.DataAccess.Caching;
+using EdFi.Security.DataAccess.Repositories;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace EdFi.Ods.Api.Container.Modules
+{
+    public class InstanceYearSpecificModule : ConditionalModule
+    {
+        public InstanceYearSpecificModule(ApiSettings apiSettings)
+            : base(apiSettings, nameof(InstanceYearSpecificModule)) { }
+
+        public override bool IsSelected() => ApiSettings.GetApiMode() == ApiMode.InstanceYearSpecific;
+
+        public override void ApplyConfigurationSpecificRegistrations(ContainerBuilder builder)
+        {
+            builder.RegisterType<TokenControllerRouteConvention>()
+                .As<IApplicationModelConvention>()
+                .SingleInstance();
+
+            builder.RegisterType<InstanceIdContextFilter>()
+                .As<IFilterMetadata>();
+
+            builder.RegisterType<InstanceIdContextProvider>()
+                .As<IInstanceIdContextProvider>()
+                .As<IHttpContextStorageTransferKeys>();
+
+            builder.RegisterType<InstanceYearSpecificAdminDatabaseNameReplacementTokenProvider>()
+                .As<IAdminDatabaseNameReplacementTokenProvider>();
+
+            builder.RegisterType<InstanceYearSpecificSecurityDatabaseNameReplacementTokenProvider>()
+                .As<ISecurityDatabaseNameReplacementTokenProvider>();
+
+            builder.RegisterType<InstanceYearSpecificDatabaseNameReplacementTokenProvider>()
+                .As<IDatabaseNameReplacementTokenProvider>();
+
+            builder.RegisterType<InstanceSecurityRepository>()
+                .As<ISecurityRepository>()
+                .SingleInstance();
+
+            builder.RegisterType<InstanceSecurityRepositoryCache>()
+                .As<IInstanceSecurityRepositoryCache>()
+                .SingleInstance();
+        }
+    }
+}

--- a/Application/EdFi.Ods.Api/Container/Modules/InstanceYearSpecificPersistenceModule.cs
+++ b/Application/EdFi.Ods.Api/Container/Modules/InstanceYearSpecificPersistenceModule.cs
@@ -1,0 +1,48 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Autofac;
+using EdFi.Admin.DataAccess.Providers;
+using EdFi.Common.Configuration;
+using EdFi.Ods.Api.Database;
+using EdFi.Ods.Common.Configuration;
+using EdFi.Ods.Common.Container;
+using EdFi.Security.DataAccess.Providers;
+
+namespace EdFi.Ods.Api.Container.Modules
+{
+    public class InstanceYearSpecificPersistenceModule : ConditionalModule
+    {
+        public InstanceYearSpecificPersistenceModule(ApiSettings apiSettings)
+            : base(apiSettings, nameof(InstanceYearSpecificPersistenceModule)) { }
+
+        //Need to run every time
+        public override bool IsSelected() => true;
+
+        public override void ApplyConfigurationSpecificRegistrations(ContainerBuilder builder)
+        {
+            if (ApiSettings.GetApiMode() == ApiMode.InstanceYearSpecific)
+            {
+                builder.RegisterType<InstanceAdminDatabaseNameTokenReplacementConnectionStringProvider>()
+                    .As<IAdminDatabaseConnectionStringProvider>()
+                    .SingleInstance();
+
+                builder.RegisterType<InstanceSecurityDatabaseNameTokenReplacementConnectionStringProvider>()
+                    .As<ISecurityDatabaseConnectionStringProvider>()
+                    .SingleInstance();
+            }
+            else
+            {
+                builder.RegisterType<AdminDatabaseConnectionStringProvider>()
+                    .As<IAdminDatabaseConnectionStringProvider>()
+                    .SingleInstance();
+
+                builder.RegisterType<SecurityDatabaseConnectionStringProvider>()
+                    .As<ISecurityDatabaseConnectionStringProvider>()
+                    .SingleInstance();
+            }
+        }
+    }
+}

--- a/Application/EdFi.Ods.Api/Container/Modules/PersistenceModule.cs
+++ b/Application/EdFi.Ods.Api/Container/Modules/PersistenceModule.cs
@@ -31,10 +31,6 @@ namespace EdFi.Ods.Api.Container.Modules
     {
         protected override void Load(ContainerBuilder builder)
         {
-            builder.RegisterType<AdminDatabaseConnectionStringProvider>()
-                .As<IAdminDatabaseConnectionStringProvider>()
-                .SingleInstance();
-
             builder.Register(c => new MemoryCache(new MemoryCacheOptions()))
                 .As<IMemoryCache>()
                 .SingleInstance();
@@ -124,10 +120,6 @@ namespace EdFi.Ods.Api.Container.Modules
 
             builder.RegisterGeneric(typeof(UpsertEntity<>))
                 .As(typeof(IUpsertEntity<>))
-                .SingleInstance();
-
-            builder.RegisterType<SecurityDatabaseConnectionStringProvider>()
-                .As<ISecurityDatabaseConnectionStringProvider>()
                 .SingleInstance();
 
             builder.RegisterType<UniqueIdToUsiValueMapper>().As<IUniqueIdToUsiValueMapper>()

--- a/Application/EdFi.Ods.Api/Controllers/VersionController.cs
+++ b/Application/EdFi.Ods.Api/Controllers/VersionController.cs
@@ -80,23 +80,42 @@ namespace EdFi.Ods.Api.Controllers
             {
                 var currentYear = _systemDateProvider.GetDate().Year.ToString();
 
+                // since instance is dynamic and given through url, this value is just a place holder
+                var instance = "{instance}";
+
                 bool isYearSpecific = _apiSettings.GetApiMode().Equals(ApiMode.YearSpecific);
+                bool isInstanceYearSpecific = _apiSettings.GetApiMode().Equals(ApiMode.InstanceYearSpecific);
+
+                //This also involves year itself, thus year needs to be true
+                if (isInstanceYearSpecific) isYearSpecific = true;
 
                 bool useReverseProxyHeaders = _apiSettings.UseReverseProxyHeaders ?? false;
 
                 var exposedUrls = new ExposedUrls
                 {
                     DependenciesUrl = Request.RootUrl(useReverseProxyHeaders) +
-                                      (isYearSpecific
-                                          ? $"/metadata/data/v{ApiVersionConstants.Ods}/" + currentYear + "/dependencies"
-                                          : $"/metadata/data/v{ApiVersionConstants.Ods}/dependencies"),
+                                      (isInstanceYearSpecific
+                                          ? $"/metadata/data/v{ApiVersionConstants.Ods}/" + $"{instance}/" + currentYear + "/dependencies" :
+                                          (isYearSpecific
+                                              ? $"/metadata/data/v{ApiVersionConstants.Ods}/" + currentYear + "/dependencies"
+                                              : $"/metadata/data/v{ApiVersionConstants.Ods}/dependencies")),
                     MetaDataUrl = Request.RootUrl(useReverseProxyHeaders) + "/metadata/" +
+                                  (isInstanceYearSpecific
+                                      ? $"{instance}/"
+                                      : string.Empty) +
                                   (isYearSpecific
                                       ? currentYear
                                       : string.Empty),
-                    OauthUrl = Request.RootUrl(useReverseProxyHeaders) + "/oauth/token",
+                    OauthUrl = Request.RootUrl(useReverseProxyHeaders) +
+                               (isInstanceYearSpecific
+                                   ? $"/{instance}"
+                                   : string.Empty) +
+                               "/oauth/token",
                     ApiUrl = Request.RootUrl(useReverseProxyHeaders) +
                              $"/data/v{ApiVersionConstants.Ods}/" +
+                             (isInstanceYearSpecific
+                                 ? $"{instance}/"
+                                 : string.Empty) +
                              (isYearSpecific
                                  ? currentYear
                                  : string.Empty)

--- a/Application/EdFi.Ods.Api/Conventions/DataManagementControllerRouteConvention.cs
+++ b/Application/EdFi.Ods.Api/Conventions/DataManagementControllerRouteConvention.cs
@@ -52,6 +52,12 @@ namespace EdFi.Ods.Api.Conventions
                     template += RouteConstants.SchoolYearFromRoute;
                 }
 
+                if (_apiSettings.GetApiMode() == ApiMode.InstanceYearSpecific)
+                {
+                    template += RouteConstants.InstanceIdFromRoute;
+                    template += RouteConstants.SchoolYearFromRoute;
+                }
+
                 return template;
             }
         }

--- a/Application/EdFi.Ods.Api/Conventions/TokenControllerRouteConvention.cs
+++ b/Application/EdFi.Ods.Api/Conventions/TokenControllerRouteConvention.cs
@@ -7,17 +7,17 @@ using System.Linq;
 using System.Reflection;
 using EdFi.Common.Configuration;
 using EdFi.Ods.Api.Constants;
+using EdFi.Ods.Api.Controllers;
 using EdFi.Ods.Common.Configuration;
-using EdFi.Ods.Features.Controllers;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 
-namespace EdFi.Ods.Features.Conventions
+namespace EdFi.Ods.Api.Conventions
 {
-    public class OpenApiMetadataRouteConvention : IApplicationModelConvention
+    public class TokenControllerRouteConvention : IApplicationModelConvention
     {
         private readonly ApiSettings _apiSettings;
 
-        public OpenApiMetadataRouteConvention(ApiSettings apiSettings)
+        public TokenControllerRouteConvention(ApiSettings apiSettings)
         {
             _apiSettings = apiSettings;
         }
@@ -25,36 +25,31 @@ namespace EdFi.Ods.Features.Conventions
         public void Apply(ApplicationModel application)
         {
             var controller =
-                application.Controllers.FirstOrDefault(x => x.ControllerType == typeof(OpenApiMetadataController).GetTypeInfo());
+                application.Controllers.FirstOrDefault(x => x.ControllerType == typeof(TokenController).GetTypeInfo());
 
             if (controller != null)
             {
-                var routeSuffix = new AttributeRouteModel {Template = CreateRouteTemplate()};
+                var routePrefix = new AttributeRouteModel {Template = CreateRouteTemplate()};
 
                 foreach (var selector in controller.Selectors)
                 {
                     if (selector.AttributeRouteModel != null)
                     {
                         selector.AttributeRouteModel = AttributeRouteModel.CombineAttributeRouteModel(
-                            selector.AttributeRouteModel,
-                            routeSuffix);
+                            routePrefix,
+                            selector.AttributeRouteModel);
                     }
                 }
             }
 
             string CreateRouteTemplate()
             {
-                string template = string.Empty;
 
-                if (_apiSettings.GetApiMode() == ApiMode.YearSpecific)
-                {
-                    template += RouteConstants.SchoolYearFromRoute;
-                }
+                string template = "";
 
-                if (_apiSettings.GetApiMode() == ApiMode.InstanceYearSpecific)
+               if (_apiSettings.GetApiMode() == ApiMode.InstanceYearSpecific)
                 {
                     template += RouteConstants.InstanceIdFromRoute;
-                    template += RouteConstants.SchoolYearFromRoute;
                 }
 
                 return template;

--- a/Application/EdFi.Ods.Api/Database/InstanceAdminDatabaseNameTokenReplacementConnectionStringProvider.cs
+++ b/Application/EdFi.Ods.Api/Database/InstanceAdminDatabaseNameTokenReplacementConnectionStringProvider.cs
@@ -1,0 +1,62 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using EdFi.Admin.DataAccess.Providers;
+using EdFi.Common.Configuration;
+using EdFi.Common.Database;
+using EdFi.Common.Extensions;
+using EdFi.Ods.Common.Database;
+
+namespace EdFi.Ods.Api.Database
+{
+    public class InstanceAdminDatabaseNameTokenReplacementConnectionStringProvider : IAdminDatabaseConnectionStringProvider
+    {
+        private const string ConnectionStringName = "EdFi_Admin";
+        private readonly IConfigConnectionStringsProvider _configConnectionStringsProvider;
+        private readonly IDbConnectionStringBuilderAdapterFactory _connectionStringBuilderFactory;
+        private readonly IAdminDatabaseNameReplacementTokenProvider _adminDatabaseNameReplacementTokenProvider;
+
+        public InstanceAdminDatabaseNameTokenReplacementConnectionStringProvider(IConfigConnectionStringsProvider configConnectionStringsProvider, IDbConnectionStringBuilderAdapterFactory connectionStringBuilderFactory, IAdminDatabaseNameReplacementTokenProvider adminDatabaseNameReplacementTokenProvider)
+        {
+            _configConnectionStringsProvider = configConnectionStringsProvider;
+            _connectionStringBuilderFactory = connectionStringBuilderFactory;
+            _adminDatabaseNameReplacementTokenProvider = adminDatabaseNameReplacementTokenProvider;
+        }
+
+        public string GetConnectionString()
+        {
+            var adminConnectionString = AdminConnectionString();
+
+            if (string.IsNullOrEmpty(adminConnectionString))
+            {
+                throw new ArgumentException($"No connection string named '{ConnectionStringName}' was found in the 'connectionStrings' section of the application configuration file.");
+            }
+
+            var connectionStringBuilder = _connectionStringBuilderFactory.Get();
+            connectionStringBuilder.ConnectionString = adminConnectionString;
+
+            // Override the Database Name, format if string coming in has a format replacement token,
+            // otherwise use database name set in the Initial Catalog.
+            connectionStringBuilder.DatabaseName = connectionStringBuilder.DatabaseName.IsFormatString()
+                ? string.Format(
+                    connectionStringBuilder.DatabaseName,
+                    _adminDatabaseNameReplacementTokenProvider.GetReplacementToken())
+                : connectionStringBuilder.DatabaseName;
+
+            return connectionStringBuilder.ConnectionString;
+
+            string AdminConnectionString()
+            {
+                if (_configConnectionStringsProvider.Count == 0)
+                {
+                    throw new ArgumentException("No connection strings were found in the configuration file.");
+                }
+
+                return _configConnectionStringsProvider.GetConnectionString(ConnectionStringName);
+            }
+        }
+    }
+}

--- a/Application/EdFi.Ods.Api/Database/InstanceSecurityDatabaseNameTokenReplacementConnectionStringProvider.cs
+++ b/Application/EdFi.Ods.Api/Database/InstanceSecurityDatabaseNameTokenReplacementConnectionStringProvider.cs
@@ -1,0 +1,62 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using EdFi.Common.Configuration;
+using EdFi.Common.Database;
+using EdFi.Common.Extensions;
+using EdFi.Ods.Common.Database;
+using EdFi.Security.DataAccess.Providers;
+
+namespace EdFi.Ods.Api.Database
+{
+    public class InstanceSecurityDatabaseNameTokenReplacementConnectionStringProvider : ISecurityDatabaseConnectionStringProvider
+    {
+        private const string ConnectionStringName = "EdFi_Security";
+        private readonly IConfigConnectionStringsProvider _configConnectionStringsProvider;
+        private readonly IDbConnectionStringBuilderAdapterFactory _connectionStringBuilderFactory;
+        private readonly ISecurityDatabaseNameReplacementTokenProvider _securityDatabaseNameReplacementTokenProvider;
+
+        public InstanceSecurityDatabaseNameTokenReplacementConnectionStringProvider(IConfigConnectionStringsProvider configConnectionStringsProvider, IDbConnectionStringBuilderAdapterFactory connectionStringBuilderFactory, ISecurityDatabaseNameReplacementTokenProvider securityDatabaseNameReplacementTokenProvider)
+        {
+            _configConnectionStringsProvider = configConnectionStringsProvider;
+            _connectionStringBuilderFactory = connectionStringBuilderFactory;
+            _securityDatabaseNameReplacementTokenProvider = securityDatabaseNameReplacementTokenProvider;
+        }
+
+        public string GetConnectionString()
+        {
+            var securityConnectionString = SecurityConnectionString();
+
+            if (string.IsNullOrEmpty(securityConnectionString))
+            {
+                throw new ArgumentException($"No connection string named '{ConnectionStringName}' was found in the 'connectionStrings' section of the application configuration file.");
+            }
+
+            var connectionStringBuilder = _connectionStringBuilderFactory.Get();
+            connectionStringBuilder.ConnectionString = securityConnectionString;
+
+            // Override the Database Name, format if string coming in has a format replacement token,
+            // otherwise use database name set in the Initial Catalog.
+            connectionStringBuilder.DatabaseName = connectionStringBuilder.DatabaseName.IsFormatString()
+                ? string.Format(
+                    connectionStringBuilder.DatabaseName,
+                    _securityDatabaseNameReplacementTokenProvider.GetReplacementToken())
+                : connectionStringBuilder.DatabaseName;
+
+            return connectionStringBuilder.ConnectionString;
+
+            string SecurityConnectionString()
+            {
+                if (_configConnectionStringsProvider.Count == 0)
+                {
+                    throw new ArgumentException("No connection strings were found in the configuration file.");
+                }
+
+                return _configConnectionStringsProvider.GetConnectionString(ConnectionStringName);
+            }
+        }
+    }
+}

--- a/Application/EdFi.Ods.Api/Filters/InstanceIdContextFilter.cs
+++ b/Application/EdFi.Ods.Api/Filters/InstanceIdContextFilter.cs
@@ -1,0 +1,52 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Ods.Common.Context;
+using Microsoft.AspNetCore.Mvc.Filters;
+using System.Text.RegularExpressions;
+
+namespace EdFi.Ods.Api.Filters
+{
+    public class InstanceIdContextFilter : IActionFilter
+    {
+        private const string Pattern = @"^[A-Za-z0-9-]+$";
+
+        private readonly IInstanceIdContextProvider _instanceIdContextProvider;
+
+        public InstanceIdContextFilter(IInstanceIdContextProvider instanceIdContextProvider)
+        {
+            _instanceIdContextProvider = instanceIdContextProvider;
+        }
+
+        public void OnActionExecuted(ActionExecutedContext context)
+        {
+        }
+
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+            if (!context.HttpContext.Request.RouteValues.TryGetValue("instanceIdFromRoute", out object instance))
+            {
+                return;
+            }
+
+            // Convert the object value to a string and see if it is empty
+            string instanceId = instance as string;
+            if (string.IsNullOrEmpty(instanceId))
+            {
+                return;
+            }
+
+            //check that the character's are allowed
+            Match match = Regex.Match(instanceId, Pattern);
+            if (!match.Success)
+            {
+                return;
+            }
+
+            // If we're still here, set the context value
+            _instanceIdContextProvider.SetInstanceId(instanceId);
+        }
+    }
+}

--- a/Application/EdFi.Ods.Api/Middleware/EdFiOAuthAuthenticationHandler.cs
+++ b/Application/EdFi.Ods.Api/Middleware/EdFiOAuthAuthenticationHandler.cs
@@ -6,8 +6,10 @@
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using EdFi.Ods.Api.Providers;
+using EdFi.Ods.Common.Context;
 using EdFi.Ods.Common.Security;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
@@ -19,6 +21,7 @@ namespace EdFi.Ods.Api.Middleware
     {
         private readonly IApiKeyContextProvider _apiKeyContextProvider;
         private readonly IAuthenticationProvider _authenticationProvider;
+        private readonly IInstanceIdContextProvider _instanceIdContextProvider;
 
         public EdFiOAuthAuthenticationHandler(
             IOptionsMonitor<AuthenticationSchemeOptions> options,
@@ -26,11 +29,13 @@ namespace EdFi.Ods.Api.Middleware
             UrlEncoder encoder,
             ISystemClock clock,
             IAuthenticationProvider authenticationProvider,
-            IApiKeyContextProvider apiKeyContextProvider)
+            IApiKeyContextProvider apiKeyContextProvider,
+            IInstanceIdContextProvider instanceIdContextProvider = null)
             : base(options, logger, encoder, clock)
         {
             _authenticationProvider = authenticationProvider;
             _apiKeyContextProvider = apiKeyContextProvider;
+            _instanceIdContextProvider = instanceIdContextProvider;
         }
 
         protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
@@ -43,6 +48,26 @@ namespace EdFi.Ods.Api.Middleware
                 {
                     return AuthenticateResult.NoResult();
                 }
+
+                //NOTE: Patch for setting instanceId as IFilterMetadata (InstanceIdContextFilter) is run's too late for EdFi_Admin and EdFi_Security databases.
+                /* ------- */
+                if (Request.RouteValues.TryGetValue("instanceIdFromRoute", out object instance))
+                {
+                    // Convert the object value to a string and see if it is empty
+                    var instanceId = instance as string;
+                    if (!string.IsNullOrEmpty(instanceId))
+                    {
+                        const string Pattern = @"^[A-Za-z0-9-]+$";
+                        //check that the character's are allowed
+                        Match match = Regex.Match(instanceId, Pattern);
+                        if (match.Success && _instanceIdContextProvider != null)
+                        {
+                            // If we're still here, set the context value
+                            _instanceIdContextProvider.SetInstanceId(instanceId);
+                        }
+                    }
+                }
+                /* ------- */
 
                 authenticationResult = await _authenticationProvider.GetAuthenticationResultAsync(authHeader);
 

--- a/Application/EdFi.Ods.Api/Repositories/InstanceSecurityRepository.cs
+++ b/Application/EdFi.Ods.Api/Repositories/InstanceSecurityRepository.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using EdFi.Common;
+using EdFi.Ods.Api.Caching;
+using EdFi.Ods.Common.Context;
+using EdFi.Security.DataAccess.Models;
+using Action = EdFi.Security.DataAccess.Models.Action;
+
+namespace EdFi.Security.DataAccess.Repositories
+{
+    //NOTE: This class is placed in EdFi.Ods.Api to remove cyclic dependency on InstanceSecurityRepositoryCache
+    public class InstanceSecurityRepository : ISecurityRepository
+    {
+        private readonly IInstanceIdContextProvider _instanceIdContextProvider;
+
+        public InstanceSecurityRepository(IInstanceIdContextProvider instanceIdContextProvider)
+        {
+            _instanceIdContextProvider = Preconditions.ThrowIfNull(instanceIdContextProvider, nameof(instanceIdContextProvider));
+        }
+
+        public virtual Action GetActionByHttpVerb(string httpVerb)
+        {
+            string actionName = string.Empty;
+
+            switch (httpVerb)
+            {
+                case "GET":
+                    actionName = "Read";
+                    break;
+                case "POST":
+                    actionName = "Create";
+                    break;
+                case "PUT":
+                    actionName = "Update";
+                    break;
+                case "DELETE":
+                    actionName = "Delete";
+                    break;
+            }
+
+            return GetActionByName(actionName);
+        }
+
+        public virtual Action GetActionByName(string actionName)
+        {
+            var instanceId = _instanceIdContextProvider.GetInstanceId();
+            if (string.IsNullOrEmpty(instanceId))
+            {
+                throw new InvalidOperationException("Expected instanceId is null or empty.");
+            }
+
+            var instanceSecurityRepoCacheObject = InstanceSecurityRepositoryCache.GetCache()
+                .GetSecurityRepository(instanceId);
+
+            return instanceSecurityRepoCacheObject.Actions.First(a => a.ActionName.Equals(actionName, StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        public virtual AuthorizationStrategy GetAuthorizationStrategyByName(string authorizationStrategyName)
+        {
+            var instanceId = _instanceIdContextProvider.GetInstanceId();
+            if (string.IsNullOrEmpty(instanceId))
+            {
+                throw new InvalidOperationException("Expected instanceId is null or empty.");
+            }
+
+            var instanceSecurityRepoCacheObject = InstanceSecurityRepositoryCache.GetCache()
+                .GetSecurityRepository(instanceId);
+
+            return instanceSecurityRepoCacheObject.AuthorizationStrategies.First(
+                a => a.AuthorizationStrategyName.Equals(authorizationStrategyName, StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        public virtual IEnumerable<ClaimSetResourceClaim> GetClaimsForClaimSet(string claimSetName)
+        {
+            var instanceId = _instanceIdContextProvider.GetInstanceId();
+            if (string.IsNullOrEmpty(instanceId))
+            {
+                throw new InvalidOperationException("Expected instanceId is null or empty.");
+            }
+
+            var instanceSecurityRepoCacheObject = InstanceSecurityRepositoryCache.GetCache()
+                .GetSecurityRepository(instanceId);
+
+            return instanceSecurityRepoCacheObject.ClaimSetResourceClaims.Where(c => c.ClaimSet.ClaimSetName.Equals(claimSetName, StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        /// <summary>
+        /// Gets the lineage up the taxonomy of resource claim URIs for the specified resource.
+        /// </summary>
+        /// <param name="resourceClaimUri">The resource claim URI representing the resource.</param>
+        /// <returns>The lineage of resource claim URIs.</returns>
+        public virtual IEnumerable<string> GetResourceClaimLineage(string resourceClaimUri)
+        {
+            return GetResourceClaimLineageForResourceClaim(resourceClaimUri)
+               .Select(c => c.ClaimName);
+        }
+
+        private IEnumerable<ResourceClaim> GetResourceClaimLineageForResourceClaim(string resourceClaimUri)
+        {
+            var instanceId = _instanceIdContextProvider.GetInstanceId();
+            if (string.IsNullOrEmpty(instanceId))
+            {
+                throw new InvalidOperationException("Expected instanceId is null or empty.");
+            }
+
+            var instanceSecurityRepoCacheObject = InstanceSecurityRepositoryCache.GetCache()
+                .GetSecurityRepository(instanceId);
+
+            var resourceClaimLineage = new List<ResourceClaim>();
+
+            ResourceClaim resourceClaim;
+
+            try
+            {
+                resourceClaim = instanceSecurityRepoCacheObject.ResourceClaims
+                    .SingleOrDefault(rc => rc.ClaimName.Equals(resourceClaimUri, StringComparison.InvariantCultureIgnoreCase));
+            }
+            catch (InvalidOperationException ex)
+            {
+                // Use InvalidOperationException wrapper with custom message over InvalidOperationException
+                // thrown by Linq to communicate back to caller the problem with the configuration.
+                throw new InvalidOperationException($"Multiple resource claims with a claim name of '{resourceClaimUri}' were found in the Ed-Fi API's security configuration. Authorization cannot be performed.", ex);
+            }
+
+            if (resourceClaim != null)
+            {
+                resourceClaimLineage.Add(resourceClaim);
+
+                if (resourceClaim.ParentResourceClaim != null)
+                {
+                    resourceClaimLineage.AddRange(GetResourceClaimLineageForResourceClaim(resourceClaim.ParentResourceClaim.ClaimName));
+                }
+            }
+
+            return resourceClaimLineage;
+        }
+
+        /// <summary>
+        /// Gets the authorization metadata of the lineage up the resource claim taxonomy for the specified resource claim.
+        /// </summary>
+        /// <param name="resourceClaimUri">The resource claim URI for which metadata is to be retrieved.</param>
+        /// <param name="action">The action for claim.</param>
+        /// <returns>The resource claim's lineage of authorization metadata.</returns>
+        public virtual IEnumerable<ResourceClaimAuthorizationMetadata> GetResourceClaimLineageMetadata(string resourceClaimUri, string action)
+        {
+            var strategies = new List<ResourceClaimAuthorizationMetadata>();
+
+            AddStrategiesForResourceClaimLineage(strategies, resourceClaimUri, action);
+
+            return strategies;
+        }
+
+        private void AddStrategiesForResourceClaimLineage(List<ResourceClaimAuthorizationMetadata> strategies, string resourceClaimUri, string action)
+        {
+            var instanceId = _instanceIdContextProvider.GetInstanceId();
+            if (string.IsNullOrEmpty(instanceId))
+            {
+                throw new InvalidOperationException("Expected instanceId is null or empty.");
+            }
+
+            var instanceSecurityRepoCacheObject = InstanceSecurityRepositoryCache.GetCache()
+                .GetSecurityRepository(instanceId);
+
+            //check for exact match on resource and action
+            var claimAndStrategy = instanceSecurityRepoCacheObject.ResourceClaimAuthorizationMetadata
+                .SingleOrDefault(
+                    rcas =>
+                        rcas.ResourceClaim.ClaimName.Equals(resourceClaimUri, StringComparison.InvariantCultureIgnoreCase)
+                        && rcas.Action.ActionUri.Equals(action, StringComparison.InvariantCultureIgnoreCase));
+
+            // Add the claim/strategy if it was found
+            if (claimAndStrategy != null)
+            {
+                strategies.Add(claimAndStrategy);
+            }
+
+            var resourceClaim =
+                instanceSecurityRepoCacheObject.ResourceClaims.FirstOrDefault(rc => rc.ClaimName.Equals(resourceClaimUri, StringComparison.InvariantCultureIgnoreCase));
+
+            // if there's a parent resource, recurse
+            if (resourceClaim != null && resourceClaim.ParentResourceClaim != null)
+            {
+                AddStrategiesForResourceClaimLineage(strategies, resourceClaim.ParentResourceClaim.ClaimName, action);
+            }
+        }
+
+        public virtual ResourceClaim GetResourceByResourceName(string resourceName)
+        {
+            var instanceId = _instanceIdContextProvider.GetInstanceId();
+            if (string.IsNullOrEmpty(instanceId))
+            {
+                throw new InvalidOperationException("Expected instanceId is null or empty.");
+            }
+
+            var instanceSecurityRepoCacheObject = InstanceSecurityRepositoryCache.GetCache()
+                .GetSecurityRepository(instanceId);
+
+            return instanceSecurityRepoCacheObject.ResourceClaims.FirstOrDefault(rc => rc.ResourceName.Equals(resourceName, StringComparison.InvariantCultureIgnoreCase));
+        }
+    }
+}

--- a/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
+++ b/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
@@ -34,6 +34,7 @@ using EdFi.Ods.Common.Infrastructure.Extensibility;
 using EdFi.Ods.Common.Models;
 using EdFi.Ods.Common.Models.Resource;
 using EdFi.Ods.Common.Security.Claims;
+using EdFi.Security.DataAccess.Caching;
 using log4net;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
@@ -254,6 +255,13 @@ namespace EdFi.Ods.Api.Startup
                 // Provide cache using a closure rather than repeated invocations to the container
                 IDescriptorsCache cache = null;
                 DescriptorsCache.GetCache = () => cache ??= Container.Resolve<IDescriptorsCache>();
+
+                if (ApiSettings.GetApiMode() == ApiMode.InstanceYearSpecific)
+                {
+                    // Provide SecurityRepository cache using a closure rather than repeated invocations to the container
+                    IInstanceSecurityRepositoryCache instanceSecurityRepositoryCache = null;
+                    InstanceSecurityRepositoryCache.GetCache = () => instanceSecurityRepositoryCache ??= Container.Resolve<IInstanceSecurityRepositoryCache>();
+                }
 
                 ResourceModelHelper.ResourceModel =
                     new Lazy<ResourceModel>(

--- a/Application/EdFi.Ods.Common/Context/IInstanceIdContextProvider.cs
+++ b/Application/EdFi.Ods.Common/Context/IInstanceIdContextProvider.cs
@@ -1,0 +1,13 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+namespace EdFi.Ods.Common.Context
+{
+    public interface IInstanceIdContextProvider
+    {
+        string GetInstanceId();
+
+        void SetInstanceId(string instanceId);
+    }
+}

--- a/Application/EdFi.Ods.Common/Context/InstanceIdContextProvider.cs
+++ b/Application/EdFi.Ods.Common/Context/InstanceIdContextProvider.cs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+using System.Collections.Generic;
+
+namespace EdFi.Ods.Common.Context
+{
+    public class InstanceIdContextProvider : IInstanceIdContextProvider, IHttpContextStorageTransferKeys
+    {
+        private const string InstanceIdContextKey = "InstanceIdContextProvider.InstanceId";
+
+        private readonly IContextStorage contextStorage;
+
+        public InstanceIdContextProvider(IContextStorage contextStorage)
+        {
+            this.contextStorage = contextStorage;
+        }
+
+        /// <summary>
+        /// Declare the <see cref="IContextStorage"/> keys that are read and written by the component
+        /// and should be transferred from <see cref="HttpContext"/> to <see cref="CallContext"/> for background Tasks.
+        /// </summary>
+        /// <returns>A list of keys to be transferred from <see cref="HttpContext"/> to <see cref="CallContext"/>.</returns>
+        IReadOnlyList<string> IHttpContextStorageTransferKeys.GetKeys()
+        {
+            return new[]
+                   {
+                       InstanceIdContextKey
+                   };
+        }
+
+        public string GetInstanceId()
+        {
+            return contextStorage.GetValue<string>(InstanceIdContextKey);
+        }
+
+        public void SetInstanceId(string instanceId)
+        {
+            contextStorage.SetValue(InstanceIdContextKey, instanceId);
+        }
+    }
+}

--- a/Application/EdFi.Ods.Common/Database/IAdminDatabaseNameReplacementTokenProvider.cs
+++ b/Application/EdFi.Ods.Common/Database/IAdminDatabaseNameReplacementTokenProvider.cs
@@ -1,0 +1,12 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.Ods.Common.Database
+{
+    public interface IAdminDatabaseNameReplacementTokenProvider
+    {
+        string GetReplacementToken();
+    }
+}

--- a/Application/EdFi.Ods.Common/Database/ISecurityDatabaseNameReplacementTokenProvider.cs
+++ b/Application/EdFi.Ods.Common/Database/ISecurityDatabaseNameReplacementTokenProvider.cs
@@ -1,0 +1,12 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.Ods.Common.Database
+{
+    public interface ISecurityDatabaseNameReplacementTokenProvider
+    {
+        string GetReplacementToken();
+    }
+}

--- a/Application/EdFi.Ods.Common/Database/InstanceYearSpecificAdminDatabaseNameReplacementTokenProvider.cs
+++ b/Application/EdFi.Ods.Common/Database/InstanceYearSpecificAdminDatabaseNameReplacementTokenProvider.cs
@@ -1,0 +1,35 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using EdFi.Ods.Common.Context;
+
+namespace EdFi.Ods.Common.Database
+{
+    public class InstanceYearSpecificAdminDatabaseNameReplacementTokenProvider : IAdminDatabaseNameReplacementTokenProvider
+    {
+        private readonly IInstanceIdContextProvider instanceIdContextProvider;
+
+        public InstanceYearSpecificAdminDatabaseNameReplacementTokenProvider(IInstanceIdContextProvider instanceIdContextProvider)
+        {
+            this.instanceIdContextProvider = instanceIdContextProvider;
+        }
+
+        public string GetReplacementToken()
+        {
+            //Convention: "Admin_" + instance id.
+
+            string instanceId = instanceIdContextProvider.GetInstanceId();
+
+            if (string.IsNullOrEmpty(instanceId))
+            {
+                throw new InvalidOperationException(
+                    "The instance-year-specific Admin database name replacement token cannot be derived because the instance id was not set in the current context.");
+            }
+
+            return $"Admin_{instanceId}";
+        }
+    }
+}

--- a/Application/EdFi.Ods.Common/Database/InstanceYearSpecificDatabaseNameReplacementTokenProvider.cs
+++ b/Application/EdFi.Ods.Common/Database/InstanceYearSpecificDatabaseNameReplacementTokenProvider.cs
@@ -1,0 +1,45 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using EdFi.Ods.Common.Context;
+
+namespace EdFi.Ods.Common.Database
+{
+    public class InstanceYearSpecificDatabaseNameReplacementTokenProvider : IDatabaseNameReplacementTokenProvider
+    {
+        private readonly IInstanceIdContextProvider instanceIdContextProvider;
+        private readonly ISchoolYearContextProvider schoolYearContextProvider;
+
+        public InstanceYearSpecificDatabaseNameReplacementTokenProvider(ISchoolYearContextProvider schoolYearContextProvider, IInstanceIdContextProvider instanceIdContextProvider)
+        {
+            this.instanceIdContextProvider = instanceIdContextProvider;
+            this.schoolYearContextProvider = schoolYearContextProvider;
+        }
+
+        public string GetReplacementToken()
+        {
+            //Convention: "Ods_" + instance id + "_"+ school year.
+
+            string instanceId = instanceIdContextProvider.GetInstanceId();
+
+            if (string.IsNullOrEmpty(instanceId))
+            {
+                throw new InvalidOperationException(
+                    "The instance-year-specific ODS database name replacement token cannot be derived because the instance id was not set in the current context.");
+            }
+
+            int schoolYear = schoolYearContextProvider.GetSchoolYear();
+
+            if (schoolYear == 0)
+            {
+                throw new InvalidOperationException(
+                    "The instance-year-specific ODS database name replacement token cannot be derived because the school year was not set in the current context.");
+            }
+
+            return string.Format("Ods_{0}_{1}", instanceId, schoolYear);
+        }
+    }
+}

--- a/Application/EdFi.Ods.Common/Database/InstanceYearSpecificSecurityDatabaseNameReplacementTokenProvider.cs
+++ b/Application/EdFi.Ods.Common/Database/InstanceYearSpecificSecurityDatabaseNameReplacementTokenProvider.cs
@@ -1,0 +1,35 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using EdFi.Ods.Common.Context;
+
+namespace EdFi.Ods.Common.Database
+{
+    public class InstanceYearSpecificSecurityDatabaseNameReplacementTokenProvider : ISecurityDatabaseNameReplacementTokenProvider
+    {
+        private readonly IInstanceIdContextProvider instanceIdContextProvider;
+
+        public InstanceYearSpecificSecurityDatabaseNameReplacementTokenProvider(IInstanceIdContextProvider instanceIdContextProvider)
+        {
+            this.instanceIdContextProvider = instanceIdContextProvider;
+        }
+
+        public string GetReplacementToken()
+        {
+            //Convention: "Security" + instance id.
+
+            string instanceId = instanceIdContextProvider.GetInstanceId();
+
+            if (string.IsNullOrEmpty(instanceId))
+            {
+                throw new InvalidOperationException(
+                    "The instance-year-specific Security database name replacement token cannot be derived because the instance id was not set in the current context.");
+            }
+
+            return $"Security_{instanceId}";
+        }
+    }
+}

--- a/Application/EdFi.Ods.Features/Controllers/OpenApiMetadataController.cs
+++ b/Application/EdFi.Ods.Features/Controllers/OpenApiMetadataController.cs
@@ -93,7 +93,7 @@ namespace EdFi.Ods.Features.Controllers
                         new Uri(
                             new Uri(Request.RootUrl(_useProxyHeaders).EnsureSuffixApplied("/")),
                             "metadata/"),
-                        GetMetadataUrlSegmentForCacheItem(apiContent, request.SchoolYearFromRoute));
+                        GetMetadataUrlSegmentForCacheItem(apiContent, request.SchoolYearFromRoute, request.InstanceIdFromRoute));
 
                 return new OpenApiMetadataSectionDetails
                 {
@@ -107,7 +107,7 @@ namespace EdFi.Ods.Features.Controllers
                 };
             }
 
-            string GetMetadataUrlSegmentForCacheItem(OpenApiContent apiContent, int? schoolYear)
+            string GetMetadataUrlSegmentForCacheItem(OpenApiContent apiContent, int? schoolYear, string instanceId)
             {
                 // 'Other' sections (Identity) do not live under 'ods' as other metadata endpoints do.
                 // eg identity/v1/2017/swagger.json,
@@ -115,7 +115,7 @@ namespace EdFi.Ods.Features.Controllers
                 // SDKgen All
                 // eg data/v3/2017/swagger.json,
                 // eg data/v3/swagger.json,
-                var basePath = GetBasePath(apiContent, schoolYear);
+                var basePath = GetBasePath(apiContent, schoolYear, instanceId);
 
                 // Profiles and composites endpoints have an extra url segment (profiles or composites).
                 // eg data/v3/2017/profiles/assessment/swagger.json
@@ -129,9 +129,14 @@ namespace EdFi.Ods.Features.Controllers
                 return $"{basePath}/{relativeSectionUri}{OpenApiMetadataDocumentHelper.Json}".ToLowerInvariant();
             }
 
-            string GetBasePath(OpenApiContent apiContent, int? schoolYear)
+            string GetBasePath(OpenApiContent apiContent, int? schoolYear, string instanceId)
             {
                 string basePath = $"{apiContent.BasePath}";
+
+                if (!string.IsNullOrEmpty(instanceId))
+                {
+                    basePath += $"/{instanceId}";
+                }
 
                 if (schoolYear.HasValue)
                 {

--- a/Application/EdFi.Ods.Features/Conventions/AggregateDependencyRouteConvention.cs
+++ b/Application/EdFi.Ods.Features/Conventions/AggregateDependencyRouteConvention.cs
@@ -51,6 +51,12 @@ namespace EdFi.Ods.Features.Conventions
                     template += RouteConstants.SchoolYearFromRoute;
                 }
 
+                if (_apiSettings.GetApiMode() == ApiMode.InstanceYearSpecific)
+                {
+                    template += RouteConstants.InstanceIdFromRoute;
+                    template += RouteConstants.SchoolYearFromRoute;
+                }
+
                 return template;
             }
         }

--- a/Application/EdFi.Ods.Features/Conventions/AvailableChangeVersionsRouteConvention.cs
+++ b/Application/EdFi.Ods.Features/Conventions/AvailableChangeVersionsRouteConvention.cs
@@ -53,6 +53,12 @@ namespace EdFi.Ods.Features.Conventions
                     template += RouteConstants.SchoolYearFromRoute;
                 }
 
+                if (_apiSettings.GetApiMode() == ApiMode.InstanceYearSpecific)
+                {
+                    template += RouteConstants.InstanceIdFromRoute;
+                    template += RouteConstants.SchoolYearFromRoute;
+                }
+
                 return template + "availablechangeversions/";
             }
         }

--- a/Application/EdFi.Ods.Features/Conventions/CompositesRouteConvention.cs
+++ b/Application/EdFi.Ods.Features/Conventions/CompositesRouteConvention.cs
@@ -87,6 +87,12 @@ namespace EdFi.Ods.Features.Conventions
                     template += RouteConstants.SchoolYearFromRoute;
                 }
 
+                if (_apiSettings.GetApiMode() == ApiMode.InstanceYearSpecific)
+                {
+                    template += RouteConstants.InstanceIdFromRoute;
+                    template += RouteConstants.SchoolYearFromRoute;
+                }
+
                 var compositeCategoryNames = _compositesMetadataProvider
                     .GetAllCategories()
                     .Select(x => x.Name)

--- a/Application/EdFi.Ods.Features/Conventions/DeletesRouteConvention.cs
+++ b/Application/EdFi.Ods.Features/Conventions/DeletesRouteConvention.cs
@@ -52,6 +52,12 @@ namespace EdFi.Ods.Features.Conventions
                     template += RouteConstants.SchoolYearFromRoute;
                 }
 
+                if (_apiSettings.GetApiMode() == ApiMode.InstanceYearSpecific)
+                {
+                    template += RouteConstants.InstanceIdFromRoute;
+                    template += RouteConstants.SchoolYearFromRoute;
+                }
+
                 return template;
             }
         }

--- a/Application/EdFi.Ods.Features/OpenApiMetadata/Models/OpenApiMetadataRequest.cs
+++ b/Application/EdFi.Ods.Features/OpenApiMetadata/Models/OpenApiMetadataRequest.cs
@@ -20,6 +20,8 @@ namespace EdFi.Ods.Features.OpenApiMetadata.Models
 
         public int? SchoolYearFromRoute { get; set; }
 
+        public string InstanceIdFromRoute { get; set; }
+
         public string OtherName { get; set; }
 
         public string GetFeedName()

--- a/Application/EdFi.Ods.Features/OpenApiMetadata/Models/OpenApiMetadataSectionRequest.cs
+++ b/Application/EdFi.Ods.Features/OpenApiMetadata/Models/OpenApiMetadataSectionRequest.cs
@@ -10,5 +10,7 @@ namespace EdFi.Ods.Features.OpenApiMetadata.Models
         public bool Sdk { get; set; }
 
         public int? SchoolYearFromRoute { get; set; }
+
+        public string InstanceIdFromRoute { get; set; }
     }
 }

--- a/Application/EdFi.Ods.Features/RouteInformations/ChangeQueriesOpenApiMetadataRouteInformation.cs
+++ b/Application/EdFi.Ods.Features/RouteInformations/ChangeQueriesOpenApiMetadataRouteInformation.cs
@@ -39,6 +39,12 @@ namespace EdFi.Ods.Features.RouteInformations
                 prefix += RouteConstants.SchoolYearFromRoute;
             }
 
+            if (_apiSettings.GetApiMode() == ApiMode.InstanceYearSpecific)
+            {
+                prefix += RouteConstants.InstanceIdFromRoute;
+                prefix += RouteConstants.SchoolYearFromRoute;
+            }
+
             return prefix.TrimSuffix("/");
         }
     }

--- a/Application/EdFi.Ods.Features/RouteInformations/CompositesOpenApiMetadataRouteInformation.cs
+++ b/Application/EdFi.Ods.Features/RouteInformations/CompositesOpenApiMetadataRouteInformation.cs
@@ -38,6 +38,12 @@ namespace EdFi.Ods.Features.RouteInformations
                 prefix += RouteConstants.SchoolYearFromRoute;
             }
 
+            if (_apiSettings.GetApiMode() == ApiMode.InstanceYearSpecific)
+            {
+                prefix += RouteConstants.InstanceIdFromRoute;
+                prefix += RouteConstants.SchoolYearFromRoute;
+            }
+
             prefix += "{organizationCode}/{compositeCategoryName}";
 
             return prefix.TrimSuffix("/");

--- a/Application/EdFi.Ods.Features/RouteInformations/OpenApiMetadataRouteInformationBase.cs
+++ b/Application/EdFi.Ods.Features/RouteInformations/OpenApiMetadataRouteInformationBase.cs
@@ -41,6 +41,12 @@ namespace EdFi.Ods.Features.RouteInformations {
                 prefix += RouteConstants.SchoolYearFromRoute;
             }
 
+            if (_apiSettings.GetApiMode() == ApiMode.InstanceYearSpecific)
+            {
+                prefix += RouteConstants.InstanceIdFromRoute;
+                prefix += RouteConstants.SchoolYearFromRoute;
+            }
+
             if (!string.IsNullOrEmpty(_template))
             {
                 prefix += _template;

--- a/Application/EdFi.Ods.Features/RouteInformations/ProfilesOpenApiMetadataRouteInformation.cs
+++ b/Application/EdFi.Ods.Features/RouteInformations/ProfilesOpenApiMetadataRouteInformation.cs
@@ -39,6 +39,12 @@ namespace EdFi.Ods.Features.RouteInformations
                 prefix += RouteConstants.SchoolYearFromRoute;
             }
 
+            if (_apiSettings.GetApiMode() == ApiMode.InstanceYearSpecific)
+            {
+                prefix += RouteConstants.InstanceIdFromRoute;
+                prefix += RouteConstants.SchoolYearFromRoute;
+            }
+
             prefix += "profiles/{profileName}";
 
             return prefix.TrimSuffix("/");

--- a/Application/EdFi.Ods.Security/Container/Modules/SecurityPersistenceModule.cs
+++ b/Application/EdFi.Ods.Security/Container/Modules/SecurityPersistenceModule.cs
@@ -75,10 +75,6 @@ namespace EdFi.Ods.Security.Container.Modules
                 .AsSelf()
                 .SingleInstance();
 
-            builder.RegisterType<SecurityRepository>()
-                .As<ISecurityRepository>()
-                .SingleInstance();
-
             builder.RegisterType<ClientAppRepo>()
                 .As<IClientAppRepo>()
                 .SingleInstance();

--- a/Application/EdFi.Ods.Security/Container/Modules/SecurityRepositoryModule.cs
+++ b/Application/EdFi.Ods.Security/Container/Modules/SecurityRepositoryModule.cs
@@ -1,0 +1,29 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Autofac;
+using EdFi.Common.Configuration;
+using EdFi.Ods.Common.Container;
+using EdFi.Ods.Common.Configuration;
+using EdFi.Security.DataAccess.Repositories;
+
+namespace EdFi.Ods.Security.Container.Modules
+{
+    public class SecurityRepositoryModule : ConditionalModule
+    {
+        public SecurityRepositoryModule(ApiSettings apiSettings)
+            : base(apiSettings, nameof(SecurityRepositoryModule)) { }
+
+        //Only if the ApiMode is not InstanceYearSpecific
+        public override bool IsSelected() => !(ApiSettings.GetApiMode() == ApiMode.InstanceYearSpecific);
+
+        public override void ApplyConfigurationSpecificRegistrations(ContainerBuilder builder)
+        {
+            builder.RegisterType<SecurityRepository>()
+                .As<ISecurityRepository>()
+                .SingleInstance();
+        }
+    }
+}

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Authentication/CachingOAuthTokenValidatorDecoratorTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Authentication/CachingOAuthTokenValidatorDecoratorTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Threading.Tasks;
+using EdFi.Common.Configuration;
 using EdFi.Common.Extensions;
 using EdFi.Ods.Api.Authentication;
 using EdFi.Ods.Common.Caching;
@@ -53,7 +54,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Services.Authorization
                               .Returns(Task.FromResult(_suppliedClientDetails));
 
                 _cacheProvider = Stub<ICacheProvider>();
-                _apiSettings = Stub<ApiSettings>();
+                _apiSettings =new ApiSettings { Engine = ApiConfigurationConstants.SqlServer, Mode = ApiConfigurationConstants.Sandbox };
                 _configuration = Stub<IConfigurationRoot>();
 
                 A.CallTo(() => _configuration.GetSection("BearerTokenTimeoutMinutes").Value)
@@ -66,7 +67,8 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Services.Authorization
                 var validator = new CachingOAuthTokenValidatorDecorator(
                     _decoratedValidator,
                     _cacheProvider,
-                    _configuration);
+                    _configuration,
+                    _apiSettings);
 
                 _actualDetails = validator.GetClientDetailsForTokenAsync(_suppliedApiToken)
                                           .GetResultSafely();
@@ -133,7 +135,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Services.Authorization
                 _cacheProvider = Stub<ICacheProvider>();
 
                 // Mock config file to return duration
-                _apiSettings = Stub<ApiSettings>();
+                _apiSettings =new ApiSettings { Engine = ApiConfigurationConstants.SqlServer, Mode = ApiConfigurationConstants.Sandbox };
                 _configuration = Stub<IConfigurationRoot>();
 
                 A.CallTo(() => _configuration.GetSection("BearerTokenTimeoutMinutes").Value)
@@ -146,7 +148,8 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Services.Authorization
                 var validator = new CachingOAuthTokenValidatorDecorator(
                     _decoratedValidator,
                     _cacheProvider,
-                    _configuration);
+                    _configuration,
+                    _apiSettings);
 
                 _actualDetails = validator.GetClientDetailsForTokenAsync(_suppliedInvalidApiToken)
                                           .GetResultSafely();
@@ -210,7 +213,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Services.Authorization
                 A.CallTo(()=> _cacheProvider.TryGetCachedObject(A<string>._,out outobject)).Returns(true);
 
                 // Mock config file to return duration
-                _apiSettings = Stub<ApiSettings>();
+                _apiSettings =new ApiSettings { Engine = ApiConfigurationConstants.SqlServer, Mode = ApiConfigurationConstants.Sandbox };
                 _configuration = Stub<IConfigurationRoot>();
 
                 A.CallTo(() => _configuration.GetSection("BearerTokenTimeoutMinutes").Value)
@@ -223,7 +226,8 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Services.Authorization
                 var validator = new CachingOAuthTokenValidatorDecorator(
                     _decoratedValidator,
                     _cacheProvider,
-                    _configuration);
+                    _configuration,
+                    _apiSettings);
 
                 _actualDetails = validator.GetClientDetailsForTokenAsync(_suppliedApiToken)
                                           .GetResultSafely();

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/InstanceSecurityRepositoryCacheTest.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/InstanceSecurityRepositoryCacheTest.cs
@@ -1,0 +1,101 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Common.Utils;
+using EdFi.Ods.Api.Caching;
+using EdFi.Ods.Api.Providers;
+using EdFi.Security.DataAccess.Caching;
+using EdFi.Security.DataAccess.Contexts;
+using EdFi.Security.DataAccess.Models;
+using FakeItEasy;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+
+namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
+{
+    [TestFixture]
+    public class InstanceSecurityRepositoryCacheTest
+    {
+        protected const string InitializedKeyPrefix = "SecurityRepositoriesCache.Initialized";
+        protected const string LastSyncedKey = "SecurityRepositoriesCache.LastSynced";
+
+        protected const string TestInstanceId = "Instance1";
+
+        protected MemoryCacheProvider CacheProvider { get; set; }
+
+        protected InstanceSecurityRepositoryCache InstanceSecurityRepositoryCache;
+
+        private IInstanceSecurityRepositoryCache MockInstanceSecurityRepositoryCallsAndInitializeCache(ISecurityContextFactory securityContextFactory)
+        {
+            InstanceSecurityRepositoryCacheObject values = new InstanceSecurityRepositoryCacheObject
+            (
+                 new Application { ApplicationId = 20, ApplicationName = "Ed-Fi ODS API" },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+            );
+
+            var memoryCacheOption = A.Fake<IOptions<MemoryCacheOptions>>();
+
+            MemoryCache memoryCache = new MemoryCache(memoryCacheOption);
+
+            CacheProvider = new MemoryCacheProvider(memoryCache);
+
+            CacheProvider.SetCachedObject(TestInstanceId, values);
+            CacheProvider.SetCachedObject(GetLastSynchedKey(TestInstanceId), SystemClock.Now());
+            CacheProvider.SetCachedObject(GetCurrentCacheInitializedKey(TestInstanceId), true);
+
+            InstanceSecurityRepositoryCache = new InstanceSecurityRepositoryCache(securityContextFactory, CacheProvider);
+
+            return InstanceSecurityRepositoryCache;
+        }
+        private string GetCurrentCacheInitializedKey(string instanceId)
+        {
+            return InitializedKeyPrefix + "." + instanceId;
+        }
+
+        private string GetLastSynchedKey(string instanceId)
+        {
+            return LastSyncedKey + "." + instanceId;
+        }
+
+        [Test]
+        public void GetSecurityRepository_ForInstanceSecurityRepositoryCacheObject_Finds_Cache_Object_And_Does_Not_Need_To_Call_SecurityContextFactory()
+        {
+            // Fake securityContextFactory
+
+            ISecurityContextFactory securityContextFactory = A.Fake<ISecurityContextFactory>();
+
+            var cache = MockInstanceSecurityRepositoryCallsAndInitializeCache(securityContextFactory);
+            var repositoryCacheObject = cache.GetSecurityRepository(TestInstanceId);
+
+            int ApplicationId = 20;
+
+            Assert.AreEqual(repositoryCacheObject.Application.ApplicationId, ApplicationId);
+
+            // Asserting that the call to securityContextFactory.CreateContext() was not used due to cache object being present
+            A.CallTo(() => securityContextFactory.CreateContext()).MustNotHaveHappened();
+        }
+
+        [Test]
+        public void GetSecurityRepository_ForInstanceSecurityRepositoryCacheObject_Does_Not_Finds_Cache_Object_And_Calls_SecurityContextFactory()
+        {
+            ISecurityContextFactory securityContextFactory = A.Fake<ISecurityContextFactory>();
+            A.CallTo(() => securityContextFactory.CreateContext()).Returns(SecurityContextMock.GetMockedSecurityContext()).Once();
+
+            var cache = MockInstanceSecurityRepositoryCallsAndInitializeCache(securityContextFactory);
+
+            var repositoryCacheObject = cache.GetSecurityRepository("Instance2");
+
+            int ApplicationId = 1;
+
+            Assert.AreEqual(repositoryCacheObject.Application.ApplicationId, ApplicationId);
+        }
+    }
+}

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/StubSecurityContext.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/StubSecurityContext.cs
@@ -1,0 +1,42 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Data.Entity.Infrastructure;
+using System.Linq;
+using EdFi.Security.DataAccess.Contexts;
+using EdFi.Security.DataAccess.Models;
+using FakeItEasy;
+
+namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
+{
+    public class SecurityContextMock
+    {
+        /// <summary>
+        /// Sets up a queryable fake security context with minimal data
+        /// </summary>
+        /// <returns></returns>
+        public static ISecurityContext GetMockedSecurityContext()
+        {
+            var securityContext = A.Fake<ISecurityContext>();
+            // The underlying SecurityRepository implementation expects this application, so force it to be there in the fake
+            securityContext.Applications = GetFakeDbSet<Application>().SetupData(new List<Application> { new Application { ApplicationId = 1, ApplicationName = "Ed-Fi ODS API" } });
+            securityContext.Actions = GetFakeDbSet<Action>().SetupData();
+            securityContext.AuthorizationStrategies = GetFakeDbSet<AuthorizationStrategy>().SetupData();
+            securityContext.ClaimSets = GetFakeDbSet<ClaimSet>().SetupData();
+            securityContext.ClaimSetResourceClaims = GetFakeDbSet<ClaimSetResourceClaim>().SetupData();
+            securityContext.ResourceClaims = GetFakeDbSet<ResourceClaim>().SetupData();
+            securityContext.ResourceClaimAuthorizationMetadatas = GetFakeDbSet<ResourceClaimAuthorizationMetadata>().SetupData();
+
+            return securityContext;
+        }
+
+        private static DbSet<T> GetFakeDbSet<T>() where T : class
+        {
+            return A.Fake<DbSet<T>>(o => o.Implements(typeof(IQueryable<T>)).Implements(typeof(IDbAsyncEnumerable<T>)));
+        }
+    }
+}

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Filters/InstanceIdContextFilterTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Filters/InstanceIdContextFilterTests.cs
@@ -1,0 +1,167 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Generic;
+using EdFi.Ods.Api.Filters;
+using EdFi.Ods.Common.Context;
+using EdFi.TestFixture;
+using FakeItEasy;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using NUnit.Framework;
+
+namespace EdFi.Ods.Tests.EdFi.Ods.Api.Services.Filters
+{
+    public class InstanceIdContextFilterTests : TestFixtureBase
+    {
+        protected InstanceIdContextFilter _instanceIdContextFilter;
+        protected IInstanceIdContextProvider _instanceIdContextProvider;
+        protected ActionExecutingContext _httpActionContext;
+        protected string _instanceId;
+
+        private ActionExecutingContext GetActionContext()
+        {
+            var actionContext = Stub<ActionContext>();
+            var filterMetadata = Stub<IList<IFilterMetadata>>();
+            var actionArguments = Stub<IDictionary<string, object>>();
+            var controller = Stub<object>();
+
+            actionContext.HttpContext = A.Fake<HttpContext>();
+            actionContext.RouteData = A.Fake<RouteData>();
+
+            actionContext.ActionDescriptor = A.Fake<ActionDescriptor>();
+            RouteValueDictionary keyValuePairs = new RouteValueDictionary();
+
+            keyValuePairs.Add("instanceIdFromRoute", _instanceId);
+
+            ActionExecutingContext context = new ActionExecutingContext(actionContext, filterMetadata, actionArguments, controller);
+            context.HttpContext.Request.RouteValues = keyValuePairs;
+            return context;
+        }
+
+        protected override void Arrange()
+        {
+            _instanceIdContextProvider = A.Fake<IInstanceIdContextProvider>();
+            _instanceIdContextFilter = new InstanceIdContextFilter(_instanceIdContextProvider);
+            _httpActionContext = GetActionContext();
+        }
+
+        protected override void Act()
+        {
+            _instanceIdContextFilter.OnActionExecuting(_httpActionContext);
+        }
+
+        public class When_Instance_Id_Is_An_Array : InstanceIdContextFilterTests
+        {
+            protected override void Arrange()
+            {
+                _instanceId = "instance1, instance2";
+                base.Arrange();
+            }
+
+            [Test]
+            public void Should_Not_Parse_Instance_Id()
+            {
+                A.CallTo(() => _instanceIdContextProvider.SetInstanceId(A<string>._)).MustNotHaveHappened();
+            }
+        }
+
+        public class When_Instance_Id_Is_Empty : InstanceIdContextFilterTests
+        {
+            protected override void Arrange()
+            {
+                _instanceId = "";
+                base.Arrange();
+            }
+
+            [Test]
+            public void Should_Not_Parse_InValid_Instance_Id()
+            {
+                A.CallTo(() => _instanceIdContextProvider.SetInstanceId(A<string>._)).MustNotHaveHappened();
+            }
+        }
+
+        public class When_Instance_Id_Is_Null : InstanceIdContextFilterTests
+        {
+            protected override void Arrange()
+            {
+                _instanceId = null;
+                base.Arrange();
+            }
+
+            [Test]
+            public void Should_Not_Parse_Instance_Id()
+            {
+                A.CallTo(() => _instanceIdContextProvider.SetInstanceId(A<string>._)).MustNotHaveHappened();
+            }
+        }
+
+
+        public class When_Instance_Id_Is_WhiteSpace : InstanceIdContextFilterTests
+        {
+            protected override void Arrange()
+            {
+                _instanceId = " ";
+                base.Arrange();
+            }
+
+            [Test]
+            public void Should_Not_Parse_Instance_Id()
+            {
+                A.CallTo(() => _instanceIdContextProvider.SetInstanceId(A<string>._)).MustNotHaveHappened();
+            }
+        }
+
+        public class When_Instance_Id_Is_Special_Character_Other_Than_Hyphen : InstanceIdContextFilterTests
+        {
+            protected override void Arrange()
+            {
+                _instanceId = "@#$";
+                base.Arrange();
+            }
+
+            [Test]
+            public void Should_Not_Parse_Instance_Id()
+            {
+                A.CallTo(() => _instanceIdContextProvider.SetInstanceId(A<string>._)).MustNotHaveHappened();
+            }
+        }
+
+
+        public class When_Instance_Id_Is_Valid_AlphaNumeric : InstanceIdContextFilterTests
+        {
+            protected override void Arrange()
+            {
+                _instanceId = "instance1";
+                base.Arrange();
+            }
+
+            [Test]
+            public void Should_Valid_Instance_Id()
+            {
+                A.CallTo(() => _instanceIdContextProvider.SetInstanceId(_instanceId)).MustHaveHappened();
+            }
+        }
+
+        public class When_Instance_Id_Is_Valid_Guid : InstanceIdContextFilterTests
+        {
+            protected override void Arrange()
+            {
+                _instanceId = "eaa24756-3fac-4e46-b4bb-074ff4f5b846";
+                base.Arrange();
+            }
+
+            [Test]
+            public void Should_Valid_Instance_Id()
+            {
+                A.CallTo(() => _instanceIdContextProvider.SetInstanceId(_instanceId)).MustHaveHappened();
+            }
+        }
+
+    }
+}

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Database/InstanceAdminDatabaseNameTokenReplacementOverrideDatabaseConnectionStringProviderTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Database/InstanceAdminDatabaseNameTokenReplacementOverrideDatabaseConnectionStringProviderTests.cs
@@ -1,0 +1,138 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Common.Configuration;
+using EdFi.Common.Database;
+using EdFi.Ods.Api.Database;
+using EdFi.Ods.Common.Database;
+using EdFi.TestFixture;
+using Shouldly;
+using Test.Common;
+using FakeItEasy;
+
+namespace EdFi.Ods.Tests.EdFi.Ods.Common.Database
+{
+    public class When_building_connection_string_based_on_a_admin_prototype_from_the_connectionStrings_config_section_but_with_a_database_name_replacement_token_override
+        : TestFixtureBase
+    {
+        // Supplied values
+
+        // Actual values
+        private string _actualConnectionString;
+
+        // External dependencies
+        private IAdminDatabaseNameReplacementTokenProvider _adminDatabaseNameReplacementTokenProvider;
+        private IConfigConnectionStringsProvider _configConnectionStringsProvider;
+        private IDbConnectionStringBuilderAdapterFactory _dbConnectionStringBuilderAdapterFactory;
+
+        protected override void Arrange()
+        {
+            // Set up mocked dependencies and supplied values
+            _adminDatabaseNameReplacementTokenProvider = A.Fake<IAdminDatabaseNameReplacementTokenProvider>();
+
+            A.CallTo(() => _adminDatabaseNameReplacementTokenProvider.GetReplacementToken())
+                .Returns("Admin");
+
+            _configConnectionStringsProvider = A.Fake<IConfigConnectionStringsProvider>();
+
+            A.CallTo(() => _configConnectionStringsProvider.Count)
+                .Returns(1);
+
+            A.CallTo(() => _configConnectionStringsProvider.GetConnectionString("EdFi_Admin"))
+                .Returns("Server=SomeServer; Database=EdFi_{0}; UID=SomeUser; Password=SomePassword");
+
+            _dbConnectionStringBuilderAdapterFactory = A.Fake<IDbConnectionStringBuilderAdapterFactory>();
+
+            A.CallTo(() => _dbConnectionStringBuilderAdapterFactory.Get()).Returns(new SqlConnectionStringBuilderAdapter());
+        }
+
+        protected override void Act()
+        {
+            // Perform the action to be tested
+            var provider = new InstanceAdminDatabaseNameTokenReplacementConnectionStringProvider(
+                _configConnectionStringsProvider,
+                _dbConnectionStringBuilderAdapterFactory,
+                _adminDatabaseNameReplacementTokenProvider);
+
+            _actualConnectionString = provider.GetConnectionString();
+        }
+
+        [Assert]
+        public void Should_substitute_the_database_name_token_in_the_existing_connection_string_with_the_one_supplied_by_the_database_name_replacement_token_provider()
+        {
+            _actualConnectionString.ShouldBe("Data Source=SomeServer;Initial Catalog=EdFi_Admin;User ID=SomeUser;Password=SomePassword");
+        }
+
+        [Assert]
+        public void Should_perform_substitution_using_the_SqlConnectionStringBuilder_class()
+        {
+            // SqlConnectionStringBuilder produces telltale signs in resulting connection string:
+            //      "Data Source" replaces "Server" and "Initial Catalog" replaces "Database"
+            _actualConnectionString.ShouldContain("Data Source=");
+            _actualConnectionString.ShouldContain("Initial Catalog=");
+        }
+    }
+
+    public class When_building_connection_string_based_on_a_admin_prototype_from_the_connectionStrings_config_section_with_different_database_name_replacement_token_overrides
+        : TestFixtureBase
+    {
+        // Supplied values
+
+        // Actual values
+        private string _actualConnectionString1;
+        private string _actualConnectionString2;
+        private string _actualConnectionString3;
+
+        // External dependencies
+        private IAdminDatabaseNameReplacementTokenProvider _adminDatabaseNameReplacementTokenProvider;
+        private IConfigConnectionStringsProvider _configConnectionStringsProvider;
+        private IDbConnectionStringBuilderAdapterFactory _dbConnectionStringBuilderAdapterFactory;
+
+        protected override void Arrange()
+        {
+            // Set up mocked dependencies and supplied values
+            _adminDatabaseNameReplacementTokenProvider = A.Fake<IAdminDatabaseNameReplacementTokenProvider>();
+
+            A.CallTo(() => _adminDatabaseNameReplacementTokenProvider.GetReplacementToken()).Returns("OneDatabase").Once();
+
+            A.CallTo(() => _adminDatabaseNameReplacementTokenProvider.GetReplacementToken()).Returns("AnotherDatabase").Once();
+
+            A.CallTo(() => _adminDatabaseNameReplacementTokenProvider.GetReplacementToken()).Returns("OneDatabase").Once();
+
+            _configConnectionStringsProvider = A.Fake<IConfigConnectionStringsProvider>();
+
+            A.CallTo(() => _configConnectionStringsProvider.Count).Returns(1);
+
+            A.CallTo(() => _configConnectionStringsProvider.GetConnectionString("EdFi_Admin"))
+                .Returns("Server=SomeServer; Database=EdFi_{0}; UID=SomeUser; Password=SomePassword");
+
+            _dbConnectionStringBuilderAdapterFactory = A.Fake<IDbConnectionStringBuilderAdapterFactory>();
+
+            A.CallTo(() => _dbConnectionStringBuilderAdapterFactory.Get()).Returns(new SqlConnectionStringBuilderAdapter());
+        }
+
+        protected override void Act()
+        {
+            // Perform the action to be tested
+            var provider = new InstanceAdminDatabaseNameTokenReplacementConnectionStringProvider(
+                _configConnectionStringsProvider,
+                _dbConnectionStringBuilderAdapterFactory,
+                _adminDatabaseNameReplacementTokenProvider);
+
+            _actualConnectionString1 = provider.GetConnectionString();
+            _actualConnectionString2 = provider.GetConnectionString();
+            _actualConnectionString3 = provider.GetConnectionString();
+        }
+
+        [Assert]
+        public void Should_properly_modify_connection_string_template_with_varying_database_names()
+        {
+            // Assert the expected results
+            _actualConnectionString1.ShouldContain("=EdFi_OneDatabase;");
+            _actualConnectionString2.ShouldContain("=EdFi_AnotherDatabase;");
+            _actualConnectionString3.ShouldContain("=EdFi_OneDatabase;");
+        }
+    }
+}

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Database/InstanceSecurityDatabaseNameTokenReplacementOverrideDatabaseConnectionStringProviderTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Database/InstanceSecurityDatabaseNameTokenReplacementOverrideDatabaseConnectionStringProviderTests.cs
@@ -1,0 +1,138 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Common.Configuration;
+using EdFi.Common.Database;
+using EdFi.Ods.Api.Database;
+using EdFi.Ods.Common.Database;
+using EdFi.TestFixture;
+using Shouldly;
+using Test.Common;
+using FakeItEasy;
+
+namespace EdFi.Ods.Tests.EdFi.Ods.Common.Database
+{
+    public class When_building_connection_string_based_on_a_security_prototype_from_the_connectionStrings_config_section_but_with_a_database_name_replacement_token_override
+        : TestFixtureBase
+    {
+        // Supplied values
+
+        // Actual values
+        private string _actualConnectionString;
+
+        // External dependencies
+        private ISecurityDatabaseNameReplacementTokenProvider _securityDatabaseNameReplacementTokenProvider;
+        private IConfigConnectionStringsProvider _configConnectionStringsProvider;
+        private IDbConnectionStringBuilderAdapterFactory _dbConnectionStringBuilderAdapterFactory;
+
+        protected override void Arrange()
+        {
+            // Set up mocked dependencies and supplied values
+            _securityDatabaseNameReplacementTokenProvider = A.Fake<ISecurityDatabaseNameReplacementTokenProvider>();
+
+            A.CallTo(() => _securityDatabaseNameReplacementTokenProvider.GetReplacementToken())
+                .Returns("Security");
+
+            _configConnectionStringsProvider = A.Fake<IConfigConnectionStringsProvider>();
+
+            A.CallTo(() => _configConnectionStringsProvider.Count)
+                .Returns(1);
+
+            A.CallTo(() => _configConnectionStringsProvider.GetConnectionString("EdFi_Security"))
+                .Returns("Server=SomeServer; Database=EdFi_{0}; UID=SomeUser; Password=SomePassword");
+
+            _dbConnectionStringBuilderAdapterFactory = A.Fake<IDbConnectionStringBuilderAdapterFactory>();
+
+            A.CallTo(() => _dbConnectionStringBuilderAdapterFactory.Get()).Returns(new SqlConnectionStringBuilderAdapter());
+        }
+
+        protected override void Act()
+        {
+            // Perform the action to be tested
+            var provider = new InstanceSecurityDatabaseNameTokenReplacementConnectionStringProvider(
+                _configConnectionStringsProvider,
+                _dbConnectionStringBuilderAdapterFactory,
+                _securityDatabaseNameReplacementTokenProvider);
+
+            _actualConnectionString = provider.GetConnectionString();
+        }
+
+        [Assert]
+        public void Should_substitute_the_database_name_token_in_the_existing_connection_string_with_the_one_supplied_by_the_database_name_replacement_token_provider()
+        {
+            _actualConnectionString.ShouldBe("Data Source=SomeServer;Initial Catalog=EdFi_Security;User ID=SomeUser;Password=SomePassword");
+        }
+
+        [Assert]
+        public void Should_perform_substitution_using_the_SqlConnectionStringBuilder_class()
+        {
+            // SqlConnectionStringBuilder produces telltale signs in resulting connection string:
+            //      "Data Source" replaces "Server" and "Initial Catalog" replaces "Database"
+            _actualConnectionString.ShouldContain("Data Source=");
+            _actualConnectionString.ShouldContain("Initial Catalog=");
+        }
+    }
+
+    public class When_building_connection_string_based_on_a_security_prototype_from_the_connectionStrings_config_section_with_different_database_name_replacement_token_overrides
+        : TestFixtureBase
+    {
+        // Supplied values
+
+        // Actual values
+        private string _actualConnectionString1;
+        private string _actualConnectionString2;
+        private string _actualConnectionString3;
+
+        // External dependencies
+        private ISecurityDatabaseNameReplacementTokenProvider _securityDatabaseNameReplacementTokenProvider;
+        private IConfigConnectionStringsProvider _configConnectionStringsProvider;
+        private IDbConnectionStringBuilderAdapterFactory _dbConnectionStringBuilderAdapterFactory;
+
+        protected override void Arrange()
+        {
+            // Set up mocked dependencies and supplied values
+            _securityDatabaseNameReplacementTokenProvider = A.Fake<ISecurityDatabaseNameReplacementTokenProvider>();
+
+            A.CallTo(() => _securityDatabaseNameReplacementTokenProvider.GetReplacementToken()).Returns("OneDatabase").Once();
+
+            A.CallTo(() => _securityDatabaseNameReplacementTokenProvider.GetReplacementToken()).Returns("AnotherDatabase").Once();
+
+            A.CallTo(() => _securityDatabaseNameReplacementTokenProvider.GetReplacementToken()).Returns("OneDatabase").Once();
+
+            _configConnectionStringsProvider = A.Fake<IConfigConnectionStringsProvider>();
+
+            A.CallTo(() => _configConnectionStringsProvider.Count).Returns(1);
+
+            A.CallTo(() => _configConnectionStringsProvider.GetConnectionString("EdFi_Security"))
+                .Returns("Server=SomeServer; Database=EdFi_{0}; UID=SomeUser; Password=SomePassword");
+
+            _dbConnectionStringBuilderAdapterFactory = A.Fake<IDbConnectionStringBuilderAdapterFactory>();
+
+            A.CallTo(() => _dbConnectionStringBuilderAdapterFactory.Get()).Returns(new SqlConnectionStringBuilderAdapter());
+        }
+
+        protected override void Act()
+        {
+            // Perform the action to be tested
+            var provider = new InstanceSecurityDatabaseNameTokenReplacementConnectionStringProvider(
+                _configConnectionStringsProvider,
+                _dbConnectionStringBuilderAdapterFactory,
+                _securityDatabaseNameReplacementTokenProvider);
+
+            _actualConnectionString1 = provider.GetConnectionString();
+            _actualConnectionString2 = provider.GetConnectionString();
+            _actualConnectionString3 = provider.GetConnectionString();
+        }
+
+        [Assert]
+        public void Should_properly_modify_connection_string_template_with_varying_database_names()
+        {
+            // Assert the expected results
+            _actualConnectionString1.ShouldContain("=EdFi_OneDatabase;");
+            _actualConnectionString2.ShouldContain("=EdFi_AnotherDatabase;");
+            _actualConnectionString3.ShouldContain("=EdFi_OneDatabase;");
+        }
+    }
+}

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Database/InstanceYearSpecificAdminDatabaseNameReplacementTokenProviderTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Database/InstanceYearSpecificAdminDatabaseNameReplacementTokenProviderTests.cs
@@ -1,0 +1,70 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using EdFi.Ods.Common.Context;
+using EdFi.Ods.Common.Database;
+using EdFi.TestFixture;
+using FakeItEasy;
+using NUnit.Framework;
+using Shouldly;
+
+namespace EdFi.Ods.Tests.EdFi.Ods.Common.Database
+{
+    public class When_using_instance_year_specific_admin_database_name_replacement_token_provider_with_valid_instance_context
+        : TestFixtureBase
+    {
+        private string _actualReplacementToken;
+
+        private IAdminDatabaseNameReplacementTokenProvider _adminDatabaseNameReplacementTokenProvider;
+
+        protected override void Arrange()
+        {
+            var instanceIdContextProvider = A.Fake<IInstanceIdContextProvider>();
+
+            A.CallTo(() => instanceIdContextProvider.GetInstanceId())
+                .Returns("instance1");
+
+            _adminDatabaseNameReplacementTokenProvider = new InstanceYearSpecificAdminDatabaseNameReplacementTokenProvider(instanceIdContextProvider);
+        }
+
+        protected override void Act()
+        {
+            _actualReplacementToken = _adminDatabaseNameReplacementTokenProvider.GetReplacementToken();
+        }
+
+        [Test]
+        public void Should_return_correct_value()
+        {
+            _actualReplacementToken.ShouldBe("Admin_instance1");
+        }
+    }
+
+    public class When_using_instance_year_specific_admin_database_name_replacement_token_provider_with_missing_instance_context : TestFixtureBase
+    {
+        private IAdminDatabaseNameReplacementTokenProvider _adminDatabaseNameReplacementTokenProvider;
+
+        protected override void Arrange()
+        {
+            var instanceIdContextProvider = A.Fake<IInstanceIdContextProvider>();
+
+            A.CallTo(() => instanceIdContextProvider.GetInstanceId())
+                .Returns("");
+
+            _adminDatabaseNameReplacementTokenProvider = new InstanceYearSpecificAdminDatabaseNameReplacementTokenProvider(instanceIdContextProvider);
+        }
+
+        protected override void Act()
+        {
+            _adminDatabaseNameReplacementTokenProvider.GetReplacementToken();
+        }
+
+        [Test]
+        public void Should_throw_an_InvalidOperationException()
+        {
+            ActualException.ShouldBeOfType<InvalidOperationException>();
+        }
+    }
+}

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Database/InstanceYearSpecificDatabaseNameReplacementTokenProviderTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Database/InstanceYearSpecificDatabaseNameReplacementTokenProviderTests.cs
@@ -1,0 +1,145 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using EdFi.Ods.Common.Context;
+using EdFi.Ods.Common.Database;
+using EdFi.TestFixture;
+using FakeItEasy;
+using NUnit.Framework;
+using Shouldly;
+
+namespace EdFi.Ods.Tests.EdFi.Ods.Common.Database
+{
+    public class When_using_instance_year_specific_database_name_replacement_token_provider_with_valid_instance_and_with_valid_school_year_context
+        : TestFixtureBase
+    {
+        private string _actualReplacementToken;
+
+        private IDatabaseNameReplacementTokenProvider _databaseNameReplacementTokenProvider;
+
+        protected override void Arrange()
+        {
+            var schoolYearContextProvider = A.Fake<ISchoolYearContextProvider>();
+            var instanceIdContextProvider = A.Fake<IInstanceIdContextProvider>();
+
+            A.CallTo(() => schoolYearContextProvider.GetSchoolYear())
+                .Returns(2020);
+
+            A.CallTo(() => instanceIdContextProvider.GetInstanceId())
+                .Returns("instance1");
+
+            _databaseNameReplacementTokenProvider =
+                new InstanceYearSpecificDatabaseNameReplacementTokenProvider(schoolYearContextProvider, instanceIdContextProvider);
+        }
+
+        protected override void Act()
+        {
+            _actualReplacementToken = _databaseNameReplacementTokenProvider.GetReplacementToken();
+        }
+
+        [Test]
+        public void Should_return_correct_value()
+        {
+            _actualReplacementToken.ShouldBe("Ods_instance1_2020");
+        }
+    }
+
+    public class When_using_instance_year_specific_database_name_replacement_token_provider_with_valid_instance_and_with_missing_school_year_context : TestFixtureBase
+    {
+        private IDatabaseNameReplacementTokenProvider _databaseNameReplacementTokenProvider;
+
+        protected override void Arrange()
+        {
+            var schoolYearContextProvider = A.Fake<ISchoolYearContextProvider>();
+            var instanceIdContextProvider = A.Fake<IInstanceIdContextProvider>();
+
+            A.CallTo(() => schoolYearContextProvider.GetSchoolYear())
+                .Returns(0);
+
+            A.CallTo(() => instanceIdContextProvider.GetInstanceId())
+                .Returns("instance1");
+
+            _databaseNameReplacementTokenProvider =
+                new InstanceYearSpecificDatabaseNameReplacementTokenProvider(schoolYearContextProvider, instanceIdContextProvider);
+        }
+
+        protected override void Act()
+        {
+            _databaseNameReplacementTokenProvider.GetReplacementToken();
+        }
+
+        [Test]
+        public void Should_throw_an_InvalidOperationException()
+        {
+            ActualException.ShouldBeOfType<InvalidOperationException>();
+        }
+    }
+
+    public class When_using_instance_year_specific_database_name_replacement_token_provider_with_missing_instance_and_with_valid_school_year_context : TestFixtureBase
+    {
+        private IDatabaseNameReplacementTokenProvider _databaseNameReplacementTokenProvider;
+
+        protected override void Arrange()
+        {
+            var schoolYearContextProvider = A.Fake<ISchoolYearContextProvider>();
+            var instanceIdContextProvider = A.Fake<IInstanceIdContextProvider>();
+
+            A.CallTo(() => schoolYearContextProvider.GetSchoolYear())
+                .Returns(2020);
+
+            A.CallTo(() => instanceIdContextProvider.GetInstanceId())
+                .Returns("");
+
+            _databaseNameReplacementTokenProvider =
+                new InstanceYearSpecificDatabaseNameReplacementTokenProvider(schoolYearContextProvider, instanceIdContextProvider);
+        }
+
+        protected override void Act()
+        {
+            _databaseNameReplacementTokenProvider.GetReplacementToken();
+        }
+
+        [Test]
+        public void Should_throw_an_InvalidOperationException()
+        {
+            ActualException.ShouldBeOfType<InvalidOperationException>();
+        }
+    }
+
+    public class When_using_instance_year_specific_database_name_replacement_token_provider_with_missing_instance_and_with_missing_school_year_context
+        : TestFixtureBase
+    {
+        private string _actualReplacementToken;
+
+        private IDatabaseNameReplacementTokenProvider _databaseNameReplacementTokenProvider;
+
+        protected override void Arrange()
+        {
+            var schoolYearContextProvider = A.Fake<ISchoolYearContextProvider>();
+            var instanceIdContextProvider = A.Fake<IInstanceIdContextProvider>();
+
+            A.CallTo(() => schoolYearContextProvider.GetSchoolYear())
+                .Returns(0);
+
+            A.CallTo(() => instanceIdContextProvider.GetInstanceId())
+                .Returns("");
+
+            _databaseNameReplacementTokenProvider =
+                new InstanceYearSpecificDatabaseNameReplacementTokenProvider(schoolYearContextProvider, instanceIdContextProvider);
+        }
+
+        protected override void Act()
+        {
+            _actualReplacementToken = _databaseNameReplacementTokenProvider.GetReplacementToken();
+        }
+
+        [Test]
+        public void Should_throw_an_InvalidOperationException()
+        {
+            ActualException.ShouldBeOfType<InvalidOperationException>();
+        }
+    }
+}

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Database/InstanceYearSpecificSecurityDatabaseNameReplacementTokenProviderTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Database/InstanceYearSpecificSecurityDatabaseNameReplacementTokenProviderTests.cs
@@ -1,0 +1,70 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using EdFi.Ods.Common.Context;
+using EdFi.Ods.Common.Database;
+using EdFi.TestFixture;
+using FakeItEasy;
+using NUnit.Framework;
+using Shouldly;
+
+namespace EdFi.Ods.Tests.EdFi.Ods.Common.Database
+{
+    public class When_using_instance_year_specific_security_database_name_replacement_token_provider_with_valid_instance_context
+        : TestFixtureBase
+    {
+        private string _actualReplacementToken;
+
+        private ISecurityDatabaseNameReplacementTokenProvider _securityDatabaseNameReplacementTokenProvider;
+
+        protected override void Arrange()
+        {
+            var instanceIdContextProvider = A.Fake<IInstanceIdContextProvider>();
+
+            A.CallTo(() => instanceIdContextProvider.GetInstanceId())
+                .Returns("instance1");
+
+            _securityDatabaseNameReplacementTokenProvider = new InstanceYearSpecificSecurityDatabaseNameReplacementTokenProvider(instanceIdContextProvider);
+        }
+
+        protected override void Act()
+        {
+            _actualReplacementToken = _securityDatabaseNameReplacementTokenProvider.GetReplacementToken();
+        }
+
+        [Test]
+        public void Should_return_correct_value()
+        {
+            _actualReplacementToken.ShouldBe("Security_instance1");
+        }
+    }
+
+    public class When_using_instance_year_specific_security_database_name_replacement_token_provider_with_missing_instance_context : TestFixtureBase
+    {
+        private ISecurityDatabaseNameReplacementTokenProvider _securityDatabaseNameReplacementTokenProvider;
+
+        protected override void Arrange()
+        {
+            var instanceIdContextProvider = A.Fake<IInstanceIdContextProvider>();
+
+            A.CallTo(() => instanceIdContextProvider.GetInstanceId())
+                .Returns("");
+
+            _securityDatabaseNameReplacementTokenProvider = new InstanceYearSpecificSecurityDatabaseNameReplacementTokenProvider(instanceIdContextProvider);
+        }
+
+        protected override void Act()
+        {
+            _securityDatabaseNameReplacementTokenProvider.GetReplacementToken();
+        }
+
+        [Test]
+        public void Should_throw_an_InvalidOperationException()
+        {
+            ActualException.ShouldBeOfType<InvalidOperationException>();
+        }
+    }
+}

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="AutoMapper" Version="10.0.0" />
     <PackageReference Include="CompareNETObjects" Version="4.65.0" />
     <PackageReference Include="EntityFramework" Version="6.4.0" />
+    <PackageReference Include="EntityFrameworkTesting.FakeItEasy" Version="1.3.0" />
     <PackageReference Include="FakeItEasy" Version="6.2.0" />
     <PackageReference Include="FluentValidation" Version="8.6.2" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />

--- a/Application/EdFi.Security.DataAccess/Caching/IInstanceSecurityRepositoryCache.cs
+++ b/Application/EdFi.Security.DataAccess/Caching/IInstanceSecurityRepositoryCache.cs
@@ -1,0 +1,7 @@
+﻿namespace EdFi.Security.DataAccess.Caching
+{
+    public interface IInstanceSecurityRepositoryCache
+    {
+        InstanceSecurityRepositoryCacheObject GetSecurityRepository(string instanceId);
+    }
+}

--- a/Application/EdFi.Security.DataAccess/Caching/InstanceSecurityRepositoryCacheObject.cs
+++ b/Application/EdFi.Security.DataAccess/Caching/InstanceSecurityRepositoryCacheObject.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using EdFi.Security.DataAccess.Models;
+
+namespace EdFi.Security.DataAccess.Caching
+{
+    public class InstanceSecurityRepositoryCacheObject
+    {
+        public Application Application { get; }
+
+        public List<Action> Actions { get; }
+
+        public List<ClaimSet> ClaimSets { get; }
+
+        public List<ResourceClaim> ResourceClaims { get; }
+
+        public List<AuthorizationStrategy> AuthorizationStrategies { get; }
+
+        public List<ClaimSetResourceClaim> ClaimSetResourceClaims { get; }
+
+        public List<ResourceClaimAuthorizationMetadata> ResourceClaimAuthorizationMetadata { get; }
+
+
+        public InstanceSecurityRepositoryCacheObject(
+            Application application,
+            List<Action> actions,
+            List<ClaimSet> claimSets,
+            List<ResourceClaim> resourceClaims,
+            List<AuthorizationStrategy> authorizationStrategies,
+            List<ClaimSetResourceClaim> claimSetResourceClaims,
+            List<ResourceClaimAuthorizationMetadata> resourceClaimAuthorizationMetadata)
+        {
+            Application = application;
+            Actions = actions;
+            ClaimSets = claimSets;
+            ResourceClaims = resourceClaims;
+            AuthorizationStrategies = authorizationStrategies;
+            ClaimSetResourceClaims = claimSetResourceClaims;
+            ResourceClaimAuthorizationMetadata = resourceClaimAuthorizationMetadata;
+        }
+    }
+}


### PR DESCRIPTION
Adding support for "InstanceYearSpecific" startup strategy.

Note that the OpenApi routing for "InstanceYearSpecific" is not implemented. A second pull request will be submitted in October once the OpenApi routing for "YearSpecific" and "DistrictSpecific" has been implemented by Ed-Fi team.