### PR TITLE
ODS-5070 - Handle TargetInvocationException so correct validation results gets returned from api

### DIFF
--- a/Application/EdFi.Ods.Common/Extensions/ValidatorExtensions.cs
+++ b/Application/EdFi.Ods.Common/Extensions/ValidatorExtensions.cs
@@ -11,9 +11,9 @@ using log4net;
 
 namespace EdFi.Ods.Common.Extensions
 {
-    public static class ObjectValidatorExtensions
+    public static class ValidatorExtensions
     {
-        private static readonly ILog _logger = LogManager.GetLogger(typeof(ObjectValidatorExtensions));
+        private static readonly ILog _logger = LogManager.GetLogger(typeof(ValidatorExtensions));
 
         public static ICollection<ValidationResult> ValidateObject(this IEnumerable<IObjectValidator> validators, object @object)
         {

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Extensions/ObjectValidationExtensionsTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Extensions/ObjectValidationExtensionsTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Linq;
+using EdFi.Ods.Api.Validation;
+using EdFi.Ods.Common;
+using EdFi.Ods.Common.Attributes;
+using EdFi.Ods.Common.Extensions;
+using EdFi.Ods.Common.Validation;
+using NUnit.Framework;
+using Shouldly;
+
+namespace EdFi.Ods.Tests.EdFi.Ods.Common.Extensions
+{
+    public class ObjectValidationExtensionsTests
+    {
+        [TestFixture]
+        public class When_class_with_required_non_default_throws_exception_during_validation
+        {
+            [Test]
+            public void Should_still_capture_validation_message()
+            {
+                var testClass = new ClassThatWillThrowValidationException { Value = "NewValueHere" };
+
+                var validators = new IEntityValidator[] { new DataAnnotationsEntityValidator() };
+                var results = validators.ValidateObject(testClass);
+
+                results.IsValid().ShouldBe(false);
+                results.Count.ShouldBe(1);
+                results.First().ErrorMessage.ShouldBe("Test validation failure message.");
+            }
+        }
+    }
+
+    class ClassThatWillThrowValidationException
+    {
+        private string _value;
+
+        [RequiredWithNonDefault]
+        public string Value
+        {
+            get => throw new Exception("Test validation failure message.");
+            set => _value = value;
+        }
+    }
+}

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Extensions/ValidationExtensionsTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Extensions/ValidationExtensionsTests.cs
@@ -10,7 +10,7 @@ using Shouldly;
 
 namespace EdFi.Ods.Tests.EdFi.Ods.Common.Extensions
 {
-    public class ObjectValidationExtensionsTests
+    public class ValidationExtensionsTests
     {
         [TestFixture]
         public class When_class_with_required_non_default_throws_exception_during_validation

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Extensions/ValidationExtensionsTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Extensions/ValidationExtensionsTests.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
 using System.Linq;
 using EdFi.Ods.Api.Validation;
 using EdFi.Ods.Common;


### PR DESCRIPTION
When sending an invalid calendarTypeDescriptoron the Calendar POST, a TargetInvocationException was being thrown, which then prevented the validation results from being returned by the API. Now we will catch this and then log the correct validation error.

Additionally, the Trace.Errors were swapped out for using log4net so that these types of messages could be seen in the WebApiLog.