### PR TITLE
[ODS-5013] Security Visualization utility and Graphviz

### DIFF
--- a/Utilities/GenerateSecurityGraphs/GenerateSecurityGraphs/FileDotEngine.cs
+++ b/Utilities/GenerateSecurityGraphs/GenerateSecurityGraphs/FileDotEngine.cs
@@ -14,15 +14,18 @@ namespace GenerateSecurityGraphs
     public sealed class FileDotEngine : IDotEngine
     {
         private readonly int _unflattenToDepth;
+        private readonly string _graphvizFolder;
         private readonly string _assetsFolder;
 
-        public FileDotEngine(string assetsFolder)
+        public FileDotEngine(string graphvizFolder, string assetsFolder)
         {
+            _graphvizFolder = graphvizFolder;
             _assetsFolder = assetsFolder;
         }
 
-        public FileDotEngine(string assetsFolder, int unflattenToDepth)
+        public FileDotEngine(string graphvizFolder, string assetsFolder, int unflattenToDepth)
         {
+            _graphvizFolder = graphvizFolder;
             _assetsFolder = assetsFolder;
             _unflattenToDepth = unflattenToDepth;
         }
@@ -52,7 +55,7 @@ namespace GenerateSecurityGraphs
                 var unflattenArgs = string.Format(@"-o ""{0}.unflattened"" -l{1} ""{0}""", outputFileName, _unflattenToDepth);
 
                 Process.Start(
-                    new ProcessStartInfo(@"C:\Program Files (x86)\Graphviz2.38\bin\unflatten.exe", unflattenArgs)
+                    new ProcessStartInfo(Path.Combine(_graphvizFolder, @"bin\unflatten.exe"), unflattenArgs)
                     {
                         UseShellExecute = false,
                         CreateNoWindow = true,
@@ -78,7 +81,7 @@ namespace GenerateSecurityGraphs
                     outputType);
 
                 Process.Start(
-                    new ProcessStartInfo(@"C:\Program Files (x86)\Graphviz2.38\bin\dot.exe", args)
+                    new ProcessStartInfo(Path.Combine(_graphvizFolder, @"bin\dot.exe"), args)
                     {
                         UseShellExecute = false,
                         CreateNoWindow = true,


### PR DESCRIPTION
Manually tested the next cases:

- --graphviz not specified and it is not installed ==> should download portable version
- --graphviz not specified and it is not installed and there is no internet connection ==> should show error message and exit
- --graphviz not specified and it is already installed in C:\Program Files\Graphviz ==> should use existing installation (don't download it)
- --graphviz not specified and portable version was previously downloaded ==> should not download it again

- --graphviz was specified and it is correct ==> should use it (don't download it)
- --graphviz was specified and it is invalid ==> should show error message and exit

- current directory is not the same as the executable path ==> should download portable version alongside the executable (not in the current dir)