### PR TITLE
[ODS-5097] Changing the default log location for the Web API running under IIS

### DIFF
--- a/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
+++ b/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
@@ -236,8 +236,6 @@ namespace EdFi.Ods.Api.Startup
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory, ApiSettings apiSettings)
         {
-            loggerFactory.AddLog4Net();
-
             if (!string.IsNullOrEmpty(apiSettings.PathBase))
             {
                 var pathBase = apiSettings.PathBase.Trim('/');


### PR DESCRIPTION
Remove Log4Net initialization since it is now initialized in EdFi.Ods.WebApi.Program.Main