### PR TITLE
[ODS-4557] CallContext loses values for a previous context …

### DIFF
--- a/Application/EdFi.Ods.Common/Context/CallContext.cs
+++ b/Application/EdFi.Ods.Common/Context/CallContext.cs
@@ -24,21 +24,15 @@ namespace EdFi.Ods.Common.Context
         /// <param name="data">The object to store in the call context.</param>
         public static void SetData(string name, object data)
         {
-            var local = new AsyncLocal<object>(
-                a =>
+            _state.AddOrUpdate(name, 
+                // Create a single, shared AsyncLocal instance for use from all contexts 
+                n => new AsyncLocal<object> { Value = data},
+                // Assign value for the current call context
+                (n, d) =>
                 {
-                    if (a.ThreadContextChanged && a.CurrentValue == null && a.PreviousValue != null)
-                    {
-                        _state[name].Value = a.PreviousValue;
-                    }
-                }) {Value = data};
-
-            _state.AddOrUpdate(
-                name,
-                local,
-                (k, v) => v != local
-                    ? local
-                    : v);
+                    d.Value = data;
+                    return d;
+                });
         }
 
         /// <summary>

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Context/CallContextTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Context/CallContextTests.cs
@@ -97,6 +97,71 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Common.Context
             [Test]
             public void Should_return_null_when_getting_data_for_d2() => Assert.IsNull(CallContext.GetData("d2"));
         }
+
+        public class When_setting_the_same_value_from_multiple_contexts_concurrently : TestFixtureBase
+        {
+            private class Person
+            {
+                public string Name { get; set; }
+            }
+            
+            [Test]
+            public void Should_set_and_preserve_values_for_independent_contexts()
+            {
+                const string Key = "Test";
+                
+                var thread1SetWait = new ManualResetEvent(false);
+                var thread2SetWait = new ManualResetEvent(false);
+
+                Person actualThread1PersonAfterThread1Set = null;
+                Person actualThread1PersonAfterThread2Set = null;
+                Person actualThread2PersonAfterThread2Set = null;
+
+                var t1 = Task.Run(() => 
+                    {
+                        CallContext.SetData(Key, new Person {Name = "Bob"});
+
+                        actualThread1PersonAfterThread1Set = (Person) CallContext.GetData(Key);
+
+                        // Signal thread 2 to proceed with writing its value
+                        thread1SetWait.Set();
+                        
+                        // Wait for thread 2's assignment to complete
+                        thread2SetWait.WaitOne();
+
+                        // Re-fetch the person
+                        actualThread1PersonAfterThread2Set = (Person) CallContext.GetData(Key);
+                    });
+                
+                var t2 = Task.Run(() =>
+                    {
+                        // Wait for thread 1 to set its value
+                        thread1SetWait.WaitOne();
+
+                        // Now write the value for thread 2
+                        CallContext.SetData(Key, new Person {Name = "Joe"});
+                        actualThread2PersonAfterThread2Set = (Person) CallContext.GetData(Key);
+
+                        // Signal that value has been written
+                        thread2SetWait.Set();
+                    });
+                
+                Task.WaitAll(t1, t2);
+                
+                Assert.Multiple(
+                    () =>
+                    {
+                        Assert.That(actualThread1PersonAfterThread1Set, Is.Not.Null, "Thread 1 value.");
+                        Assert.That(actualThread1PersonAfterThread1Set?.Name, Is.EqualTo("Bob"), "Thread 1 value.");
+
+                        Assert.That(actualThread2PersonAfterThread2Set, Is.Not.Null, "Thread 2 value.");
+                        Assert.That(actualThread2PersonAfterThread2Set?.Name, Is.EqualTo("Joe"), "Thread 2 value.");
+                
+                        Assert.That(actualThread1PersonAfterThread2Set, Is.Not.Null, "Thread 1 value retrieved after Thread 2 value set.");
+                        Assert.That(actualThread1PersonAfterThread2Set?.Name, Is.EqualTo("Bob"), "Thread 1 value retrieved after Thread 2 value set.");
+                    });
+            }
+        }
     }
 }
 #endif


### PR DESCRIPTION
…when the same value is set for another context.