### PR TITLE
[ODS-5078] Update internal EdFi.Common package version

### DIFF
--- a/Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj
+++ b/Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj
@@ -15,7 +15,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.2.5" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.1" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.1" />
     <PackageReference Include="log4net" Version="2.0.12" />

--- a/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
+++ b/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.2.5" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.1" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />

--- a/Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj
+++ b/Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj
@@ -14,7 +14,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.2.5" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.1" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
+++ b/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.2.5" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.1" />
     <PackageReference Include="Autofac" Version="5.1.2" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="6.2.1" />

--- a/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
+++ b/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
@@ -13,7 +13,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.2.5" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.1" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.1" />
     <PackageReference Include="Dapper" Version="2.0.35" />

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Autofac.Extras.FakeItEasy" Version="6.0.0" />
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="CompareNETObjects" Version="4.67.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.2.5" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.1" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFrameworkTesting.FakeItEasy" Version="1.3.0" />
     <PackageReference Include="FakeItEasy" Version="6.2.1" />

--- a/Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj
+++ b/Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj
@@ -14,7 +14,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.2.5" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.1" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.1" />
     <PackageReference Include="Npgsql" Version="4.1.5" />

--- a/Application/EdFi.TestObjects/EdFi.TestObjects.csproj
+++ b/Application/EdFi.TestObjects/EdFi.TestObjects.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.2.5" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.1" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj
+++ b/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Autofac" Version="6.1.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.2.5" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.1" />
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.10" />

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
@@ -21,7 +21,7 @@
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="aqua-graphcompare" Version="1.2.2" />
-      <PackageReference Include="EdFi.Suite3.Common" Version="5.2.5" />
+      <PackageReference Include="EdFi.Suite3.Common" Version="5.3.1" />
       <PackageReference Include="EdFi.Suite3.OdsApi.TestSdk" Version="5.2.111" />
       <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
       <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />

--- a/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.1.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.2.5" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.1" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
     <PackageReference Include="log4net" Version="2.0.12" />

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Autofac" Version="6.1.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.2.5" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.1" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
     <PackageReference Include="log4net" Version="2.0.12" />

--- a/Utilities/DataLoading/EdFi.XmlLookup.Console/EdFi.XmlLookup.Console.csproj
+++ b/Utilities/DataLoading/EdFi.XmlLookup.Console/EdFi.XmlLookup.Console.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Autofac" Version="6.1.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.2.5" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.1" />
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.10" />

--- a/tests/EdFi.Admin.DataAccess.UnitTests/EdFi.Admin.DataAccess.UnitTests.csproj
+++ b/tests/EdFi.Admin.DataAccess.UnitTests/EdFi.Admin.DataAccess.UnitTests.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.2.5" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.1" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="6.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />

--- a/tests/EdFi.Common.UnitTests/EdFi.Common.UnitTests.csproj
+++ b/tests/EdFi.Common.UnitTests/EdFi.Common.UnitTests.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.2.5" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.1" />
     <PackageReference Include="FakeItEasy" Version="6.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="nunit" Version="3.12.0" />

--- a/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
+++ b/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="ApprovalTests" Version="5.4.4" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Dapper" Version="2.0.35" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.2.5" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.1" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="6.2.1" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />

--- a/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
+++ b/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="ApprovalUtilities" Version="5.4.4" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Dapper" Version="2.0.35" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.2.5" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.1" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="6.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.10" />

--- a/tests/EdFi.Security.DataAccess.UnitTests/EdFi.Security.DataAccess.UnitTests.csproj
+++ b/tests/EdFi.Security.DataAccess.UnitTests/EdFi.Security.DataAccess.UnitTests.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.2.5" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.1" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFrameworkTesting.FakeItEasy" Version="1.3.0" />
     <PackageReference Include="FakeItEasy" Version="6.2.1" />


### PR DESCRIPTION
Upgraded to 5.3.1v all projects that reference EdFi.Suite3.Common

After the PR is merged, I will check if the following packages need to be re-generated through TeamCity:

- EdFi.Admin.DataAccess
- EdFi.Common
- EdFi.LoadTools
- EdFi.Ods.Api
- EdFi.Ods.Common
- EdFi.Ods.Standard
- EdFi.Security.DataAccess
