### PR TITLE
[ODS-4852] Minimal Template Builds fails sometimes after merge of ODS-4788

### DIFF
--- a/Utilities/DataLoading/EdFi.LoadTools/ApiClient/TokenRetriever.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/ApiClient/TokenRetriever.cs
@@ -38,17 +38,21 @@ namespace EdFi.LoadTools.ApiClient
 
         public async Task<BearerToken> ObtainNewBearerToken()
         {
+            var requestMessage = new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                Content = new StringContent("Grant_type=client_credentials", Encoding.UTF8, "application/x-www-form-urlencoded"),
+                RequestUri = new Uri(_configuration.Url)
+            };
+
             var plainTextBytes = Encoding.UTF8.GetBytes($"{_configuration.Key}:{_configuration.Secret}");
             var bearerToken = Convert.ToBase64String(plainTextBytes);
             var authHeader = $"Basic {bearerToken}";
 
-            _client.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse(authHeader);
-
-            var form = "Grant_type=client_credentials";
-            var content = new StringContent(form, Encoding.UTF8, "application/x-www-form-urlencoded");
+            requestMessage.Headers.Authorization = AuthenticationHeaderValue.Parse(authHeader);
 
             _log.Debug($"Post bearer token to '{_configuration.Url}'");
-            var response = await _client.PostAsync(_configuration.Url, content).ConfigureAwait(false);
+            var response = await _client.SendAsync(requestMessage).ConfigureAwait(false);
 
             response.EnsureSuccessStatusCode();
 


### PR DESCRIPTION
DefaultRequestHeaders is not thread safe
see: https://github.com/dotnet/runtime/issues/1500