### PR TITLE
[ODS-4957] Convert reasonNotTested into a managedDescriptor

### DIFF
--- a/Artifacts/MsSql/Data/Security/1090-ManagedReasonNotTestedDescriptor.sql
+++ b/Artifacts/MsSql/Data/Security/1090-ManagedReasonNotTestedDescriptor.sql
@@ -1,0 +1,11 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+DECLARE @managedDescriptorsResourceClaimId as INT
+SELECT @managedDescriptorsResourceClaimId = ResourceClaimId
+FROM dbo.ResourceClaims
+WHERE ClaimName = 'http://ed-fi.org/ods/identity/claims/domains/managedDescriptors'
+
+UPDATE dbo.ResourceClaims SET ParentResourceClaimId = @managedDescriptorsResourceClaimId WHERE ClaimName = 'http://ed-fi.org/ods/identity/claims/reasonNotTestedDescriptor'

--- a/Artifacts/PgSql/Data/Security/1090-ManagedReasonNotTestedDescriptor.sql
+++ b/Artifacts/PgSql/Data/Security/1090-ManagedReasonNotTestedDescriptor.sql
@@ -1,0 +1,16 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+DO language plpgsql $$
+DECLARE
+    managed_descriptors_resource_claim_id INT;
+BEGIN
+    SELECT ResourceClaimId INTO managed_descriptors_resource_claim_id
+    FROM dbo.ResourceClaims
+    WHERE ClaimName = 'http://ed-fi.org/ods/identity/claims/domains/managedDescriptors';
+
+    UPDATE dbo.ResourceClaims SET ParentResourceClaimId = managed_descriptors_resource_claim_id WHERE ClaimName = 'http://ed-fi.org/ods/identity/claims/reasonNotTestedDescriptor';
+
+END $$;


### PR DESCRIPTION
Adding security update scripts for MSSQL and PostgreSQL to change ReasonNotTestedDescriptor to be part of managedDescriptors, allowing Create/Update/Delete based on namespace.