### PR TITLE
[ODS-4022] Ed-Fi ODS/API availableChangeQueries OpenApi Spec definition is incorrect

### DIFF
--- a/Application/EdFi.Ods.Features/Resources/ChangeQueries.json
+++ b/Application/EdFi.Ods.Features/Resources/ChangeQueries.json
@@ -51,15 +51,15 @@
   "definitions": {
     "availableChangeVersion": {
       "required": [
-        "oldestChangeVersionId",
-        "newestChangeVersionId"
+        "OldestChangeVersionId",
+        "NewestChangeVersionId"
       ], 
       "properties": {
-        "oldestChangeVersionId": {
+        "OldestChangeVersionId": {
           "type": "integer",
           "format": "int64"
         },
-        "newestChangeVersionId": {
+        "NewestChangeVersionId": {
           "type": "integer",
           "format": "int64"
         }


### PR DESCRIPTION
Adjusting metadata to match actual response for availableChangeVersions endpoint.