### PR TITLE
[EDFI-1067] Update the ODS/API to NET 6.0

### DIFF
--- a/Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj
+++ b/Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>EdFi.Admin.DataAccess</PackageId>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <AssemblyName>EdFi.Admin.DataAccess</AssemblyName>
     <RootNamespace>EdFi.Admin.DataAccess</RootNamespace>
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.1" />
+    <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="Npgsql" Version="4.1.5" />
   </ItemGroup>

--- a/Application/EdFi.Admin.DataAccess/Models/ApiClient.cs
+++ b/Application/EdFi.Admin.DataAccess/Models/ApiClient.cs
@@ -55,7 +55,7 @@ namespace EdFi.Admin.DataAccess.Models
         public string Key { get; set; }
 
         /// <summary>
-        /// 128-bit crypto-strength string 
+        /// 128-bit crypto-strength string
         /// </summary>
         [Required]
         [StringLength(100)]
@@ -96,7 +96,7 @@ namespace EdFi.Admin.DataAccess.Models
         public string Status { get; set; }
 
         /// <summary>
-        /// Indicates client access status to the key. 
+        /// Indicates client access status to the key.
         /// "Not Sent": credentials has not been sent to the client yet
         /// "Sent": challenge has been sent to the client and waiting for activation
         /// "Active": client has successfully retrieved the credentials
@@ -120,12 +120,12 @@ namespace EdFi.Admin.DataAccess.Models
         public string ActivationCode { get; set; }
 
         /// <summary>
-        /// Number of retries client has done to get the credentials. 
+        /// Number of retries client has done to get the credentials.
         /// </summary>
         public int? ActivationRetried { get; set; }
 
         /// <summary>
-        /// Have a reference to OwnershipToken table ownershiptokenid for specific apiclient. 
+        /// Have a reference to OwnershipToken table ownershiptokenid for specific apiclient.
         /// </summary>
         public virtual OwnershipToken CreatorOwnershipTokenId { get; set; }
 
@@ -153,18 +153,18 @@ namespace EdFi.Admin.DataAccess.Models
         public Dictionary<string, string> Domains { get; set; }
 
         /// <summary>
-        /// Method to generate a new secret 128-bit crypto-strength random number 
+        /// Method to generate a new secret 128-bit crypto-strength random number
         /// and returns the new secret for display or other purposes.
         /// </summary>
         /// <param name="length">The length of the string to be generated</param>
-        /// <returns>Random string with only alphanumeric values (no '+' or '/')</returns>        
+        /// <returns>Random string with only alphanumeric values (no '+' or '/')</returns>
         private static string GenerateRandomString(int length = 24)
         {
             string result;
             var numBytes = (length + 3) / 4 * 3;
             var bytes = new byte[numBytes];
 
-            using (var rng = new RNGCryptoServiceProvider())
+            using (var rng = RandomNumberGenerator.Create())
             {
                 do
                 {

--- a/Application/EdFi.Admin.DataAccess/global.json
+++ b/Application/EdFi.Admin.DataAccess/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.101",
+    "rollForward": "latestMinor"
+  }
+}

--- a/Application/EdFi.Common/EdFi.Common.csproj
+++ b/Application/EdFi.Common/EdFi.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RestorePackages>true</RestorePackages>
@@ -13,9 +13,9 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.10" />
-    <PackageReference Include="log4net" Version="2.0.12" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Npgsql" Version="4.1.5" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
   </ItemGroup>
 </Project>

--- a/Application/EdFi.Common/Security/HashHelper.cs
+++ b/Application/EdFi.Common/Security/HashHelper.cs
@@ -15,7 +15,7 @@ namespace EdFi.Common.Security
         /// </summary>
         /// <param name="stringToHash"></param>
         /// <returns></returns>
-        public static byte[] GetSha256Hash(string stringToHash) => new SHA256Managed()
+        public static byte[] GetSha256Hash(string stringToHash) =>  SHA256.Create()
            .ComputeHash(Encoding.UTF8.GetBytes(stringToHash), 0, Encoding.UTF8.GetByteCount(stringToHash));
     }
 }

--- a/Application/EdFi.Common/global.json
+++ b/Application/EdFi.Common/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.101",
+    "rollForward": "latestMinor"
+  }
+}

--- a/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
+++ b/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>EdFi.Ods.Api</PackageId>
-    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>  
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EdFi.Ods.Api</AssemblyName>
     <AssemblyVersion>99.99.99.00</AssemblyVersion>
     <RootNamespace>EdFi.Ods.Api</RootNamespace>
@@ -27,23 +27,23 @@
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />
-    <PackageReference Include="log4net" Version="2.0.12" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.16.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.10" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="NHibernate" Version="5.2.7" />
+    <PackageReference Include="log4net" Version="2.0.13" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
+    <PackageReference Include="NHibernate" Version="5.3.10" />
     <PackageReference Include="Npgsql" Version="4.1.5" />
     <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="Remotion.Linq" Version="2.2.0" />
     <PackageReference Include="Remotion.Linq.EagerFetching" Version="2.2.0" />
     <PackageReference Include="Sandwych.QuickGraph.Core" Version="1.0.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
   </ItemGroup>

--- a/Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj
+++ b/Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj
@@ -18,18 +18,18 @@
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />
-    <PackageReference Include="log4net" Version="2.0.12" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NHibernate" Version="5.2.7" />
+    <PackageReference Include="log4net" Version="2.0.13" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NHibernate" Version="5.3.10" />
     <PackageReference Include="Npgsql" Version="4.1.5" />
     <PackageReference Include="Sandwych.QuickGraph.Core" Version="1.0.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.10" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Metadata\Schemas\Ed-Fi-ODS-API-Profiles.xsd" />

--- a/Application/EdFi.Ods.Composites.Enrollment/EdFi.Ods.Composites.Enrollment.csproj
+++ b/Application/EdFi.Ods.Composites.Enrollment/EdFi.Ods.Composites.Enrollment.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EdFi.Ods.Composites.Enrollment</AssemblyName>
     <RootNamespace>EdFi.Ods.Composites.Enrollment</RootNamespace>
     <RestorePackages>true</RestorePackages>

--- a/Application/EdFi.Ods.Composites.Test/EdFi.Ods.Composites.Test.csproj
+++ b/Application/EdFi.Ods.Composites.Test/EdFi.Ods.Composites.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EdFi.Ods.Composites.Test</AssemblyName>
     <RootNamespace>EdFi.Ods.Composites.Test</RootNamespace>
     <RestorePackages>true</RestorePackages>

--- a/Application/EdFi.Ods.Features/EdFi.Ods.Features.csproj
+++ b/Application/EdFi.Ods.Features/EdFi.Ods.Features.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>EdFi.Ods.Features</RootNamespace>
     <AssemblyName>EdFi.Ods.Features</AssemblyName>
     <Configurations>Debug;Release</Configurations>
@@ -17,7 +17,7 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Resources\ChangeQueries.json" />
@@ -32,6 +32,6 @@
     <ProjectReference Include="..\EdFi.Ods.Common\EdFi.Ods.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/Application/EdFi.Ods.Profiles.Test/EdFi.Ods.Profiles.Test.csproj
+++ b/Application/EdFi.Ods.Profiles.Test/EdFi.Ods.Profiles.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyTitle>EdFi.Ods.Profiles.Test</AssemblyTitle>
     <Product>EdFi.Ods.Profiles.Test</Product>
     <RestorePackages>true</RestorePackages>
@@ -13,9 +13,9 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
+++ b/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemlbyName>EdFi.Ods.Repositories.NHibernate.Tests</AssemlbyName>
     <RootNamespace>EdFi.Ods.Repositories.NHibernate.Tests</RootNamespace>
     <Copyright>Copyright © 2019 Ed-Fi Alliance, LLC and Contributors</Copyright>
@@ -18,23 +18,23 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
-    <PackageReference Include="Autofac" Version="5.1.2" />
+    <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.3.43" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="FakeItEasy" Version="6.2.1" />
+    <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />
-    <PackageReference Include="log4net" Version="2.0.12" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NHibernate" Version="5.2.7" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="log4net" Version="2.0.13" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="NHibernate" Version="5.3.10" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Remotion.Linq" Version="2.2.0" />
     <PackageReference Include="Remotion.Linq.EagerFetching" Version="2.2.0" />
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.23" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.30" />
+    <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\tests\EdFi.TestFixture\EdFi.TestFixture.csproj" />

--- a/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
+++ b/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EdFi.Ods.Sandbox</AssemblyName>
     <RootNamespace>EdFi.Ods.Sandbox</RootNamespace>
     <RestorePackages>true</RestorePackages>
@@ -16,15 +16,15 @@
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.3.43" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.1" />
-    <PackageReference Include="Dapper" Version="2.0.35" />
+    <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
+    <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Npgsql" Version="4.1.5" />
-    <PackageReference Include="log4net" Version="2.0.12" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.10" />
+    <PackageReference Include="log4net" Version="2.0.13" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Npgsql" Version="4.1.5" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/Application/EdFi.Ods.Standard/EdFi.Ods.Standard.csproj
+++ b/Application/EdFi.Ods.Standard/EdFi.Ods.Standard.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <PackageId>EdFi.Ods.Standard</PackageId>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EdFi.Ods.Standard</AssemblyName>
     <RootNamespace>EdFi.Ods.Standard</RootNamespace>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -16,12 +16,12 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NHibernate" Version="5.2.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NHibernate" Version="5.3.10" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EdFi.Ods.Api\EdFi.Ods.Api.csproj" />

--- a/Application/EdFi.Ods.Tests.TestExtension/EdFi.Ods.Tests.TestExtension.csproj
+++ b/Application/EdFi.Ods.Tests.TestExtension/EdFi.Ods.Tests.TestExtension.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EdFi.Ods.Tests.FakeExtension</AssemblyName>
     <RootNamespace>EdFi.Ods.Tests.FakeExtension</RootNamespace>
     <Copyright>Copyright © 2019 Ed-Fi Alliance, LLC and Contributors</Copyright>
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Marker_EdFi_Ods_Test_TestExtension.cs">

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EdFi.Ods.Tests</AssemblyName>
     <RootNamespace>EdFi.Ods.Tests</RootNamespace>
     <Copyright>Copyright © 2019 Ed-Fi Alliance, LLC and Contributors</Copyright>
@@ -19,34 +19,34 @@
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.3.43" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.3.43" />
-    <PackageReference Include="NHibernate" Version="5.2.7" />
-    <PackageReference Include="Autofac.Extras.FakeItEasy" Version="6.0.0" />
+    <PackageReference Include="NHibernate" Version="5.3.10" />
+    <PackageReference Include="Autofac.Extras.FakeItEasy" Version="7.0.0" />
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="CompareNETObjects" Version="4.67.0" />
+    <PackageReference Include="CompareNETObjects" Version="4.74.0" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFrameworkTesting.FakeItEasy" Version="1.3.0" />
-    <PackageReference Include="FakeItEasy" Version="6.2.1" />
+    <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />
-    <PackageReference Include="log4net" Version="2.0.12" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="log4net" Version="2.0.13" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Npgsql" Version="4.1.5" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.13.0" />
     <PackageReference Include="Remotion.Linq" Version="2.2.0" />
     <PackageReference Include="Remotion.Linq.EagerFetching" Version="2.2.0" />
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.23" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.30" />
     <PackageReference Include="Sandwych.QuickGraph.Core" Version="1.0.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\tests\EdFi.TestFixture\EdFi.TestFixture.csproj" />

--- a/Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj
+++ b/Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>EdFi.Security.DataAccess</PackageId>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EdFi.Security.DataAccess</AssemblyName>
     <RootNamespace>EdFi.Security.DataAccess</RootNamespace>
     <RestorePackages>true</RestorePackages>
@@ -17,12 +17,12 @@
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.1" />
+    <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="Npgsql" Version="4.1.5" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/Application/EdFi.Security.DataAccess/global.json
+++ b/Application/EdFi.Security.DataAccess/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.101",
+    "rollForward": "latestMinor"
+  }
+}

--- a/Application/EdFi.TestObjects/EdFi.TestObjects.csproj
+++ b/Application/EdFi.TestObjects/EdFi.TestObjects.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EdFi.TestObjects</AssemblyName>
     <RootNamespace>EdFi.TestObjects</RootNamespace>
     <Copyright>Copyright © 2019 Ed-Fi Alliance, LLC and Contributors</Copyright>
@@ -17,9 +17,9 @@
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="log4net" Version="2.0.12" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="log4net" Version="2.0.13" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Application/Test.Common/Test.Common.csproj
+++ b/Application/Test.Common/Test.Common.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Test.Common</AssemblyName>
     <RootNamespace>Test.Common</RootNamespace>
     <Copyright>Copyright © 2019 Ed-Fi Alliance, LLC and Contributors</Copyright>
@@ -17,13 +17,11 @@
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.3.43" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="log4net" Version="2.0.12" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="FakeItEasy" Version="6.2.1" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="log4net" Version="2.0.13" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="FakeItEasy" Version="7.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,4 +13,4 @@ profile to this file with their first pull request.
 * **[Jean-Francois Guertin, EdWire](https://github.com/frenchyjef)**
 * **[Mansoor Khalid, EdWire](https://github.com/Mansoor-Khalid)**
 * **[Google Cloud](https://cloud.google.com/) / [Innive](https://innive.com/)**
-* **[Jim McKay, Instructure](https://github.com/jamessmckay)**
+* **[Jim McKay](https://github.com/jamessmckay)**

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/EdFi.Ods.CodeGen.Tests.csproj
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/EdFi.Ods.CodeGen.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
     <IsTestProject>true</IsTestProject>
     <RestorePackages>true</RestorePackages>
@@ -23,19 +23,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ApprovalTests" Version="5.4.4" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="CommandLineParser" Version="2.7.82" />
-    <PackageReference Include="FakeItEasy" Version="6.2.1" />
+    <PackageReference Include="ApprovalTests" Version="5.7.1" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.10" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/EdFi.Ods.CodeGen.csproj
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/EdFi.Ods.CodeGen.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyVersion>0.0.0</AssemblyVersion>
     <AssemblyName>EdFi.Ods.CodeGen</AssemblyName>
     <FileVersion>0.0.0</FileVersion>
@@ -26,21 +26,21 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
-    <PackageReference Include="Autofac" Version="5.1.2" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="CommandLineParser" Version="2.7.82" />
-    <PackageReference Include="DatabaseSchemaReader" Version="2.7.4" />
+    <PackageReference Include="Autofac" Version="6.3.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="DatabaseSchemaReader" Version="2.7.11" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.10" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="6.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Stubble.Core" Version="1.9.3" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Application\EdFi.Ods.Common\EdFi.Ods.Common.csproj" />

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Generators/Resources/PropertyData.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Generators/Resources/PropertyData.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -148,7 +149,8 @@ namespace EdFi.Ods.CodeGen.Generators.Resources
                 PropertyNamespacePrefix = propertyNamespacePrefix,
                 NullPropertyPrefix = Property.EntityProperty.Entity.IsEntityExtension
                     ? $"{propertyNamespacePrefix}I{Property.EntityProperty.Entity.Name}."
-                    : $"{propertyNamespacePrefix}I{Property.EntityProperty.Entity.ResolvedEdFiEntityName()}."
+                    : $"{propertyNamespacePrefix}I{Property.EntityProperty.Entity.ResolvedEdFiEntityName()}.",
+                IsNullable = Property.PropertyType.IsNullable
             };
         }
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Mustache/Resources.mustache
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Mustache/Resources.mustache
@@ -579,7 +579,6 @@ namespace {{ResourceClassesNamespace}}
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as {{NamespacePrefix}}I{{EntityName}};
 
             if (ReferenceEquals(this, compareTo))
@@ -598,49 +597,82 @@ namespace {{ResourceClassesNamespace}}
             {{#Usi}}
             {{#Property}}
             // Property
+            {{#IsNullable}}
             if ((this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}} == null
                 || !(this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}}.Equals(compareTo.{{PropertyName}}))
                 return false;
+            {{/IsNullable}}
+            {{^IsNullable}}
+            if ((this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}}.Equals(compareTo.{{PropertyName}}))
+                return false;
+            {{/IsNullable}}
             {{/Property}}
             {{/Usi}}
             {{#Standard}}
             {{#Property}}
 
             // Standard Property
+            {{#IsNullable}}
             if ((this as {{NamespacePrefix}}I{{ClassName}}).{{CSharpSafePropertyName}} == null
                 || !(this as {{NamespacePrefix}}I{{ClassName}}).{{CSharpSafePropertyName}}.Equals(compareTo.{{CSharpSafePropertyName}}))
                 return false;
+            {{/IsNullable}}
+            {{^IsNullable}}
+             if ((this as {{NamespacePrefix}}I{{ClassName}}).{{CSharpSafePropertyName}}.Equals(compareTo.{{CSharpSafePropertyName}}))
+                return false;
+            {{/IsNullable}}
+
             {{/Property}}
             {{/Standard}}
             {{#Referenced}}
             {{#Property}}
 
             // Referenced Property
+            {{#IsNullable}}
             if ((this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}} == null
                 || !(this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}}.Equals(compareTo.{{PropertyName}}))
                 return false;
+            {{/IsNullable}}
+            {{^IsNullable}}
+            if (!(this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}}.Equals(compareTo.{{PropertyName}}))
+                return false;
+            {{/IsNullable}}
+
             {{/Property}}
             {{/Referenced}}
             {{#UnifiedType}}
             {{#Property}}
 
             // Unified Type Property
+            {{#IsNullable}}
             if ((this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}} == null
                 ||!(this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}}.Equals(compareTo.{{PropertyName}}))
                 return false;
+            {{/IsNullable}}
+            {{^IsNullable}}
+            if (!(this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}}.Equals(compareTo.{{PropertyName}}))
+                return false;
+            {{/IsNullable}}
+
             {{/Property}}
             {{/UnifiedType}}
             {{#Derived}}
             {{#Property}}
 
             // Derived Property
+            {{#IsNullable}}
             if ((this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}} == null
                 || !(this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}}.Equals(compareTo.{{PropertyName}}))
                 return false;
+            {{/IsNullable}}
+            {{^IsNullable}}
+            if (!(this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}}.Equals(compareTo.{{PropertyName}}))
+                return false;
+            {{/IsNullable}}
+
             {{/Property}}
             {{/Derived}}
             {{/Properties}}
-            #pragma warning disable 472
 
             return true;
         }
@@ -653,7 +685,6 @@ namespace {{ResourceClassesNamespace}}
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -667,46 +698,72 @@ namespace {{ResourceClassesNamespace}}
                 {{#Property}}
 
                 //Property
-                if ((this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}} != null)
+                {{#IsNullable}}
+                 if ((this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}} != null)
                     hash = hash * 23 + (this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}}.GetHashCode();
+                {{/IsNullable}}
+                {{^IsNullable}}
+                hash = hash * 23 + (this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}}.GetHashCode();
+                {{/IsNullable}}
+
                 {{/Property}}
                 {{/Usi}}
                 {{#Standard}}
                 {{#Property}}
 
                 // Standard Property
+                {{#IsNullable}}
                 if ((this as {{NamespacePrefix}}I{{ClassName}}).{{CSharpSafePropertyName}} != null)
                     hash = hash * 23 + (this as {{NamespacePrefix}}I{{{ClassName}}}).{{CSharpSafePropertyName}}.GetHashCode();
+                {{/IsNullable}}
+                {{^IsNullable}}
+                 hash = hash * 23 + (this as {{NamespacePrefix}}I{{{ClassName}}}).{{CSharpSafePropertyName}}.GetHashCode();
+                {{/IsNullable}}
+
                 {{/Property}}
                 {{/Standard}}
                 {{#Referenced}}
                 {{#Property}}
 
                 //Referenced Property
+                {{#IsNullable}}
                 if ((this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}} != null)
                     hash = hash * 23 + (this as {{NamespacePrefix}}I{{{ClassName}}}).{{PropertyName}}.GetHashCode();
+                {{/IsNullable}}
+                hash = hash * 23 + (this as {{NamespacePrefix}}I{{{ClassName}}}).{{PropertyName}}.GetHashCode();
                 {{/Property}}
                 {{/Referenced}}
                 {{#UnifiedType}}
                 {{#Property}}
 
                 //Unified Type Property
+                {{#IsNullalbe}}
                 if ((this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}} != null)
                     hash = hash * 23 + (this as {{NamespacePrefix}}I{{{ClassName}}}).{{PropertyName}}.GetHashCode();
+                {{/IsNullalbe}}
+                {{^IsNullable}}
+                hash = hash * 23 + (this as {{NamespacePrefix}}I{{{ClassName}}}).{{PropertyName}}.GetHashCode();
+                {{/IsNullable}}
+
                 {{/Property}}
                 {{/UnifiedType}}
                 {{#Derived}}
                 {{#Property}}
 
                 //Derived Property
+                {{#IsNullable}}
                 if ((this as {{NamespacePrefix}}I{{ClassName}}).{{PropertyName}} != null)
                     hash = hash * 23 + (this as {{NamespacePrefix}}I{{{ClassName}}}).{{PropertyName}}.GetHashCode();
+                {{/IsNullable}}
+                {{^IsNullable}}
+                hash = hash * 23 + (this as {{NamespacePrefix}}I{{{ClassName}}}).{{PropertyName}}.GetHashCode();
+                {{/IsNullable}}
+
                 {{/Property}}
                 {{/Derived}}
                 {{/Properties}}
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
         {{/Identifiers}}

--- a/Utilities/CodeGeneration/global.json
+++ b/Utilities/CodeGeneration/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.101",
+    "rollForward": "latestMinor"
+  }
+}

--- a/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj
+++ b/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj
@@ -35,17 +35,17 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.1.0" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
+    <PackageReference Include="Autofac" Version="6.3.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
-    <PackageReference Include="log4net" Version="2.0.12" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.10" />
+    <PackageReference Include="log4net" Version="2.0.13" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EdFi.LoadTools\EdFi.LoadTools.csproj" />

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <AssemblyName>EdFi.LoadTools.Test</AssemblyName>
         <RootNamespace>EdFi.LoadTools.Test</RootNamespace>
         <Copyright>Copyright © 2020 Ed-Fi Alliance, LLC and Contributors</Copyright>
@@ -25,15 +25,15 @@
       <PackageReference Include="EdFi.Suite3.OdsApi.TestSdk" Version="5.3.243" />
       <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
       <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
-      <PackageReference Include="log4net" Version="2.0.12" />
-      <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.8" />
-      <PackageReference Include="Microsoft.Extensions.Primitives" Version="3.1.10" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-      <PackageReference Include="Moq" Version="4.14.5" />
-      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-      <PackageReference Include="NUnit" Version="3.12.0" />
-      <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-      <PackageReference Include="Shouldly" Version="4.0.1" />
+      <PackageReference Include="log4net" Version="2.0.13" />
+      <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+      <PackageReference Include="Moq" Version="4.16.1" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+      <PackageReference Include="NUnit" Version="3.13.2" />
+      <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+      <PackageReference Include="Shouldly" Version="4.0.3" />
     </ItemGroup>
     <ItemGroup>
       <None Update="appsettings.json">

--- a/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
@@ -22,13 +22,13 @@
     <None Include="../../../LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.1.0" />
+    <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
-    <PackageReference Include="log4net" Version="2.0.12" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.10" />
+    <PackageReference Include="log4net" Version="2.0.13" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.10" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Sandwych.QuickGraph.Core" Version="1.0.0" />

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
@@ -37,19 +37,19 @@
     <ProjectReference Include="..\EdFi.LoadTools\EdFi.LoadTools.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.1.0" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
+    <PackageReference Include="Autofac" Version="6.3.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
-    <PackageReference Include="log4net" Version="2.0.12" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.10" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="log4net" Version="2.0.13" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/Utilities/DataLoading/EdFi.XmlLookup.Console/EdFi.XmlLookup.Console.csproj
+++ b/Utilities/DataLoading/EdFi.XmlLookup.Console/EdFi.XmlLookup.Console.csproj
@@ -26,17 +26,17 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.1.0" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
+    <PackageReference Include="Autofac" Version="6.3.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
-    <PackageReference Include="log4net" Version="2.0.12" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.10" />
+    <PackageReference Include="log4net" Version="2.0.13" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EdFi.LoadTools\EdFi.LoadTools.csproj" />

--- a/Utilities/DataLoading/global.json
+++ b/Utilities/DataLoading/global.json
@@ -1,0 +1,5 @@
+{
+  "sdk": {
+    "version": "6.0.101",
+    "rollForward": "latestMinor"
+}

--- a/Utilities/GenerateSecurityGraphs/GenerateSecurityGraphs/GenerateSecurityGraphs.csproj
+++ b/Utilities/GenerateSecurityGraphs/GenerateSecurityGraphs/GenerateSecurityGraphs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Copyright>Copyright © 2020 Ed-Fi Alliance, LLC and Contributors</Copyright>
     <TreatErrorsAsWarning>true</TreatErrorsAsWarning>
     <RestorePackages>true</RestorePackages>
@@ -10,11 +10,11 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Dapper" Version="2.0.90" />
-    <PackageReference Include="QuikGraph" Version="2.2.0" />
-    <PackageReference Include="QuikGraph.Graphviz" Version="2.2.0" />
-    <PackageReference Include="QuikGraph.Serialization" Version="2.2.2" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="Dapper" Version="2.0.123" />
+    <PackageReference Include="QuikGraph" Version="2.3.0" />
+    <PackageReference Include="QuikGraph.Graphviz" Version="2.3.1" />
+    <PackageReference Include="QuikGraph.Serialization" Version="2.3.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Utilities/GenerateSecurityGraphs/global.json
+++ b/Utilities/GenerateSecurityGraphs/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.101",
+    "rollForward": "latestMinor"
+  }
+}

--- a/Utilities/VisualStudioProjectTemplates/EdFi.ProjectTemplates.Extensions/Template_Project.csproj
+++ b/Utilities/VisualStudioProjectTemplates/EdFi.ProjectTemplates.Extensions/Template_Project.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>$safeprojectname$</AssemblyName>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <RestorePackages>true</RestorePackages>

--- a/Utilities/VisualStudioProjectTemplates/EdFi.ProjectTemplates.Profiles/Template_Project.csproj
+++ b/Utilities/VisualStudioProjectTemplates/EdFi.ProjectTemplates.Profiles/Template_Project.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>$safeprojectname$</AssemblyName>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <RestorePackages>true</RestorePackages>
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="8.6.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/EdFi.Admin.DataAccess.IntegrationTests/EdFi.Admin.DataAccess.IntegrationTests.csproj
+++ b/tests/EdFi.Admin.DataAccess.IntegrationTests/EdFi.Admin.DataAccess.IntegrationTests.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Company>Ed-Fi Alliance</Company>
     <Product>EdFi.Admin.DataAccess.IntegrationTests</Product>
     <Assembly>EdFi.Admin.DataAccess.IntegrationTests</Assembly>
@@ -16,21 +16,19 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="6.2.1" />
+    <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="NCrunch.Framework" Version="4.5.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Shouldly" Version="3.0.2" />
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.30" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Application\Test.Common\Test.Common.csproj" />

--- a/tests/EdFi.Admin.DataAccess.UnitTests/EdFi.Admin.DataAccess.UnitTests.csproj
+++ b/tests/EdFi.Admin.DataAccess.UnitTests/EdFi.Admin.DataAccess.UnitTests.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EdFi.Admin.DataAccess.UnitTests</AssemblyName>
     <RootNamespace>EdFi.Admin.DataAccess.UnitTests</RootNamespace>
     <Copyright>Copyright © 2020 Ed-Fi Alliance, LLC and Contributors</Copyright>
@@ -18,16 +18,16 @@
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="FakeItEasy" Version="6.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NCrunch.Framework" Version="4.5.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="FakeItEasy" Version="7.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="NCrunch.Framework" Version="4.7.0.4" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Shouldly" Version="3.0.2" />
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.23" />
+    <PackageReference Include="Shouldly" Version="4.0.3" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.30" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Application\EdFi.Admin.DataAccess\EdFi.Admin.DataAccess.csproj" />

--- a/tests/EdFi.Common.UnitTests/EdFi.Common.UnitTests.csproj
+++ b/tests/EdFi.Common.UnitTests/EdFi.Common.UnitTests.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RestorePackages>true</RestorePackages>
@@ -19,23 +19,23 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="FakeItEasy" Version="6.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+	<PackageReference Include="FakeItEasy" Version="7.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="nunit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.23" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.30" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/EdFi.Ods.Api.IntegrationTests/EdFi.Ods.Api.IntegrationTests.csproj
+++ b/tests/EdFi.Ods.Api.IntegrationTests/EdFi.Ods.Api.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EdFi.Ods.Api.IntegrationTests</AssemblyName>
     <RootNamespace>EdFi.Ods.Api.IntegrationTests</RootNamespace>
     <Copyright>Copyright © 2020 Ed-Fi Alliance, LLC and Contributors</Copyright>
@@ -13,19 +13,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Shouldly" Version="3.0.2" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.23" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.30" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
+++ b/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>EdFi.Ods.WebApi.CompositeSpecFlowTests</RootNamespace>
     <Copyright>Copyright © 2020 Ed-Fi Alliance, LLC and Contributors</Copyright>
     <TreatErrorsAsWarning>true</TreatErrorsAsWarning>
@@ -27,21 +27,21 @@
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.3.43" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.3.43" />
-    <PackageReference Include="NHibernate" Version="5.2.7" />
-    <PackageReference Include="ApprovalTests" Version="5.4.4" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Dapper" Version="2.0.35" />
+    <PackageReference Include="NHibernate" Version="5.3.10" />
+    <PackageReference Include="ApprovalTests" Version="5.7.1" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
+    <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="FakeItEasy" Version="6.2.1" />
+    <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />
     <PackageReference Include="Gherkin" Version="6.0.0" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />
-    <PackageReference Include="log4net" Version="2.0.12" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="log4net" Version="2.0.13" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -49,7 +49,7 @@
     <PackageReference Include="Remotion.Linq.EagerFetching" Version="2.2.0" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.30" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="SpecFlow" Version="3.5.5" />
     <PackageReference Include="SpecFlow.NUnit" Version="3.5.5" />

--- a/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
+++ b/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EdFi.Ods.WebApi.IntegrationTests</AssemblyName>
     <RootNamespace>EdFi.Ods.WebApi.IntegrationTests</RootNamespace>
     <Copyright>Copyright © 2020 Ed-Fi Alliance, LLC and Contributors</Copyright>
@@ -15,23 +15,23 @@
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.3.43" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.3.43" />
-    <PackageReference Include="NHibernate" Version="5.2.7" />
-    <PackageReference Include="ApprovalTests" Version="5.4.4" />
-    <PackageReference Include="ApprovalUtilities" Version="5.4.4" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Dapper" Version="2.0.35" />
+    <PackageReference Include="NHibernate" Version="5.3.10" />
+    <PackageReference Include="ApprovalTests" Version="5.7.1" />
+    <PackageReference Include="ApprovalUtilities" Version="5.7.1" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
+    <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="FakeItEasy" Version="6.2.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="FakeItEasy" Version="7.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.23" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.30" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
   </ItemGroup>
 

--- a/tests/EdFi.Security.DataAccess.UnitTests/EdFi.Security.DataAccess.UnitTests.csproj
+++ b/tests/EdFi.Security.DataAccess.UnitTests/EdFi.Security.DataAccess.UnitTests.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EdFi.Security.DataAccess.UnitTests</AssemblyName>
     <RootNamespace>EdFi.Security.DataAccess.UnitTests</RootNamespace>
     <Copyright>Copyright © 2020 Ed-Fi Alliance, LLC and Contributors</Copyright>
@@ -19,15 +19,15 @@
     <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFrameworkTesting.FakeItEasy" Version="1.3.0" />
-    <PackageReference Include="FakeItEasy" Version="6.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="FakeItEasy" Version="7.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.23" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.30" />
+    <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Application\EdFi.Security.DataAccess\EdFi.Security.DataAccess.csproj" />

--- a/tests/EdFi.TestFixture/EdFi.TestFixture.csproj
+++ b/tests/EdFi.TestFixture/EdFi.TestFixture.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Copyright>Copyright © 2020 Ed-Fi Alliance, LLC and Contributors</Copyright>
     <TreatErrorsAsWarning>true</TreatErrorsAsWarning>
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="FakeItEasy" Version="6.2.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="FakeItEasy" Version="7.2.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* updated the project files to support net 6.0
* fixed the resources being generated to remove the compile error
* added global.json files to the solutions that require it

Notes
* Must install the net 6.0 sdk before proceeding
* There is a required change to codegen. This needs to be run first manually before running initdev. (run initdev -nocodegen after to build otherwise) until the image is built in team city.
* added global.json files, this ensures the application is built correctly with the right framework. May want to spin off a ticket to remove the checks in the powershell scripts.

Remaining Work
* TeamCity needs to be updated with the net 6.0 sdk
* CodeGen Package needs to be created and solution updated with that package
* CodeGen Approval Tests need to be updated
* EdFi.Common needs a new package created and solution updated
* EdFi.Admin.DataAccess needs a new package created and solution updated
* EdFi.Security.DataAccess needs a new package created and solution updated

Items not addressed
* Sandbox Admin Identity package was not updated due to the change in the model (the current model works fine with net 6.0)
* PostgreSQL packages not updated due to the unknown repercussion with Sandbox Admin
*  Fluent Validation package was not updated. This requires a migration from 8.x to 10.x and there are breaking changes, suggestion here is to spin off a ticket and do the necessary update. This will require a codegen change too.