### PR TITLE
[ODS-4875] API returns 500 rather than 401 status for descriptors requests from a snapshot that is not available

### DIFF
--- a/Application/EdFi.Ods.Common/Infrastructure/Configuration/NHibernateOdsConnectionProvider.cs
+++ b/Application/EdFi.Ods.Common/Infrastructure/Configuration/NHibernateOdsConnectionProvider.cs
@@ -49,10 +49,10 @@ namespace EdFi.Ods.Common.Infrastructure.Configuration
                 connection.ConnectionString = _connectionStringProvider.GetConnectionString();
                 await connection.OpenAsync(cancellationToken);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 connection.Dispose();
-                throw;
+                throw new DatabaseConnectionException("Unable to open connection to the ODS database.", ex);
             }
 
             return connection;


### PR DESCRIPTION
Added logic to wrap a failed `async` connection attempt in an DatabaseConnectionException.