### PR TITLE
[ODS-4379] Clean up redundant security metadata for Bootstrap claim set

### DIFF
--- a/Artifacts/MsSql/Data/Security/1060-RemoveRedundantBootstrapPermissions.sql
+++ b/Artifacts/MsSql/Data/Security/1060-RemoveRedundantBootstrapPermissions.sql
@@ -15,18 +15,8 @@
     SELECT @authorizationStrategyId=AuthorizationStrategyId FROM dbo.AuthorizationStrategies WHERE DisplayName='No Further Authorization Required'
     SELECT @createActionId =ActionId FROM dbo.Actions WHERE ActionName='Create'
 
-    IF NOT  EXISTS (SELECT 1 FROM dbo.ResourceClaims WHERE ClaimName = @claim_Name)
+    IF EXISTS (SELECT 1 FROM dbo.ResourceClaims WHERE ClaimName = @claim_Name) AND EXISTS (SELECT 1 FROM dbo.ClaimSets WHERE ClaimSetName = @claimSet_Name)
     BEGIN
-        SET @msg = CONCAT('ClaimName ''', @claim_Name, ''' not found.');
-        THROW 50000, @msg, 1
-    END
-
-    IF NOT  EXISTS (SELECT 1 FROM dbo.ClaimSets WHERE ClaimSetName = @claimSet_Name)
-    BEGIN
-        SET @msg = CONCAT('ClaimSetName ''', @claimSet_Name, ''' not found.');
-        THROW 50000, @msg, 1
-    END
-
     SELECT	@educationOrganizationsResourceClaimId = ResourceClaimId
     FROM	dbo.ResourceClaims rc
     WHERE	rc.ClaimName = @claim_Name
@@ -44,3 +34,4 @@
             AND csrc.ResourceClaim_ResourceClaimId IN 
                 (SELECT  ResourceClaimId FROM dbo.ResourceClaims rc
                 WHERE	rc.ParentResourceClaimId = @educationOrganizationsResourceClaimId))
+    END

--- a/Artifacts/PgSql/Data/Security/1060-RemoveRedundantBootstrapPermissions.sql
+++ b/Artifacts/PgSql/Data/Security/1060-RemoveRedundantBootstrapPermissions.sql
@@ -17,16 +17,8 @@
         SELECT AuthorizationStrategyId INTO authorizationStrategy_Id FROM dbo.AuthorizationStrategies WHERE DisplayName='No Further Authorization Required';
         SELECT ActionId INTO createAction_Id FROM dbo.Actions WHERE ActionName='Create';
 
-        IF NOT EXISTS (SELECT 1 FROM dbo.ResourceClaims WHERE ClaimName = claim_Name)
+        IF EXISTS (SELECT 1 FROM dbo.ResourceClaims WHERE ClaimName = claim_Name) AND EXISTS (SELECT 1 FROM dbo.ClaimSets WHERE ClaimSetName = claimSet_Name)
         THEN
-            RAISE EXCEPTION 'ClaimName ''%'' not found.', claim_Name;
-        END IF;
-
-        IF NOT EXISTS (SELECT 1 FROM dbo.ClaimSets WHERE ClaimSetName = claimSet_Name)
-        THEN
-            RAISE EXCEPTION 'ClaimSetName ''%'' not found.', claimSet_Name;
-        END IF;
-
         SELECT ResourceClaimId INTO educationOrganizationsResourceClaimId
         FROM dbo.ResourceClaims
         WHERE ClaimName = claim_Name;
@@ -44,5 +36,5 @@
                 AND ResourceClaim_ResourceClaimId IN 
                     (SELECT  ResourceClaimId  FROM dbo.ResourceClaims 
                     WHERE ParentResourceClaimId = educationOrganizationsResourceClaimId));
-
-    END $$;
+        END IF;
+        END $$;


### PR DESCRIPTION
If  EXISTS (SELECT 1 FROM dbo.ResourceClaims WHERE ClaimName = claim_Name) AND EXISTS (SELECT 1 FROM dbo.ClaimSets WHERE ClaimSetName = claimSet_Name) then  clean up redundant security metadata for Bootstrap claim set.

we are not doing error handling here 