### PR TITLE
ODS-5241 Update codegen tests for NET6 update

### DIFF
--- a/Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj
+++ b/Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="log4net" Version="2.0.12" />

--- a/Application/EdFi.Common/Inflection/Inflector.cs
+++ b/Application/EdFi.Common/Inflection/Inflector.cs
@@ -175,6 +175,29 @@ namespace EdFi.Common.Inflection
         }
 
         /// <summary>
+        /// Gets the singularized or pluralized form of the supplied word based on the basic count provided.
+        /// </summary>
+        /// <param name="word">The word to be inflected.</param>
+        /// <param name="basisCount">The basis for determining whether to singularize or pluralize the word.</param>
+        /// <param name="singularWordOverride">An override value to use for the singular form.</param>
+        /// <param name="pluralWordOverride">An override value to use for the plural form.</param>
+        /// <returns>The inflected word.</returns>
+        public static string Inflect(string word, int basisCount, string singularWordOverride = null, string pluralWordOverride = null)
+        {
+            if (basisCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(basisCount), "Value must be greater than or equal to 0.");
+            }
+            
+            if (basisCount == 1)
+            {
+                return singularWordOverride ?? MakeSingular(word);
+            }
+
+            return pluralWordOverride ?? MakePlural(word);
+        }
+        
+        /// <summary>
         ///     Applies the rules.
         /// </summary>
         /// <param name="rules">The rules.</param>

--- a/Application/EdFi.Ods.Api/Caching/InstanceSecurityRepositoryCache.cs
+++ b/Application/EdFi.Ods.Api/Caching/InstanceSecurityRepositoryCache.cs
@@ -120,36 +120,40 @@ namespace EdFi.Ods.Api.Caching
         {
             using (var context = _securityContextFactory.CreateContext())
             {
-                var application =
-                    context.Applications.First(
-                        app => app.ApplicationName.Equals(EdFiOdsApi, StringComparison.InvariantCultureIgnoreCase));
+                var application = context.Applications.First(
+                    app => app.ApplicationName.Equals(EdFiOdsApi, StringComparison.InvariantCultureIgnoreCase));
 
                 var actions = context.Actions.ToList();
 
-                var claimSets = context.ClaimSets.Include(cs => cs.Application)
-                                       .ToList();
+                var claimSets = context.ClaimSets
+                    .Include(cs => cs.Application)
+                    .ToList();
 
-                var resourceClaims = context.ResourceClaims.Include(rc => rc.Application)
-                                            .Include(rc => rc.ParentResourceClaim)
-                                            .Where(rc => rc.Application.ApplicationId.Equals(application.ApplicationId))
-                                            .ToList();
+                var resourceClaims = context.ResourceClaims
+                    .Include(rc => rc.Application)
+                    .Include(rc => rc.ParentResourceClaim)
+                    .Where(rc => rc.Application.ApplicationId.Equals(application.ApplicationId))
+                    .ToList();
 
-                var authorizationStrategies = context.AuthorizationStrategies.Include(auth => auth.Application)
-                                                     .Where(auth => auth.Application.ApplicationId.Equals(application.ApplicationId))
-                                                     .ToList();
+                var authorizationStrategies = context.AuthorizationStrategies
+                    .Include(auth => auth.Application)
+                    .Where(auth => auth.Application.ApplicationId.Equals(application.ApplicationId))
+                    .ToList();
 
-                var claimSetResourceClaims = context.ClaimSetResourceClaims.Include(csrc => csrc.Action)
-                                                    .Include(csrc => csrc.ClaimSet)
-                                                    .Include(csrc => csrc.ResourceClaim)
-                                                    .Where(csrc => csrc.ResourceClaim.Application.ApplicationId.Equals(application.ApplicationId))
-                                                    .ToList();
+                var claimSetResourceClaims = context.ClaimSetResourceClaimActions
+                    .Include(csrc => csrc.Action)
+                    .Include(csrc => csrc.ClaimSet)
+                    .Include(csrc => csrc.ResourceClaim)
+                    .Include(csrc => csrc.AuthorizationStrategyOverrides)
+                    .Where(csrc => csrc.ResourceClaim.Application.ApplicationId.Equals(application.ApplicationId))
+                    .ToList();
 
-                var resourceClaimAuthorizationMetadata =
-                    context.ResourceClaimAuthorizationMetadatas.Include(rcas => rcas.Action)
-                           .Include(rcas => rcas.AuthorizationStrategy)
-                           .Include(rcas => rcas.ResourceClaim)
-                           .Where(rcas => rcas.ResourceClaim.Application.ApplicationId.Equals(application.ApplicationId))
-                           .ToList();
+                var resourceClaimAuthorizationMetadata = context.ResourceClaimActions
+                    .Include(rca => rca.Action)
+                    .Include(rca => rca.AuthorizationStrategies)
+                    .Include(rca => rca.ResourceClaim)
+                    .Where(rca => rca.ResourceClaim.Application.ApplicationId.Equals(application.ApplicationId))
+                    .ToList();
 
                 var repo = new InstanceSecurityRepositoryCacheObject(
                     application,
@@ -170,7 +174,7 @@ namespace EdFi.Ods.Api.Caching
 
             try
             {
-                return CacheProviderExtensions.TryGetCachedObject(_cacheProvider, lookupKey, out securityRepositoryCacheObject);
+                return _cacheProvider.TryGetCachedObject(lookupKey, out securityRepositoryCacheObject);
             }
             finally
             {

--- a/Application/EdFi.Ods.Api/Constants/ApiVersionConstants.cs
+++ b/Application/EdFi.Ods.Api/Constants/ApiVersionConstants.cs
@@ -27,12 +27,12 @@ namespace EdFi.Ods.Api.Constants
         /// <summary>
         /// Informational version of the ods api.
         /// </summary>
-        public const string InformationalVersion = "5.3";
+        public const string InformationalVersion = "5.4";
 
         /// <summary>
         /// Semantic version of the ods api.
         /// </summary>
-        public const string Version = "5.3";
+        public const string Version = "5.4";
 
         /// <summary>
         /// Suite version of the ods api.

--- a/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
+++ b/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
@@ -21,9 +21,9 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="3.1.1" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.1.1" />
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.3.43" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.3.43" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.2" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.2" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />

--- a/Application/EdFi.Ods.Api/Providers/AuthenticationProvider.cs
+++ b/Application/EdFi.Ods.Api/Providers/AuthenticationProvider.cs
@@ -88,7 +88,8 @@ namespace EdFi.Ods.Api.Providers
                 apiClientDetails.EducationOrganizationIds,
                 apiClientDetails.ClaimSetName,
                 apiClientDetails.NamespacePrefixes,
-                apiClientDetails.Profiles.ToList());
+                apiClientDetails.Profiles.ToList(),
+                apiClientDetails.OwnershipTokenIds.ToList());
 
             var apiKeyContext = new ApiKeyContext(
                 apiClientDetails.ApiKey,

--- a/Application/EdFi.Ods.Api/Security/Authorization/EdFiAuthorizationProvider.cs
+++ b/Application/EdFi.Ods.Api/Security/Authorization/EdFiAuthorizationProvider.cs
@@ -11,6 +11,7 @@ using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using EdFi.Common.Extensions;
+using EdFi.Common.Utils.Extensions;
 using EdFi.Ods.Common;
 using EdFi.Ods.Common.Extensions;
 using EdFi.Ods.Common.Security;
@@ -120,13 +121,8 @@ namespace EdFi.Ods.Api.Security.Authorization
                 }
             }
 
-            await details.AuthorizationStrategy.AuthorizeSingleItemAsync(
-                new[]
-                {
-                    details.RelevantClaim
-                },
-                authorizationContext, 
-                cancellationToken);
+            var tasks = details.AuthorizationStrategies.Select(x => x.AuthorizeSingleItemAsync(new[] { details.RelevantClaim }, authorizationContext, cancellationToken));
+            await Task.WhenAll(tasks);
         }
 
         /// <summary>
@@ -138,7 +134,14 @@ namespace EdFi.Ods.Api.Security.Authorization
         {
             var details = GetAuthorizationDetails(authorizationContext);
 
-            return details.AuthorizationStrategy.GetAuthorizationFilters(new[] {details.RelevantClaim}, authorizationContext);
+            var relevantClaims = new[] { details.RelevantClaim };
+
+            var authorizationFilters = details.AuthorizationStrategies
+                .Distinct()
+                .SelectMany(x => x.GetAuthorizationFilters(relevantClaims, authorizationContext))
+                .ToArray();
+
+            return authorizationFilters;
         }
 
         /// <summary>
@@ -271,18 +274,17 @@ namespace EdFi.Ods.Api.Security.Authorization
             var relevantPrincipalClaim = relevantPrincipalClaims.First();
 
             // Look for an authorization strategy override on the caller's claims (flow the overrides down, even if they aren't the first claim encountered going up the hierarchy)
-            string authorizationStrategyOverrideName =
-                (from rpc in relevantPrincipalClaims
-                 select rpc.ToEdFiResourceClaimValue()
-                           .GetAuthorizationStrategyNameOverride(claimCheckResponse.RequestedAction))
-               .FirstOrDefault(x => !string.IsNullOrWhiteSpace(x));
+            var authorizationStrategyOverrideNames = relevantPrincipalClaims
+                    .Select(rpc => rpc.ToEdFiResourceClaimValue()
+                    .GetAuthorizationStrategyNameOverrides(claimCheckResponse.RequestedAction))
+                    .FirstOrDefault(x => x != null);
 
-            string metadataAuthorizationStrategyName =
-                claimCheckResponse.AuthorizationMetadata
-                                  .SkipWhile(s => string.IsNullOrWhiteSpace(s.AuthorizationStrategy))
-                                  .Select(s => s.AuthorizationStrategy)
-                                  .FirstOrDefault();
-
+            var metadataAuthorizationStrategyNames =
+                 claimCheckResponse.AuthorizationMetadata
+                                     .Where(s => s.AuthorizationStrategies != null && s.AuthorizationStrategies.Any())
+                                     .Select(s => s.AuthorizationStrategies )
+                                     .FirstOrDefault();
+            
             // TODO: GKM - When claimset-specific override support is added, use this logic
             //string claimSpecificOverrideAuthorizationStrategyName =
             //    resourceClaimAuthorizationStrategies
@@ -292,19 +294,16 @@ namespace EdFi.Ods.Api.Security.Authorization
             //        .FirstOrDefault();
 
             // Use the claim's override, if present
-            //string authorizationStrategyName = 
-            //    claimSpecificAuthorizationStrategyName ?? metadataAuthorizationStrategyName;
+            var authorizationStrategyNames =
+              authorizationStrategyOverrideNames
+              ?? metadataAuthorizationStrategyNames;
 
-            string authorizationStrategyName =
-                authorizationStrategyOverrideName
-                ?? metadataAuthorizationStrategyName;
-
-            // Make sure an authorization strategy is defined for this request
-            if (string.IsNullOrWhiteSpace(authorizationStrategyName))
+            // No authorization strategies were defined for this request
+            if (authorizationStrategyNames == null || !authorizationStrategyNames.Any())
             {
                 throw new Exception(
                     string.Format(
-                        "No authorization strategy was defined for the requested action '{0}' against resource URIs ['{1}'] matched by the caller's claim '{2}'.",
+                        "No authorization strategies were defined for the requested action '{0}' against resource URIs ['{1}'] matched by the caller's claim '{2}'.",
                         claimCheckResponse.RequestedAction,
                         string.Join("', '", claimCheckResponse.RequestedResourceUris),
                         relevantPrincipalClaim.Type));
@@ -312,7 +311,7 @@ namespace EdFi.Ods.Api.Security.Authorization
 
             _logger.DebugFormat(
                 "Authorization strategy '{0}' selected for request against resource '{1}'.",
-                authorizationStrategyName,
+                string.Join("', '", authorizationStrategyNames),
                 authorizationContext.Resource.First()
                                     .Value);
 
@@ -334,7 +333,7 @@ namespace EdFi.Ods.Api.Security.Authorization
 
             // Set outbound authorization details
             return new AuthorizationDetails(
-                GetAuthorizationStrategy(authorizationStrategyName),
+                GetAuthorizationStrategies(authorizationStrategyNames),
                 relevantPrincipalClaim,
                 ruleSetName);
         }
@@ -386,7 +385,7 @@ namespace EdFi.Ods.Api.Security.Authorization
                     .FirstOrDefault(x => x.Any());
 
             // Return the authorization metadata located, or an empty list.
-            return resourceClaimAuthorizationMetadata 
+            return resourceClaimAuthorizationMetadata
                 ?? new List<ResourceClaimAuthorizationMetadata>();
         }
 
@@ -415,7 +414,7 @@ namespace EdFi.Ods.Api.Security.Authorization
                 string apiClientClaimSetName =
                     principal.Claims.SingleOrDefault(c => c.Type == EdFiOdsApiClaimTypes.ClaimSetName)?.Value;
 
-                response.SecurityExceptionMessage = 
+                response.SecurityExceptionMessage =
                     $@"Access to the resource could not be authorized. Are you missing a claim? This resource can be authorized by the following claims:
     {string.Join(Environment.NewLine + "    ", authorizingClaimNames)}
 The API client has been assigned the '{apiClientClaimSetName}' claim set with the following resource claims:
@@ -427,9 +426,10 @@ The API client has been assigned the '{apiClientClaimSetName}' claim set with th
             // 2) Second check: Of the claims that apply for this resource do we have any that match the action requested or a higher action?
             var edfiClaimValuesToEvaluate = principalClaimsToEvaluate.Select(
                 x => new
-                     {
-                         Claim = x, EdFiResourceClaimValue = x.ToEdFiResourceClaimValue()
-                     });
+                {
+                    Claim = x,
+                    EdFiResourceClaimValue = x.ToEdFiResourceClaimValue()
+                });
 
             var claimsWithMatchingActions = edfiClaimValuesToEvaluate.Where(
                                                                           x => IsRequestedActionSatisfiedByClaimActions(
@@ -477,17 +477,22 @@ The API client has been assigned the '{apiClientClaimSetName}' claim set with th
             throw new NotSupportedException("The requested action is not a supported action.  Authorization cannot be performed.");
         }
 
-        private IEdFiAuthorizationStrategy GetAuthorizationStrategy(string strategyName)
+        private IReadOnlyList<IEdFiAuthorizationStrategy> GetAuthorizationStrategies(IReadOnlyList<string> strategyNames)
         {
-            if (!_authorizationStrategyByName.ContainsKey(strategyName))
-            {
-                throw new Exception(
-                    string.Format(
-                        "Could not find authorization implementation for strategy '{0}' based on naming convention of '{{strategyName}}AuthorizationStrategy'.",
-                        strategyName));
-            }
+            return strategyNames.Select(
+                    strategyName =>
+                    {
+                        if (!_authorizationStrategyByName.ContainsKey(strategyName))
+                        {
+                            throw new Exception(
+                                string.Format(
+                                    "Could not find authorization implementation for strategy '{0}' based on naming convention of '{{strategyName}}AuthorizationStrategy'.",
+                                    strategyName));
+                        }
 
-            return _authorizationStrategyByName[strategyName];
+                        return _authorizationStrategyByName[strategyName];
+                    })
+                .ToArray();
         }
 
         private class AuthorizationDetails
@@ -495,14 +500,14 @@ The API client has been assigned the '{apiClientClaimSetName}' claim set with th
             /// <summary>
             /// Initializes a new instance of the <see cref="AuthorizationDetails"/> class.
             /// </summary>
-            public AuthorizationDetails(IEdFiAuthorizationStrategy authorizationStrategy, Claim relevantClaim, string validationRuleSetName)
+            public AuthorizationDetails(IReadOnlyList<IEdFiAuthorizationStrategy> authorizationStrategies, Claim relevantClaim, string validationRuleSetName)
             {
-                AuthorizationStrategy = authorizationStrategy;
+                AuthorizationStrategies = authorizationStrategies;
                 RelevantClaim = relevantClaim;
                 ValidationRuleSetName = validationRuleSetName;
             }
 
-            public IEdFiAuthorizationStrategy AuthorizationStrategy { get; }
+            public IReadOnlyList<IEdFiAuthorizationStrategy> AuthorizationStrategies { get; }
 
             public Claim RelevantClaim { get; }
 

--- a/Application/EdFi.Ods.Api/Security/Authorization/Repositories/AggregateRootCriteriaProviderDecoratorBase.cs
+++ b/Application/EdFi.Ods.Api/Security/Authorization/Repositories/AggregateRootCriteriaProviderDecoratorBase.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+﻿// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.

--- a/Application/EdFi.Ods.Api/Security/AuthorizationStrategies/OwnershipBased/OwnershipBasedAuthorizationContextData.cs
+++ b/Application/EdFi.Ods.Api/Security/AuthorizationStrategies/OwnershipBased/OwnershipBasedAuthorizationContextData.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EdFi.Ods.Api.Security.AuthorizationStrategies.OwnershipBased
+{
+    public class OwnershipBasedAuthorizationContextData
+    {
+        public short? CreatedByOwnershipTokenId { get; set; }
+    }
+}

--- a/Application/EdFi.Ods.Api/Security/AuthorizationStrategies/OwnershipBased/OwnershipBasedAuthorizationStrategy.cs
+++ b/Application/EdFi.Ods.Api/Security/AuthorizationStrategies/OwnershipBased/OwnershipBasedAuthorizationStrategy.cs
@@ -1,0 +1,84 @@
+﻿using EdFi.Ods.Common.Security;
+using EdFi.Ods.Common.Security.Authorization;
+using EdFi.Ods.Common.Security.Claims;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EdFi.Ods.Api.Security.AuthorizationStrategies.OwnershipBased
+{
+    public class OwnershipBasedAuthorizationStrategy : IEdFiAuthorizationStrategy
+    {
+        private readonly AuthorizationContextDataFactory _authorizationContextDataFactory
+            = new AuthorizationContextDataFactory();
+
+        public Task AuthorizeSingleItemAsync(
+            IEnumerable<Claim> relevantClaims,
+            EdFiAuthorizationContext authorizationContext,
+            CancellationToken cancellationToken)
+        {
+            
+            var contextData = _authorizationContextDataFactory
+               .CreateContextData<OwnershipBasedAuthorizationContextData>(
+                    authorizationContext.Data);
+
+            if (contextData == null)
+            {               
+                throw new NotSupportedException(
+                    "No 'OwnershipTokenId' property could be found on the resource's underlying entity in order to perform authorization. Should a different authorization strategy be used?");
+            }
+
+            if (contextData.CreatedByOwnershipTokenId != null)
+            {
+                var hasOwnershipToken = authorizationContext.Principal.Claims
+                    .Any(c => 
+                        c.Type == EdFiOdsApiClaimTypes.OwnershipTokenId 
+                        && c.Value == contextData.CreatedByOwnershipTokenId.ToString());
+
+                if (!hasOwnershipToken)
+                {
+                    throw new EdFiSecurityException(
+                        "Access to the resource item could not be authorized using any of the caller's ownership tokens.");
+                }
+            }
+            else
+            {
+                throw new EdFiSecurityException(
+                    "Access to the resource item could not be authorized based on the caller's ownership token because the resource item has no owner.");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Applies filtering to a multiple-item request.
+        /// </summary>
+        /// <param name="relevantClaims">The subset of the caller's claims that are relevant for the authorization decision.</param>
+        /// <param name="authorizationContext">The authorization context.</param>
+        /// <returns>The collection of authorization filters to be applied to the query.</returns>
+        public IReadOnlyList<AuthorizationFilterDetails> GetAuthorizationFilters(
+            IEnumerable<Claim> relevantClaims,
+            EdFiAuthorizationContext authorizationContext)
+        {
+            var tokens = authorizationContext.Principal.Claims
+                .Where(c => c.Type == EdFiOdsApiClaimTypes.OwnershipTokenId)
+                .Select(x => (object) x.Value)
+                .ToArray();
+
+            return new[]
+            {
+                new AuthorizationFilterDetails
+                {
+                   FilterName ="CreatedByOwnershipTokenId",
+                   SubjectEndpointName ="CreatedByOwnershipTokenId",
+                   ClaimEndpointName ="CreatedByOwnershipTokenId",
+                   ClaimValues = tokens
+                }
+            };
+        }        
+    }
+}

--- a/Application/EdFi.Ods.Api/Security/AuthorizationStrategies/OwnershipBased/OwnershipBasedAuthorizationStrategyFilterConfigurator.cs
+++ b/Application/EdFi.Ods.Api/Security/AuthorizationStrategies/OwnershipBased/OwnershipBasedAuthorizationStrategyFilterConfigurator.cs
@@ -1,0 +1,33 @@
+﻿using EdFi.Ods.Api.Security.AuthorizationStrategies.NHibernateConfiguration;
+using EdFi.Ods.Api.Security.AuthorizationStrategies.Relationships.Filters;
+using EdFi.Ods.Common.Infrastructure.Filtering;
+using EdFi.Ods.Common.Specifications;
+using System.Collections.Generic;
+
+namespace EdFi.Ods.Api.Security.AuthorizationStrategies.OwnershipBased
+{
+    public class OwnershipBasedAuthorizationStrategyFilterConfigurator : INHibernateFilterConfigurator
+    {
+        /// <summary>
+        /// Gets the authorization strategy's NHibernate filter definitions and a functional delegate for determining when to apply them. 
+        /// </summary>
+        /// <returns>A read-only list of filter application details to be applied to the NHibernate configuration and mappings.</returns>
+        public IReadOnlyList<FilterApplicationDetails> GetFilters()
+        {
+            var filters = new List<FilterApplicationDetails>
+            {
+                new FilterApplicationDetails(
+                    "CreatedByOwnershipTokenId",
+                    @"(CreatedByOwnershipTokenId IS NOT NULL AND CreatedByOwnershipTokenId IN (:CreatedByOwnershipTokenId))",
+                    @"({currentAlias}.CreatedByOwnershipTokenId IS NOT NULL AND {currentAlias}.CreatedByOwnershipTokenId IN (:CreatedByOwnershipTokenId))",
+                    (c, w, p, jt) =>
+                    {
+                        w.ApplyPropertyFilters(p,"CreatedByOwnershipTokenId");
+                    },
+                    (t, p) => !DescriptorEntitySpecification.IsEdFiDescriptorEntity(t) && p.HasPropertyNamed("CreatedByOwnershipTokenId")),
+            }.AsReadOnly();
+
+            return filters;
+        }
+    }
+}

--- a/Application/EdFi.Ods.Api/Security/AuthorizationStrategies/ResourceAuthorizationMetadataProvider.cs
+++ b/Application/EdFi.Ods.Api/Security/AuthorizationStrategies/ResourceAuthorizationMetadataProvider.cs
@@ -77,11 +77,11 @@ namespace EdFi.Ods.Api.Security.AuthorizationStrategies
                 select new ResourceClaimAuthorizationMetadata
                 {
                     ClaimName = c,
-                    AuthorizationStrategy =
+                    AuthorizationStrategies =
                         resourceClaimLineageWithMetadata
                             .Where(x => c.EqualsIgnoreCase(x.ResourceClaim.ClaimName))
-                            .Select(x => x.AuthorizationStrategy.AuthorizationStrategyName)
-                            .SingleOrDefault()
+                            .SelectMany(x => x.AuthorizationStrategies.Select(y => y.AuthorizationStrategy.AuthorizationStrategyName))
+                            .ToArray()
                 };
 
             return resourceClaimsLineage;

--- a/Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj
+++ b/Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj
@@ -16,7 +16,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Application/EdFi.Ods.Common/Security/Claims/EdFiResourceClaimValue.cs
+++ b/Application/EdFi.Ods.Common/Security/Claims/EdFiResourceClaimValue.cs
@@ -33,15 +33,15 @@ namespace EdFi.Ods.Common.Security.Claims
         /// Initializes a new instance of the <see cref="EdFiResourceClaimValue"/> class using the specified action and authorization strategy name override.
         /// </summary>
         /// <param name="action">The action URI representing the action that the claim is authorized to perform on the resource.</param>
-        /// <param name="authorizationStrategyNameOverride">The name of the authorization strategy that should be used for authorization (in lieu of the default for the resource).</param>
-        public EdFiResourceClaimValue(string action, string authorizationStrategyNameOverride)
-            : this(action, null, authorizationStrategyNameOverride) { }
+        /// <param name="authorizationStrategyNameOverrides">The names of the authorization strategies that should be used for authorization (in lieu of the default for the resource).</param>
+        public EdFiResourceClaimValue(string action, IReadOnlyList<string> authorizationStrategyNameOverrides)
+            : this(action, null, authorizationStrategyNameOverrides) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EdFiResourceClaimValue"/> class using the specified action and Education Organization ids.
         /// </summary>
         /// <param name="action">The action URI representing the action that the claim is authorized to perform on the resource.</param>
-        /// <param name="educationOrganizationIds">The Local Education Agency Ids to which the claim applies.</param>
+        /// <param name="educationOrganizationIds">The education organization ids to which the claim applies.</param>
         public EdFiResourceClaimValue(string action, List<int> educationOrganizationIds)
             : this(
                 action,
@@ -53,13 +53,13 @@ namespace EdFi.Ods.Common.Security.Claims
         /// Initializes a new instance of the <see cref="EdFiResourceClaimValue"/> class using the specified action, Education Organization ids, and authorization strategy name override.
         /// </summary>
         /// <param name="action">The action URI representing the action that the claim is authorized to perform on the resource.</param>
-        /// <param name="educationOrganizationIds">The Local Education Agency Ids to which the claim applies.</param>
-        /// <param name="authorizationStrategyNameOverride">The name of the authorization strategy that should be used for authorization (in lieu of the default for the resource).</param>
-        public EdFiResourceClaimValue(string action, List<int> educationOrganizationIds, string authorizationStrategyNameOverride)
+        /// <param name="educationOrganizationIds">The education organization ids to which the claim applies.</param>
+        /// <param name="authorizationStrategyNameOverrides">The names of the authorization strategies that should be used for authorization (in lieu of the default for the resource).</param>
+        public EdFiResourceClaimValue(string action, List<int> educationOrganizationIds, IReadOnlyList<string> authorizationStrategyNameOverrides)
         {
             Actions = new[]
                       {
-                          new ResourceAction(action, authorizationStrategyNameOverride)
+                          new ResourceAction(action, authorizationStrategyNameOverrides)
                       };
 
             EducationOrganizationIds = educationOrganizationIds;
@@ -69,18 +69,18 @@ namespace EdFi.Ods.Common.Security.Claims
         /// Initializes a new instance of the <see cref="EdFiResourceClaimValue"/> class using the specified action, Education Organization ids, and authorization strategy and validation rule set name overrides.
         /// </summary>
         /// <param name="action">The action URI representing the action that the claim is authorized to perform on the resource.</param>
-        /// <param name="educationOrganizationIds">The Local Education Agency Ids to which the claim applies.</param>
-        /// <param name="authorizationStrategyNameOverride">The name of the authorization strategy that should be used for authorization (in lieu of any default defined for the resource).</param>
+        /// <param name="educationOrganizationIds">The education organization ids to which the claim applies.</param>
+        /// <param name="authorizationStrategyNameOverrides">The names of the authorization strategies that should be used for authorization (in lieu of any default defined for the resource).</param>
         /// <param name="validationRuleSetNameOverride">The name of the validation rule set to be executed during authorization (in lieu of any default defined for the resource).</param>
         public EdFiResourceClaimValue(
             string action,
             List<int> educationOrganizationIds,
-            string authorizationStrategyNameOverride,
+            IReadOnlyList<string> authorizationStrategyNameOverrides,
             string validationRuleSetNameOverride)
         {
             Actions = new[]
                       {
-                          new ResourceAction(action, authorizationStrategyNameOverride, validationRuleSetNameOverride)
+                          new ResourceAction(action, authorizationStrategyNameOverrides, validationRuleSetNameOverride)
                       };
 
             EducationOrganizationIds = educationOrganizationIds;
@@ -97,33 +97,32 @@ namespace EdFi.Ods.Common.Security.Claims
         public List<int> EducationOrganizationIds { get; set; }
 
         /// <summary>
-        /// Attempts to obtain an authorization strategy override for the specified action.
+        /// Attempts to obtain the names of the authorization strategy overrides for the specified action.
         /// </summary>
         /// <param name="action">The action URI representing the action that the claim is authorized to perform on the resource.</param>
-        /// <param name="authorizationStrategyNameOverride">If found, will contain the name of the authorization strategy that should be used for authorization (in lieu of the default for the resource).</param>
-        /// <returns><b>true</b> if the specified action had an authorization strategy override; otherwise <b>false</b>.</returns>
-        public bool TryGetAuthorizationStrategyOverride(string action, out string authorizationStrategyNameOverride)
+        /// <param name="authorizationStrategyNameOverrides">If found, will contain the names of the authorization strategies that should be used for authorization (in lieu of the default for the resource).</param>
+        /// <returns><b>true</b> if the specified action had authorization strategy overrides; otherwise <b>false</b>.</returns>
+        public bool TryGetAuthorizationStrategyOverride(string action, out IReadOnlyList<string> authorizationStrategyNameOverrides)
         {
-            authorizationStrategyNameOverride = GetAuthorizationStrategyNameOverride(action);
+            authorizationStrategyNameOverrides = GetAuthorizationStrategyNameOverrides(action);
 
-            return !string.IsNullOrEmpty(authorizationStrategyNameOverride);
+            return authorizationStrategyNameOverrides != null;
         }
 
         /// <summary>
-        /// Gets the name of authorization strategy override for the specified action, if present.
+        /// Gets the names of authorization strategy overrides for the specified action, if present.
         /// </summary>
         /// <param name="action">The action URI representing the action that the claim is authorized to perform on the resource.</param>
         /// <returns>The authorization strategy override for the specified action; otherwise <b>null</b>.</returns>
-        public string GetAuthorizationStrategyNameOverride(string action)
+        public IReadOnlyList<string> GetAuthorizationStrategyNameOverrides(string action)
         {
             return
-                Actions.Where(x => x.Name == action)
-                       .Select(x => x.AuthorizationStrategyNameOverride)
-                       .FirstOrDefault();
+                Actions.FirstOrDefault(x => x.Name == action)
+                       ?.AuthorizationStrategyNameOverrides;
         }
 
         /// <summary>
-        /// Gets the name of authorization strategy override for the specified action, if present.
+        /// Gets the names of the authorization strategy overrides for the specified action, if present.
         /// </summary>
         /// <param name="action">The action URI representing the action that the claim is authorized to perform on the resource.</param>
         /// <returns>The authorization validation rule set name override for the specified action; otherwise <b>null</b>.</returns>
@@ -154,23 +153,23 @@ namespace EdFi.Ods.Common.Security.Claims
             : this(name, null) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ResourceAction"/> class using the specified action and authorization strategy name override.
+        /// Initializes a new instance of the <see cref="ResourceAction"/> class using the specified action and authorization strategy name overrides.
         /// </summary>
         /// <param name="name">The name (URI) of the action.</param>
-        /// <param name="authorizationStrategyNameOverride">The name of the authorization strategy that should be used for authorization (in lieu of the default for the resource).</param>
-        public ResourceAction(string name, string authorizationStrategyNameOverride)
-            : this(name, authorizationStrategyNameOverride, null) { }
+        /// <param name="authorizationStrategyNameOverrides">The names of the authorization strategies that should be used for authorization (in lieu of the default for the resource).</param>
+        public ResourceAction(string name, IReadOnlyList<string> authorizationStrategyNameOverrides)
+            : this(name, authorizationStrategyNameOverrides, null) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ResourceAction"/> class using the specified action and overrides for authorization strategy name and validation rule set name.
+        /// Initializes a new instance of the <see cref="ResourceAction"/> class using the specified action and overrides for authorization strategy names and and validation rule set name.
         /// </summary>
         /// <param name="name">The name (URI) of the action.</param>
-        /// <param name="authorizationStrategyNameOverride">The name of the authorization strategy that should be used for authorization (in lieu of the default for the resource).</param>
+        /// <param name="authorizationStrategyNameOverrides">The names of the authorization strategies that should be used for authorization (in lieu of the default for the resource).</param>
         /// <param name="validationRuleSetNameOverride">The name of the rule set to be executed.</param>
-        public ResourceAction(string name, string authorizationStrategyNameOverride, string validationRuleSetNameOverride)
+        public ResourceAction(string name, IReadOnlyList<string> authorizationStrategyNameOverrides, string validationRuleSetNameOverride)
         {
             Name = name;
-            AuthorizationStrategyNameOverride = authorizationStrategyNameOverride;
+            AuthorizationStrategyNameOverrides = authorizationStrategyNameOverrides;
             ValidationRuleSetNameOverride = validationRuleSetNameOverride;
         }
 
@@ -180,9 +179,9 @@ namespace EdFi.Ods.Common.Security.Claims
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets the name of the authorization strategy that should be used for authorization (in lieu of the default for the resource).
+        /// Gets or sets the names of the authorization strategies that should be used for authorization (in lieu of the default for the resource).
         /// </summary>
-        public string AuthorizationStrategyNameOverride { get; set; }
+        public IReadOnlyList<string> AuthorizationStrategyNameOverrides { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the rule set that should be used to validate the entity for the action.

--- a/Application/EdFi.Ods.Common/Security/Claims/IClaimsIdentityProvider.cs
+++ b/Application/EdFi.Ods.Common/Security/Claims/IClaimsIdentityProvider.cs
@@ -31,7 +31,8 @@ namespace EdFi.Ods.Common.Security.Claims
             IEnumerable<int> localEducationAgencyIds,
             string claimSetName,
             IEnumerable<string> vendorNamespacePrefixes,
-            IReadOnlyList<string> assignedProfileNames);
+            IReadOnlyList<string> assignedProfileNames,
+            IReadOnlyList<short?> ownershipTokenIds);
     }
 
     /// <summary>

--- a/Application/EdFi.Ods.Common/Security/Claims/IResourceAuthorizationMetadataProvider.cs
+++ b/Application/EdFi.Ods.Common/Security/Claims/IResourceAuthorizationMetadataProvider.cs
@@ -34,9 +34,9 @@ namespace EdFi.Ods.Common.Security.Claims
         public string ClaimName { get; set; }
 
         /// <summary>
-        /// The name of the strategy to be used in the authorization decision.
+        /// The names of the strategies to be used in the authorization decision.
         /// </summary>
-        public string AuthorizationStrategy { get; set; }
+        public IReadOnlyList<string> AuthorizationStrategies { get; set; }
 
         /// <summary>
         /// The name of the validation rule set to be executed during authorization of data modifying operations.

--- a/Application/EdFi.Ods.Common/Security/EdFiOdsApiClaimTypes.cs
+++ b/Application/EdFi.Ods.Common/Security/EdFiOdsApiClaimTypes.cs
@@ -24,5 +24,10 @@ namespace EdFi.Ods.Common.Security
         /// The name of the claim set assigned to the Ed-Fi ODS API client.
         /// </summary>
         public const string ClaimSetName = @"http://ed-fi.org/claims/claimSetName";
+
+        /// <summary>
+        /// An ownership token assigned to the Ed-Fi ODS API client.
+        /// </summary>
+        public const string OwnershipTokenId = @"http://ed-fi.org/claims/ownershipTokenId";
     }
 }

--- a/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
+++ b/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
@@ -17,9 +17,9 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
     <PackageReference Include="Autofac" Version="6.3.0" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.3.43" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.2" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />

--- a/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
+++ b/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
@@ -13,8 +13,8 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.3.43" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.2" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="Dapper" Version="2.0.123" />

--- a/Application/EdFi.Ods.Standard/Artifacts/MsSql/Structure/Ods/1330-UpdateVersionTo54.sql
+++ b/Application/EdFi.Ods.Standard/Artifacts/MsSql/Structure/Ods/1330-UpdateVersionTo54.sql
@@ -1,0 +1,18 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+IF object_id('util.GetEdFiOdsVersion', 'FN') IS NOT NULL
+BEGIN
+    DROP FUNCTION util.GetEdFiOdsVersion;
+END
+GO
+
+CREATE FUNCTION util.GetEdFiOdsVersion()
+RETURNS VARCHAR(60)
+AS
+BEGIN
+    RETURN '5.4'
+END
+GO

--- a/Application/EdFi.Ods.Standard/Artifacts/PgSql/Structure/Ods/1330-UpdateVersionTo54.sql
+++ b/Application/EdFi.Ods.Standard/Artifacts/PgSql/Structure/Ods/1330-UpdateVersionTo54.sql
@@ -1,0 +1,11 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+CREATE OR REPLACE FUNCTION util.GetEdFiOdsVersion()
+RETURNS VARCHAR(60) AS $$
+BEGIN	
+   RETURN '5.4';
+END;
+$$ LANGUAGE plpgsql;

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/StubSecurityContext.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/StubSecurityContext.cs
@@ -27,9 +27,9 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
             securityContext.Actions = GetFakeDbSet<Action>().SetupData();
             securityContext.AuthorizationStrategies = GetFakeDbSet<AuthorizationStrategy>().SetupData();
             securityContext.ClaimSets = GetFakeDbSet<ClaimSet>().SetupData();
-            securityContext.ClaimSetResourceClaims = GetFakeDbSet<ClaimSetResourceClaim>().SetupData();
+            securityContext.ClaimSetResourceClaimActions = GetFakeDbSet<ClaimSetResourceClaimAction>().SetupData();
             securityContext.ResourceClaims = GetFakeDbSet<ResourceClaim>().SetupData();
-            securityContext.ResourceClaimAuthorizationMetadatas = GetFakeDbSet<ResourceClaimAuthorizationMetadata>().SetupData();
+            securityContext.ResourceClaimActions = GetFakeDbSet<ResourceClaimAction>().SetupData();
 
             return securityContext;
         }

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Security/Authorization/EdFiAuthorizationProviderTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Security/Authorization/EdFiAuthorizationProviderTests.cs
@@ -42,9 +42,9 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
                 // Create provider with stubs
                 var provider = new EdFiAuthorizationProvider(
                     Stub<IResourceAuthorizationMetadataProvider>(),
-                    new IEdFiAuthorizationStrategy[0],
+                    Array.Empty<IEdFiAuthorizationStrategy>(),
                     Stub<ISecurityRepository>(),
-                    new IExplicitObjectValidator[0]);
+                    Array.Empty<IExplicitObjectValidator>());
 
                 provider.AuthorizeSingleItemAsync(null, CancellationToken.None)
                     .WaitSafely();
@@ -64,9 +64,9 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
                 // Execute code under test
                 var provider = new EdFiAuthorizationProvider(
                     Stub<IResourceAuthorizationMetadataProvider>(),
-                    new IEdFiAuthorizationStrategy[0],
+                    Array.Empty<IEdFiAuthorizationStrategy>(),
                     Stub<ISecurityRepository>(),
-                    new IExplicitObjectValidator[0]);
+                    Array.Empty<IExplicitObjectValidator>());
 
                 provider.AuthorizeSingleItemAsync(
                         new EdFiAuthorizationContext(
@@ -93,9 +93,9 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
                 // Execute code under test
                 var provider = new EdFiAuthorizationProvider(
                     Stub<IResourceAuthorizationMetadataProvider>(),
-                    new IEdFiAuthorizationStrategy[0],
+                    Array.Empty<IEdFiAuthorizationStrategy>(),
                     Stub<ISecurityRepository>(),
-                    new IExplicitObjectValidator[0]);
+                    Array.Empty<IExplicitObjectValidator>());
 
                 provider.AuthorizeSingleItemAsync(
                         new EdFiAuthorizationContext(
@@ -122,9 +122,9 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
                 // Execute code under test
                 var provider = new EdFiAuthorizationProvider(
                     Stub<IResourceAuthorizationMetadataProvider>(),
-                    new IEdFiAuthorizationStrategy[0],
+                    Array.Empty<IEdFiAuthorizationStrategy>(),
                     Stub<ISecurityRepository>(),
-                    new IExplicitObjectValidator[0]);
+                    Array.Empty<IExplicitObjectValidator>());
 
                 provider.AuthorizeSingleItemAsync(
                         new EdFiAuthorizationContext(
@@ -151,9 +151,9 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
                 // Execute code under test
                 var provider = new EdFiAuthorizationProvider(
                     Stub<IResourceAuthorizationMetadataProvider>(),
-                    new IEdFiAuthorizationStrategy[0],
+                    Array.Empty<IEdFiAuthorizationStrategy>(),
                     Stub<ISecurityRepository>(),
-                    new IExplicitObjectValidator[0]);
+                    Array.Empty<IExplicitObjectValidator>());
 
                 provider.AuthorizeSingleItemAsync(
                         new EdFiAuthorizationContext(
@@ -180,9 +180,9 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
                 // Execute code under test
                 var provider = new EdFiAuthorizationProvider(
                     Stub<IResourceAuthorizationMetadataProvider>(),
-                    new IEdFiAuthorizationStrategy[0],
+                    Array.Empty<IEdFiAuthorizationStrategy>(),
                     Stub<ISecurityRepository>(),
-                    new IExplicitObjectValidator[0]);
+                    Array.Empty<IExplicitObjectValidator>());
 
                 provider.AuthorizeSingleItemAsync(
                         new EdFiAuthorizationContext(
@@ -256,7 +256,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
                     Stub<IResourceAuthorizationMetadataProvider>(),
                     authorizationStrategies,
                     Stub<ISecurityRepository>(),
-                    new IExplicitObjectValidator[0]);
+                    Array.Empty<IExplicitObjectValidator>());
             }
 
             [Assert]
@@ -281,14 +281,14 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
                     Stub<IResourceAuthorizationMetadataProvider>(),
                     authorizationStrategies,
                     Stub<ISecurityRepository>(),
-                    new IExplicitObjectValidator[0]);
+                    Array.Empty<IExplicitObjectValidator>());
             }
 
             [Assert]
             public void Should_throw_an_ArgumentException_indicating_that_the_authorization_strategy_doesnt_follow_proper_naming_conventions()
             {
                 ActualException.ShouldBeExceptionType<ArgumentException>();
-                ActualException.Message.ShouldContain(typeof(AuthorizationStrategyNotFollowingConventions).Name);
+                ActualException.Message.ShouldContain(nameof(AuthorizationStrategyNotFollowingConventions));
             }
         }
     }
@@ -314,17 +314,18 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
             {
                 FilteringWasCalled = true;
 
-                return new AuthorizationFilterDetails[0];
+                return Array.Empty<AuthorizationFilterDetails>();
             }
         }
 
-        public class FirstAuthorizationStrategy : AuthorizationStrategyBase { }
-
         public class SecondAuthorizationStrategy : AuthorizationStrategyBase { }
+        public class AnotherSecondAuthorizationStrategy : AuthorizationStrategyBase { }
 
         public class FourthAuthorizationStrategy : AuthorizationStrategyBase { }
+        public class AnotherFourthAuthorizationStrategy : AuthorizationStrategyBase { }
 
         public class OverrideAuthorizationStrategy : AuthorizationStrategyBase { }
+        public class AnotherOverrideAuthorizationStrategy : AuthorizationStrategyBase { }
 
         public abstract class When_authorizing_a_request : TestFixtureBase
         {
@@ -337,8 +338,13 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
             protected const string ReadActionUri = @"http://ACTIONS/read";
 
             protected readonly SecondAuthorizationStrategy SecondAuthorizationStrategy = new SecondAuthorizationStrategy();
+            protected readonly AnotherSecondAuthorizationStrategy AnotherSecondAuthorizationStrategy = new AnotherSecondAuthorizationStrategy();
+            
             protected readonly FourthAuthorizationStrategy FourthAuthorizationStrategy = new FourthAuthorizationStrategy();
+            protected readonly AnotherFourthAuthorizationStrategy AnotherFourthAuthorizationStrategy = new AnotherFourthAuthorizationStrategy();
+
             protected readonly OverrideAuthorizationStrategy OverrideAuthorizationStrategy = new OverrideAuthorizationStrategy();
+            protected readonly AnotherOverrideAuthorizationStrategy AnotherOverrideAuthorizationStrategy = new AnotherOverrideAuthorizationStrategy();
 
             // Define all authorization strategies
             protected IEdFiAuthorizationStrategy[] AuthorizationStrategies;
@@ -350,7 +356,12 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
 
                 AuthorizationStrategies = new IEdFiAuthorizationStrategy[]
                 {
-                    SecondAuthorizationStrategy, FourthAuthorizationStrategy, OverrideAuthorizationStrategy
+                    SecondAuthorizationStrategy, 
+                    AnotherSecondAuthorizationStrategy, 
+                    FourthAuthorizationStrategy, 
+                    AnotherFourthAuthorizationStrategy, 
+                    OverrideAuthorizationStrategy,
+                    AnotherOverrideAuthorizationStrategy
                 };
             }
 
@@ -399,6 +410,17 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
                             ActionId = 1, ActionName = "Delete", ActionUri = "http://ACTIONS/delete"
                         });
 
+                // NOTE: These mocks create results for a implied resource claim lineage where Resource 1 is the lowest level claim,
+                // and Resource Claim 4 is the highest level claim.
+                //
+                //     Resource4 
+                //         ↑
+                //     Resource3
+                //         ↑
+                //     Resource2
+                //         ↑
+                //     Resource1
+                //
                 A.CallTo(() => securityRepository.GetResourceClaimLineage(Resource1ClaimUri))
                     .Returns(
                         new[]
@@ -439,15 +461,15 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
 
         public abstract class When_authorizing_a_request_affected_by_authorization_strategies : When_authorizing_a_request
         {
-            protected virtual ClaimsPrincipal Given_a_principal_with_a_single_resource_claim_and_an_authorization_strategy_override(
+            protected virtual ClaimsPrincipal Given_a_principal_with_a_single_resource_claim_and_some_authorization_strategy_overrides(
                 string resourceClaimUri,
                 string actionUri,
-                string authorizationStrategyNameOverride)
+                params string[] authorizationStrategyNameOverrides)
             {
                 // Issue Resource claim with action
                 Claim[] claims =
                 {
-                    JsonClaimHelper.CreateClaim(resourceClaimUri, new EdFiResourceClaimValue(actionUri, authorizationStrategyNameOverride))
+                    JsonClaimHelper.CreateClaim(resourceClaimUri, new EdFiResourceClaimValue(actionUri, authorizationStrategyNameOverrides))
                 };
 
                 return
@@ -468,19 +490,19 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
                             {
                                 new ResourceClaimAuthorizationMetadata
                                 {
-                                    ClaimName = Resource1ClaimUri, AuthorizationStrategy = null //"First"
+                                    ClaimName = Resource1ClaimUri, AuthorizationStrategies = null //"First"
                                 },
                                 new ResourceClaimAuthorizationMetadata
                                 {
-                                    ClaimName = Resource2ClaimUri, AuthorizationStrategy = "Second"
+                                    ClaimName = Resource2ClaimUri, AuthorizationStrategies = new [] { "Second", "AnotherSecond" }
                                 },
                                 new ResourceClaimAuthorizationMetadata
                                 {
-                                    ClaimName = Resource3ClaimUri, AuthorizationStrategy = null
+                                    ClaimName = Resource3ClaimUri, AuthorizationStrategies = null
                                 },
                                 new ResourceClaimAuthorizationMetadata
                                 {
-                                    ClaimName = Resource4ClaimUri, AuthorizationStrategy = "Fourth"
+                                    ClaimName = Resource4ClaimUri, AuthorizationStrategies = new [] { "Fourth", "AnotherFourth" }
                                 }
                             }
 
@@ -493,15 +515,15 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
             }
         }
 
-        public class When_authorizing_a_request_for_a_resource_with_an_explicit_authorization_strategy_defined
+        public class When_authorizing_a_request_for_a_resource_with_a_default_authorization_strategy_defined
             : When_authorizing_a_request_affected_by_authorization_strategies
         {
             protected override void Act()
             {
-                // Caller has Read access to Resource 4
+                // Caller has Read access to Resource 4 (the top level claim)
                 var claimsPrincipal = Given_a_principal_with_a_single_resource_claim(Resource4ClaimUri, ReadActionUri);
 
-                // Request is for Read access to Resource 2
+                // Request is for Read access to Resource 2 (lower level claim)
                 var authorizationContext = new EdFiAuthorizationContext(
                     claimsPrincipal,
                     new[] {Resource2ClaimUri},
@@ -510,30 +532,40 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
 
                 // Get the strategy metadata provider, using the authorization context values
                 var authorizationMetadataProvider = CreateResourceAuthorizationMetadataProvider(
-                    authorizationContext.Resource.Single()
-                        .Value,
-                    authorizationContext.Action.Single()
-                        .Value);
+                    authorizationContext.Resource.Single().Value,
+                    authorizationContext.Action.Single().Value);
 
                 var provider = new EdFiAuthorizationProvider(
                     authorizationMetadataProvider,
                     AuthorizationStrategies,
                     SecurityRepository,
-                    new IExplicitObjectValidator[0]);
+                    Array.Empty<IExplicitObjectValidator>());
 
                 provider.AuthorizeSingleItemAsync(authorizationContext, CancellationToken.None).Wait();
             }
 
             [Assert]
-            public void Should_attempt_to_authorize_using_the_authorization_strategy_assigned_to_the_requested_resource_claim()
+            public void Should_attempt_to_authorize_using_the_authorization_strategies_assigned_to_the_requested_resource_claim()
             {
-                SecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue();
+                "".ShouldSatisfyAllConditions(
+                    () => SecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue(),
+                    () => AnotherSecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue());
+            }
+
+            [Assert]
+            public void Should_not_attempt_to_authorize_using_any_default_authorization_strategies_from_higher_up_hierarchy()
+            {
+                "".ShouldSatisfyAllConditions(
+                    () => FourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse(),
+                    () => AnotherFourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse());
             }
 
             [Assert]
             public void Should_not_attempt_to_authorize_using_any_other_authorization_strategies()
             {
-                FourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse();
+                "".ShouldSatisfyAllConditions(
+                    () => OverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse(),
+                    () => AnotherOverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse());
             }
         }
 
@@ -543,12 +575,12 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
         {
             protected override void Act()
             {
-                // Caller has Read access to Resource 4
+                // Caller has Read access to Resource 4 (top level claim), with 2 auth strategies applied as an override
                 var claimsPrincipal =
-                    Given_a_principal_with_a_single_resource_claim_and_an_authorization_strategy_override(
+                    Given_a_principal_with_a_single_resource_claim_and_some_authorization_strategy_overrides(
                         Resource4ClaimUri,
                         ReadActionUri,
-                        "Override");
+                        "Override", "AnotherOverride");
 
                 // Request is for Read access to Resource 2
                 var authorizationContext = new EdFiAuthorizationContext(
@@ -559,31 +591,40 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
 
                 // Get the strategy metadata provider, using the authorization context values
                 var authorizationMetadataProvider = CreateResourceAuthorizationMetadataProvider(
-                    authorizationContext.Resource.Single()
-                        .Value,
-                    authorizationContext.Action.Single()
-                        .Value);
+                    authorizationContext.Resource.Single().Value,
+                    authorizationContext.Action.Single().Value);
 
                 var provider = new EdFiAuthorizationProvider(
                     authorizationMetadataProvider,
                     AuthorizationStrategies,
                     SecurityRepository,
-                    new IExplicitObjectValidator[0]);
+                    Array.Empty<IExplicitObjectValidator>());
 
                 provider.AuthorizeSingleItemAsync(authorizationContext, CancellationToken.None).WaitSafely();
             }
 
             [Assert]
-            public void Should_attempt_to_authorize_using_the_override_authorization_strategy()
+            public void Should_attempt_to_authorize_using_the_override_authorization_strategies()
             {
-                OverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue();
+                "".ShouldSatisfyAllConditions(
+                    () => OverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue(),
+                    () => AnotherOverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue());
+            }
+
+            [Assert]
+            public void Should_not_attempt_to_authorize_using_the_default_authorization_strategies_of_the_requested_resource()
+            {
+                "".ShouldSatisfyAllConditions(
+                    () => SecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse(),
+                    () => AnotherSecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse());
             }
 
             [Assert]
             public void Should_not_attempt_to_authorize_using_any_other_authorization_strategies()
             {
-                SecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse();
-                FourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse();
+                "".ShouldSatisfyAllConditions(
+                    () => FourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse(),
+                    () => AnotherFourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse());
             }
         }
 
@@ -593,21 +634,21 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
         {
             protected override void Act()
             {
-                // Caller has claims for Resources 1 and 3 (out of order)
+                // Caller has claims for Resources 1 and 3 (intentionally supplied out of order)
                 Claim[] claims =
                 {
                     // The "out of order" of these claims is intentional and is testing that the match is
                     // made on the first matching claim based on the authorization metadata hierarchy
                     // rather than the order in which the claims are issued to the caller in the claim set.
-                    // In this case, Resource2 is "lower" in the hierarchy, and should be the one matched first.
+                    // In this test data, Resource2 is "lower" than Resource3 in the hierarchy, and should be the one matched first.
                     JsonClaimHelper.CreateClaim(Resource3ClaimUri, new EdFiResourceClaimValue(ReadActionUri)),
-                    JsonClaimHelper.CreateClaim(Resource1ClaimUri, new EdFiResourceClaimValue(ReadActionUri, "Override"))
+                    JsonClaimHelper.CreateClaim(Resource1ClaimUri, new EdFiResourceClaimValue(ReadActionUri, new [] { "Override", "AnotherOverride" }))
 
                     // This claim is "below" requested resource, so it should be ignored
                     // (NOTE: This will not happen with the current implementation of the API, but has been added for full coverage/definition of expected behavior)
                 };
 
-                // Caller has Read access to Resources 1 and 3
+                // Caller has Read access to Resources 1 and 3 (and has overrides on Resource 3)
                 var claimsPrincipal =
                     new ClaimsPrincipal(
                         new ClaimsIdentity(claims, EdFiAuthenticationTypes.OAuth));
@@ -621,16 +662,14 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
 
                 // Get the strategy metadata provider, using the authorization context values
                 var authorizationMetadataProvider = CreateResourceAuthorizationMetadataProvider(
-                    authorizationContext.Resource.Single()
-                        .Value,
-                    authorizationContext.Action.Single()
-                        .Value);
+                    authorizationContext.Resource.Single().Value,
+                    authorizationContext.Action.Single().Value);
 
                 var provider = new EdFiAuthorizationProvider(
                     authorizationMetadataProvider,
                     AuthorizationStrategies,
                     SecurityRepository,
-                    new IExplicitObjectValidator[0]);
+                    Array.Empty<IExplicitObjectValidator>());
 
                 provider.AuthorizeSingleItemAsync(authorizationContext, CancellationToken.None).WaitSafely();
             }
@@ -639,14 +678,25 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
             public void
                 Should_attempt_to_authorize_using_the_strategy_obtained_from_the_next_lowest_level_resource_claim_with_an_assigned_authorization_strategy()
             {
-                SecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue();
+                "".ShouldSatisfyAllConditions(
+                    () => SecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue(),
+                    () => AnotherSecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue());
+            }
+
+            [Assert]
+            public void Should_not_attempt_to_authorize_using_the_lower_level_resource_overridden_authorization_strategies()
+            {
+                "".ShouldSatisfyAllConditions(
+                    () => OverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse(),
+                    () => AnotherOverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse());
             }
 
             [Assert]
             public void Should_not_attempt_to_authorize_using_any_other_authorization_strategies()
             {
-                OverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse();
-                FourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse();
+                "".ShouldSatisfyAllConditions(
+                    () => FourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse(),
+                    () => AnotherFourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse());
             }
         }
 
@@ -668,16 +718,14 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
 
                 // Get the strategy metadata provider, using the authorization context values
                 var authorizationMetadataProvider = CreateResourceAuthorizationMetadataProvider(
-                    authorizationContext.Resource.Single()
-                        .Value,
-                    authorizationContext.Action.Single()
-                        .Value);
+                    authorizationContext.Resource.Single().Value,
+                    authorizationContext.Action.Single().Value);
 
                 var provider = new EdFiAuthorizationProvider(
                     authorizationMetadataProvider,
                     AuthorizationStrategies,
                     SecurityRepository,
-                    new IExplicitObjectValidator[0]);
+                    Array.Empty<IExplicitObjectValidator>());
 
                 provider.AuthorizeSingleItemAsync(authorizationContext, CancellationToken.None).WaitSafely();
             }
@@ -686,18 +734,30 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
             public void
                 Should_attempt_to_authorize_using_the_strategy_obtained_from_the_next_lowest_level_resource_claim_with_an_assigned_authorization_strategy()
             {
-                SecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue();
+                "".ShouldSatisfyAllConditions(
+                    () => SecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue(),
+                    () => AnotherSecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue());
+            }
+
+            [Assert]
+            public void Should_not_attempt_to_authorize_using_the_top_level_claims_default_authorization_strategies()
+            {
+                "".ShouldSatisfyAllConditions(
+                    () => FourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse(),
+                    () => AnotherFourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse());
             }
 
             [Assert]
             public void Should_not_attempt_to_authorize_using_any_other_authorization_strategies()
             {
-                FourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse();
+                "".ShouldSatisfyAllConditions(
+                    () => OverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse(),
+                    () => AnotherOverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse());
             }
         }
 
         public class
-            When_authorizing_a_request_for_a_resource_without_an_explicit_authorization_strategy_defined_but_with_a_parent_resource_claim_with_one_defined_that_is_ABOVE_the_callers_assigned_claim_in_the_taxonomy
+            When_authorizing_a_request_for_a_resource_without_a_default_authorization_strategy_defined_but_with_a_parent_resource_claim_with_one_defined_that_is_ABOVE_the_callers_assigned_claim_in_the_taxonomy
             : When_authorizing_a_request_affected_by_authorization_strategies
         {
             protected override void Act()
@@ -714,31 +774,35 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
 
                 // Get the strategy metadata provider, using the authorization context values
                 var authorizationMetadataProvider = CreateResourceAuthorizationMetadataProvider(
-                    authorizationContext.Resource.Single()
-                        .Value,
-                    authorizationContext.Action.Single()
-                        .Value);
+                    authorizationContext.Resource.Single().Value,
+                    authorizationContext.Action.Single().Value);
 
                 var provider = new EdFiAuthorizationProvider(
                     authorizationMetadataProvider,
                     AuthorizationStrategies,
                     SecurityRepository,
-                    new IExplicitObjectValidator[0]);
+                    Array.Empty<IExplicitObjectValidator>());
 
                 provider.AuthorizeSingleItemAsync(authorizationContext, CancellationToken.None).WaitSafely();
             }
 
             [Assert]
             public void
-                Should_attempt_to_authorize_using_the_strategy_obtained_from_the_next_lowest_level_resource_claim_with_an_assigned_authorization_strategy()
+                Should_attempt_to_authorize_using_the_strategy_obtained_from_the_next_higher_level_resource_claim_with_an_assigned_authorization_strategy()
             {
-                FourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue();
+                "".ShouldSatisfyAllConditions(
+                    () => FourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue(),
+                    () => AnotherFourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue());
             }
 
             [Assert]
             public void Should_not_attempt_to_authorize_using_any_other_authorization_strategies()
             {
-                SecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse();
+                "".ShouldSatisfyAllConditions(
+                    () => SecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse(),
+                    () => AnotherSecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse(),
+                    () => OverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse(),
+                    () => AnotherOverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse());
             }
         }
 
@@ -748,12 +812,12 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
         {
             protected override void Act()
             {
-                // Caller has Read access to Resource 4
+                // Caller has Read access to Resource 4, with overrides
                 var claimsPrincipal =
-                    Given_a_principal_with_a_single_resource_claim_and_an_authorization_strategy_override(
+                    Given_a_principal_with_a_single_resource_claim_and_some_authorization_strategy_overrides(
                         Resource4ClaimUri,
                         ReadActionUri,
-                        "Override");
+                        "Override", "AnotherOverride");
 
                 // Request is for Read access to Resource 1
                 var authorizationContext = new EdFiAuthorizationContext(
@@ -773,22 +837,33 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
                     authorizationMetadataProvider,
                     AuthorizationStrategies,
                     SecurityRepository,
-                    new IExplicitObjectValidator[0]);
+                    Array.Empty<IExplicitObjectValidator>());
 
                 provider.AuthorizeSingleItemAsync(authorizationContext, CancellationToken.None).WaitSafely();
             }
 
             [Assert]
-            public void Should_attempt_to_authorize_using_the_override_authorization_strategy()
+            public void Should_attempt_to_authorize_using_the_override_authorization_strategies()
             {
-                OverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue();
+                "".ShouldSatisfyAllConditions(
+                    () => OverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue(),
+                    () => AnotherOverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue());
             }
 
             [Assert]
+            public void Should_not_attempt_to_authorize_using_the_default_authorization_strategies_on_an_intermediate_resource()
+            {
+                "".ShouldSatisfyAllConditions(
+                    () => SecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse(),
+                    () => AnotherSecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse());
+            }
+            
+            [Assert]
             public void Should_not_attempt_to_authorize_using_any_other_authorization_strategies()
             {
-                SecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse();
-                FourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse();
+                "".ShouldSatisfyAllConditions(
+                    () => FourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse(),
+                    () => AnotherFourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse());
             }
         }
 
@@ -798,12 +873,12 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
         {
             protected override void Act()
             {
-                // Caller has Read access to Resource 3
+                // Caller has Read access to Resource 3, with overrides
                 var claimsPrincipal =
-                    Given_a_principal_with_a_single_resource_claim_and_an_authorization_strategy_override(
+                    Given_a_principal_with_a_single_resource_claim_and_some_authorization_strategy_overrides(
                         Resource3ClaimUri,
                         ReadActionUri,
-                        "Override");
+                        "Override", "AnotherOverride");
 
                 // Request is for Read access to Resource 3
                 var authorizationContext = new EdFiAuthorizationContext(
@@ -823,26 +898,37 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
                     authorizationMetadataProvider,
                     AuthorizationStrategies,
                     SecurityRepository,
-                    new IExplicitObjectValidator[0]);
+                    Array.Empty<IExplicitObjectValidator>());
 
                 provider.AuthorizeSingleItemAsync(authorizationContext, CancellationToken.None).WaitSafely();
             }
 
             [Assert]
-            public void Should_attempt_to_authorize_using_the_override_authorization_strategy()
+            public void Should_attempt_to_authorize_using_the_override_authorization_strategies()
             {
-                OverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue();
+                "".ShouldSatisfyAllConditions(
+                    () => OverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue(),
+                    () => AnotherOverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue());
             }
 
             [Assert]
+            public void Should_not_attempt_to_authorize_using_the_higher_level_claims_default_authorization_strategies()
+            {
+                "".ShouldSatisfyAllConditions(
+                    () => FourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse(),
+                    () => AnotherFourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse());
+            }
+            
+            [Assert]
             public void Should_not_attempt_to_authorize_using_any_other_authorization_strategies()
             {
-                FourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse();
-                SecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse();
+                "".ShouldSatisfyAllConditions(
+                    () => SecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse(),
+                    () => AnotherSecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse());
             }
         }
 
-        public class When_authorizing_a_request_for_which_the_principal_has_multiple_matching_claims_with_an_authorization_strategy_override_defined
+        public class When_authorizing_a_request_for_which_the_principal_has_multiple_matching_claims
             : When_authorizing_a_request_affected_by_authorization_strategies
         {
             protected override void Act()
@@ -871,10 +957,8 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
 
                 // Get the strategy metadata provider, using the authorization context values
                 var authorizationMetadataProvider = CreateResourceAuthorizationMetadataProvider(
-                    authorizationContext.Resource.Single()
-                        .Value,
-                    authorizationContext.Action.Single()
-                        .Value);
+                    authorizationContext.Resource.Single().Value,
+                    authorizationContext.Action.Single().Value);
 
                 var provider = new EdFiAuthorizationProvider(
                     authorizationMetadataProvider,
@@ -889,8 +973,25 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
             public void
                 Should_resolve_claims_using_authorization_metadata_order_rather_than_callers_claims_order_and_invoke_lowest_matching_claims_authorization_strategy()
             {
-                SecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue();
-                FourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse();
+                "".ShouldSatisfyAllConditions(
+                    () => SecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue(),
+                    () => AnotherSecondAuthorizationStrategy.SingleItemWasCalled.ShouldBeTrue());
+            }
+
+            [Assert]
+            public void Should_not_attempt_to_authorize_using_the_higher_level_claim_default_authorization_strategies()
+            {
+                "".ShouldSatisfyAllConditions(
+                    () => FourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse(),
+                    () => AnotherFourthAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse());
+            }
+
+            [Assert]
+            public void Should_not_attempt_to_authorize_using_any_other_authorization_strategies()
+            {
+                "".ShouldSatisfyAllConditions(
+                    () => OverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse(),
+                    () => AnotherOverrideAuthorizationStrategy.SingleItemWasCalled.ShouldBeFalse());
             }
         }
 
@@ -991,7 +1092,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
                                     ClaimName = Resource4ClaimUri, ValidationRuleSetName = "RuleSetFor4",
 
                                     // We need an authorization strategy defined somewhere in the lineage
-                                    AuthorizationStrategy = "Fourth"
+                                    AuthorizationStrategies = new List<string> { "Fourth" }
                                 }
                             }
 
@@ -1744,7 +1845,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
                 {
                     new ResourceClaimAuthorizationMetadata
                     {
-                        ClaimName = claim, AuthorizationStrategy = strategy
+                        ClaimName = claim, AuthorizationStrategies  = new List<string> { strategy }
                     }
                 };
             }
@@ -1933,7 +2034,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
                     Given_authorization_metadata_for_resource_claim_and_action_with_authorization_strategy(
                         Resource1ClaimUri,
                         ReadActionUri,
-                        "Missing"),
+                        new [] {"Missing", "AnotherMissing"}),
                     Given_a_collection_of_unused_authorization_strategies(),
                     Given_a_security_repository_returning_all_actions(),
                     new IExplicitObjectValidator[0]);
@@ -1955,7 +2056,43 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
             }
         }
 
-        public class When_there_is_no_authorization_strategy_defined_in_the_metadata_for_the_matched_claim
+        public class When_there_is_no_authorization_strategies_defined_in_the_metadata_for_the_matched_claim
+            : TestFixtureBase
+        {
+            // Supplied values
+
+            // Actual values
+
+            protected override void Act()
+            {
+                // Execute code under test
+
+                var provider = new EdFiAuthorizationProvider(
+                    Given_authorization_metadata_for_resource_claim_and_action_with_authorization_strategy(
+                        Resource2ClaimUri,
+                        ReadActionUri,
+                        Array.Empty<string>()),
+                    Given_a_collection_of_unused_authorization_strategies(),
+                    Given_a_security_repository_returning_all_actions(),
+                    new IExplicitObjectValidator[0]);
+
+                provider.AuthorizeSingleItemAsync(
+                        Given_an_authorization_context_for_a_request_to_read_a_resource_with_a_principal(
+                            Resource2ClaimUri,
+                            Given_a_ClaimsPrincipal_with_a_read_claim_for_resource(Resource2ClaimUri)),
+                        CancellationToken.None)
+                    .WaitSafely();
+            }
+
+            [Assert]
+            public void Should_throw_exception_indicating_that_no_authorization_strategy_were_defined_in_the_metadata()
+            {
+                ActualException.ShouldBeExceptionType<Exception>();
+                ActualException.Message.ShouldContain("No authorization strategies were defined");
+            }
+        }
+
+        public class When_there_is_no_value_present_for_the_authorization_strategies_defined_in_the_metadata_for_the_matched_claim
             : TestFixtureBase
         {
             // Supplied values
@@ -1984,10 +2121,10 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
             }
 
             [Assert]
-            public void Should_throw_exception_indicating_that_no_authorization_strategy_was_defined_in_the_metadata()
+            public void Should_throw_exception_indicating_that_no_authorization_strategy_were_defined_in_the_metadata()
             {
                 ActualException.ShouldBeExceptionType<Exception>();
-                ActualException.Message.ShouldContain("No authorization strategy was defined");
+                ActualException.Message.ShouldContain("No authorization strategies were defined");
             }
         }
 
@@ -2009,7 +2146,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
             Given_authorization_metadata_for_resource_claim_and_action_with_authorization_strategy(
             string resourceClaim,
             string actionUri,
-            string authorizationStrategyName)
+            string[] authorizationStrategyNames)
         {
             var authorizationMetadataProvider = A.Fake<IResourceAuthorizationMetadataProvider>();
 
@@ -2019,7 +2156,8 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization
                         {
                             new ResourceClaimAuthorizationMetadata
                             {
-                                ClaimName = resourceClaim, AuthorizationStrategy = authorizationStrategyName
+                                ClaimName = resourceClaim,  
+                                AuthorizationStrategies  = authorizationStrategyNames
                             }
                         }
                         .ToList());

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Security/Authorization/Repositories/AuthorizationDecoratorTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Security/Authorization/Repositories/AuthorizationDecoratorTests.cs
@@ -102,19 +102,21 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization.Repositories
                         .ToString("n"),
                     ApplicationId = 999,
                     ClaimSetName = "SomeClaimSet",
-                    NamespacePrefixes = new List<string> {"Namespace"},
-                    EducationOrganizationIds = new List<int>
+                    NamespacePrefixes = new [] {"Namespace"},
+                    EducationOrganizationIds = new []
                     {
                         123,
                         234
-                    }
+                    },
+                    OwnershipTokenIds = new short?[] { 1 }
                 };
 
                 var claimsIdentity = claimsIdentityProvider.GetClaimsIdentity(
                     apiClientDetails.EducationOrganizationIds,
                     apiClientDetails.ClaimSetName,
                     apiClientDetails.NamespacePrefixes,
-                    apiClientDetails.Profiles.ToList());
+                    apiClientDetails.Profiles.ToList(), 
+                    apiClientDetails.OwnershipTokenIds.ToList());
 
                 ClaimsPrincipal.ClaimsPrincipalSelector = () => new ClaimsPrincipal(claimsIdentity);
             }

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Security/Authorization/Repositories/CompositeAuthorizationDecoratorTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Security/Authorization/Repositories/CompositeAuthorizationDecoratorTests.cs
@@ -145,14 +145,16 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Authorization.Repositories
                     {
                         123,
                         234
-                    }
+                    },
+                    OwnershipTokenIds = new List<short?> { 1 }
                 };
 
                 var claimsIdentity = claimsIdentityProvider.GetClaimsIdentity(
                     apiClientDetails.EducationOrganizationIds,
                     apiClientDetails.ClaimSetName,
                     apiClientDetails.NamespacePrefixes,
-                    apiClientDetails.Profiles.ToList());
+                    apiClientDetails.Profiles.ToList(),
+                    apiClientDetails.OwnershipTokenIds.ToList());
 
                 _expectedClaimsPrincipal = new ClaimsPrincipal(claimsIdentity);
 

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Security/AuthorizationStrategies/Relationships/AuthorizationBuilderTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Security/AuthorizationStrategies/Relationships/AuthorizationBuilderTests.cs
@@ -20,6 +20,7 @@ using Test.Common;
 
 namespace EdFi.Ods.Tests.EdFi.Security.Authorization
 {
+    [TestFixture]
     public class Feature_building_claims_authorization_segments
     {
         public class When_building_a_single_segment_for_a_claimset_that_has_no_education_organization_identifiers

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Security/Claims/ClaimsIdentityProviderTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Security/Claims/ClaimsIdentityProviderTests.cs
@@ -89,33 +89,39 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Claims
                 _apiKeyContextProvider = A.Fake<IApiKeyContextProvider>();
                 A.CallTo(() => _apiKeyContextProvider.GetApiKeyContext()).Returns(apiKeyContext);
 
-                var suppliedResourceClaims = new List<ClaimSetResourceClaim>
+                var suppliedResourceClaims = new List<ClaimSetResourceClaimAction>
                 {
-                    new ClaimSetResourceClaim
+                    new ClaimSetResourceClaimAction
                     {
                         Action = new Action { ActionUri = "actionUri-1a" },
                         ResourceClaim = new ResourceClaim { ClaimName = "resourceClaimName1" },
-                        AuthorizationStrategyOverride = new AuthorizationStrategy
+                        AuthorizationStrategyOverrides = new List<ClaimSetResourceClaimActionAuthorizationStrategyOverrides>
                         {
-                            AuthorizationStrategyName = "actionUri-1a-Strategy"
+                            new ClaimSetResourceClaimActionAuthorizationStrategyOverrides
+                            {
+                                AuthorizationStrategy = new AuthorizationStrategy { AuthorizationStrategyName=  "actionUri-1a-Strategy" }
+                            }
                         },
                         ValidationRuleSetNameOverride = null
                     },
-                    new ClaimSetResourceClaim
+                    new ClaimSetResourceClaimAction
                     {
                         Action = new Action { ActionUri = "actionUri-1b" },
                         ResourceClaim = new ResourceClaim { ClaimName = "resourceClaimName1" },
-                        AuthorizationStrategyOverride = new AuthorizationStrategy
+                        AuthorizationStrategyOverrides = new List<ClaimSetResourceClaimActionAuthorizationStrategyOverrides>
                         {
-                            AuthorizationStrategyName = "actionUri-1b-Strategy"
+                            new ClaimSetResourceClaimActionAuthorizationStrategyOverrides
+                            {
+                                AuthorizationStrategy = new AuthorizationStrategy { AuthorizationStrategyName=  "actionUri-1b-Strategy" }
+                            }
                         },
                         ValidationRuleSetNameOverride = "actionUri-1b-RuleSetName"
                     },
-                    new ClaimSetResourceClaim
+                    new ClaimSetResourceClaimAction
                     {
                         Action = new Action { ActionUri = "actionUri-2" },
                         ResourceClaim = new ResourceClaim { ClaimName = "resourceClaimName2" },
-                        AuthorizationStrategyOverride = null,
+                        AuthorizationStrategyOverrides = null,
                         ValidationRuleSetNameOverride = "actionUri-2-RuleSetName"
                     }
                 };
@@ -189,27 +195,9 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Claims
                 edFiResourceClaim1.Actions.Count()
                     .ShouldBe(2);
 
-                Assert.That(
-                    edFiResourceClaim1.Actions.Select(
-                        x => new
-                        {
-                            x.Name,
-                            x.AuthorizationStrategyNameOverride
-                        }),
-                    Is.EquivalentTo(
-                        new[]
-                        {
-                            new
-                            {
-                                Name = "actionUri-1a",
-                                AuthorizationStrategyNameOverride = "actionUri-1a-Strategy"
-                            },
-                            new
-                            {
-                                Name = "actionUri-1b",
-                                AuthorizationStrategyNameOverride = "actionUri-1b-Strategy"
-                            }
-                        }));
+                Assert.AreEqual(edFiResourceClaim1.Actions.SelectMany(x => x.AuthorizationStrategyNameOverrides).ToArray(), new string[]{ "actionUri-1a-Strategy","actionUri-1b-Strategy" });
+                Assert.AreEqual(edFiResourceClaim1.Actions.Select(x => x.Name).ToArray(), new string[] { "actionUri-1a", "actionUri-1b" });
+                
             }
 
             [Assert]
@@ -218,25 +206,10 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Claims
                 var claim2 = _actualIdentity.Claims.SingleOrDefault(c => c.Type == "resourceClaimName2");
                 var edFiResourceClaim2 = claim2.ToEdFiResourceClaimValue();
 
-                edFiResourceClaim2.Actions.Count()
-                    .ShouldBe(1);
+                edFiResourceClaim2.Actions.Count().ShouldBe(1);
 
-                Assert.That(
-                    edFiResourceClaim2.Actions.Select(
-                        x => new
-                        {
-                            x.Name,
-                            x.AuthorizationStrategyNameOverride
-                        }),
-                    Is.EquivalentTo(
-                        new[]
-                        {
-                            new
-                            {
-                                Name = "actionUri-2",
-                                AuthorizationStrategyNameOverride = null as string
-                            }
-                        }));
+                Assert.AreEqual(edFiResourceClaim2.Actions.Where(x => x.AuthorizationStrategyNameOverrides != null).SelectMany(x => x.AuthorizationStrategyNameOverrides).ToArray(), new string[] {  });
+                Assert.AreEqual(edFiResourceClaim2.Actions.Select(x => x.Name).ToArray(), new string[] { "actionUri-2" });
             }
 
             [Assert]
@@ -368,33 +341,39 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Security.Claims
                 _apiKeyContextProvider = A.Fake<IApiKeyContextProvider>();
                 A.CallTo(() => _apiKeyContextProvider.GetApiKeyContext()).Returns(apiKeyContext);
 
-                var suppliedResourceClaims = new List<ClaimSetResourceClaim>
+                var suppliedResourceClaims = new List<ClaimSetResourceClaimAction>
                 {
-                    new ClaimSetResourceClaim
+                    new ClaimSetResourceClaimAction
                     {
                         Action = new Action { ActionUri = "actionUri-1a" },
                         ResourceClaim = new ResourceClaim { ClaimName = "resourceClaimName1" },
-                        AuthorizationStrategyOverride = new AuthorizationStrategy
+                        AuthorizationStrategyOverrides = new List<ClaimSetResourceClaimActionAuthorizationStrategyOverrides>
                         {
-                            AuthorizationStrategyName = "actionUri-1a-Strategy"
+                            new ClaimSetResourceClaimActionAuthorizationStrategyOverrides
+                            {
+                                AuthorizationStrategy = new AuthorizationStrategy { AuthorizationStrategyName=  "actionUri-1a-Strategy" }
+                            }
                         },
                         ValidationRuleSetNameOverride = null
                     },
-                    new ClaimSetResourceClaim
+                    new ClaimSetResourceClaimAction
                     {
                         Action = new Action { ActionUri = "actionUri-1b" },
                         ResourceClaim = new ResourceClaim { ClaimName = "resourceClaimName1" },
-                        AuthorizationStrategyOverride = new AuthorizationStrategy
+                        AuthorizationStrategyOverrides = new List<ClaimSetResourceClaimActionAuthorizationStrategyOverrides>
                         {
-                            AuthorizationStrategyName = "actionUri-1b-Strategy"
+                            new ClaimSetResourceClaimActionAuthorizationStrategyOverrides
+                            {
+                                AuthorizationStrategy = new AuthorizationStrategy { AuthorizationStrategyName=  "actionUri-1b-Strategy" }
+                            }
                         },
                         ValidationRuleSetNameOverride = "actionUri-1b-RuleSetName"
                     },
-                    new ClaimSetResourceClaim
+                    new ClaimSetResourceClaimAction
                     {
                         Action = new Action { ActionUri = "actionUri-2" },
                         ResourceClaim = new ResourceClaim { ClaimName = "resourceClaimName2" },
-                        AuthorizationStrategyOverride = null,
+                        AuthorizationStrategyOverrides = null,
                         ValidationRuleSetNameOverride = "actionUri-2-RuleSetName"
                     }
                 };

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
@@ -17,13 +17,13 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.3.43" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.3.43" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.2" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.2" />
     <PackageReference Include="NHibernate" Version="5.3.10" />
     <PackageReference Include="Autofac.Extras.FakeItEasy" Version="7.0.0" />
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="CompareNETObjects" Version="4.74.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFrameworkTesting.FakeItEasy" Version="1.3.0" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />

--- a/Application/EdFi.Security.DataAccess/Caching/InstanceSecurityRepositoryCacheObject.cs
+++ b/Application/EdFi.Security.DataAccess/Caching/InstanceSecurityRepositoryCacheObject.cs
@@ -15,9 +15,9 @@ namespace EdFi.Security.DataAccess.Caching
 
         public List<AuthorizationStrategy> AuthorizationStrategies { get; }
 
-        public List<ClaimSetResourceClaim> ClaimSetResourceClaims { get; }
+        public List<ClaimSetResourceClaimAction> ClaimSetResourceClaimActions { get; }
 
-        public List<ResourceClaimAuthorizationMetadata> ResourceClaimAuthorizationMetadata { get; }
+        public List<ResourceClaimAction> ResourceClaimActions { get; }
 
 
         public InstanceSecurityRepositoryCacheObject(
@@ -26,16 +26,16 @@ namespace EdFi.Security.DataAccess.Caching
             List<ClaimSet> claimSets,
             List<ResourceClaim> resourceClaims,
             List<AuthorizationStrategy> authorizationStrategies,
-            List<ClaimSetResourceClaim> claimSetResourceClaims,
-            List<ResourceClaimAuthorizationMetadata> resourceClaimAuthorizationMetadata)
+            List<ClaimSetResourceClaimAction> claimSetResourceClaimActions,
+            List<ResourceClaimAction> resourceClaimActions)
         {
             Application = application;
             Actions = actions;
             ClaimSets = claimSets;
             ResourceClaims = resourceClaims;
             AuthorizationStrategies = authorizationStrategies;
-            ClaimSetResourceClaims = claimSetResourceClaims;
-            ResourceClaimAuthorizationMetadata = resourceClaimAuthorizationMetadata;
+            ClaimSetResourceClaimActions = claimSetResourceClaimActions;
+            ResourceClaimActions = resourceClaimActions;
         }
     }
 }

--- a/Application/EdFi.Security.DataAccess/Contexts/ISecurityContext.cs
+++ b/Application/EdFi.Security.DataAccess/Contexts/ISecurityContext.cs
@@ -21,11 +21,15 @@ namespace EdFi.Security.DataAccess.Contexts
 
         DbSet<ClaimSet> ClaimSets { get; set; }
 
-        DbSet<ClaimSetResourceClaim> ClaimSetResourceClaims { get; set; }
+        DbSet<ClaimSetResourceClaimAction> ClaimSetResourceClaimActions { get; set; }
 
         DbSet<ResourceClaim> ResourceClaims { get; set; }
 
-        DbSet<ResourceClaimAuthorizationMetadata> ResourceClaimAuthorizationMetadatas { get; set; }
+        DbSet<ResourceClaimAction> ResourceClaimActions { get; set; }
+
+        DbSet<ClaimSetResourceClaimActionAuthorizationStrategyOverrides> ClaimSetResourceClaimActionAuthorizationStrategyOverrides { get; set; }
+
+        DbSet<ResourceClaimActionAuthorizationStrategies> ResourceClaimActionAuthorizationStrategies { get; set; }
 
         int SaveChanges();
 

--- a/Application/EdFi.Security.DataAccess/Contexts/SecurityContext.cs
+++ b/Application/EdFi.Security.DataAccess/Contexts/SecurityContext.cs
@@ -25,11 +25,15 @@ namespace EdFi.Security.DataAccess.Contexts
 
         public DbSet<ClaimSet> ClaimSets { get; set; }
 
-        public DbSet<ClaimSetResourceClaim> ClaimSetResourceClaims { get; set; }
+        public DbSet<ClaimSetResourceClaimAction> ClaimSetResourceClaimActions { get; set; }
 
         public DbSet<ResourceClaim> ResourceClaims { get; set; }
 
-        public DbSet<ResourceClaimAuthorizationMetadata> ResourceClaimAuthorizationMetadatas { get; set; }
+        public DbSet<ResourceClaimAction> ResourceClaimActions { get; set; }
+
+        public DbSet<ClaimSetResourceClaimActionAuthorizationStrategyOverrides> ClaimSetResourceClaimActionAuthorizationStrategyOverrides { get; set; }
+
+        public DbSet<ResourceClaimActionAuthorizationStrategies> ResourceClaimActionAuthorizationStrategies { get; set; }
 
         protected override void OnModelCreating(DbModelBuilder modelBuilder)
         {

--- a/Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj
+++ b/Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj
@@ -15,7 +15,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="Npgsql" Version="4.1.5" />

--- a/Application/EdFi.Security.DataAccess/Models/ClaimSetResourceClaimAction.cs
+++ b/Application/EdFi.Security.DataAccess/Models/ClaimSetResourceClaimAction.cs
@@ -3,27 +3,37 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace EdFi.Security.DataAccess.Models
 {
-    public class ClaimSetResourceClaim
+    public class ClaimSetResourceClaimAction
     {
         [Key]
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        public int ClaimSetResourceClaimId { get; set; }
+        public int ClaimSetResourceClaimActionId { get; set; }
+
+        public int ActionId { get; set; }
 
         [Required]
+        [ForeignKey("ActionId")]
         public Action Action { get; set; }
 
+        public int ClaimSetId { get; set; }
+
         [Required]
+        [ForeignKey("ClaimSetId")]
         public ClaimSet ClaimSet { get; set; }
 
+        public int ResourceClaimId { get; set; }
+
         [Required]
+        [ForeignKey("ResourceClaimId")]
         public ResourceClaim ResourceClaim { get; set; }
 
-        public AuthorizationStrategy AuthorizationStrategyOverride { get; set; }
+        public List<ClaimSetResourceClaimActionAuthorizationStrategyOverrides> AuthorizationStrategyOverrides { get; set; }
 
         [StringLength(255)]
         public string ValidationRuleSetNameOverride { get; set; }

--- a/Application/EdFi.Security.DataAccess/Models/ClaimSetResourceClaimActionAuthorizationStrategyOverrides.cs
+++ b/Application/EdFi.Security.DataAccess/Models/ClaimSetResourceClaimActionAuthorizationStrategyOverrides.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text;
+
+namespace EdFi.Security.DataAccess.Models
+{
+    public class ClaimSetResourceClaimActionAuthorizationStrategyOverrides
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int ClaimSetResourceClaimActionAuthorizationStrategyOverrideId { get; set; }
+
+        public int ClaimSetResourceClaimActionId { get; set; }
+
+        [Required]
+        [Index(IsUnique = true, Order = 1)]
+        [ForeignKey("ClaimSetResourceClaimActionId")]
+        public ClaimSetResourceClaimAction ClaimSetResourceClaimAction { get; set; }
+
+        public int AuthorizationStrategyId { get; set; }
+
+        [Required]
+        [Index(IsUnique = true, Order = 2)]
+        [ForeignKey("AuthorizationStrategyId")]
+        public AuthorizationStrategy AuthorizationStrategy { get; set; }
+    }
+}

--- a/Application/EdFi.Security.DataAccess/Models/ResourceClaimAction.cs
+++ b/Application/EdFi.Security.DataAccess/Models/ResourceClaimAction.cs
@@ -3,23 +3,30 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace EdFi.Security.DataAccess.Models
 {
-    public class ResourceClaimAuthorizationMetadata
+    public class ResourceClaimAction
     {
         [Key]
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        public int ResourceClaimAuthorizationStrategyId { get; set; }
+        public int ResourceClaimActionId { get; set; }
+
+        public int ActionId { get; set; }
 
         [Required]
+        [ForeignKey("ActionId")]
         public Action Action { get; set; }
 
-        public AuthorizationStrategy AuthorizationStrategy { get; set; }
+        public List<ResourceClaimActionAuthorizationStrategies> AuthorizationStrategies { get; set; }
+
+        public int ResourceClaimId { get; set; }
 
         [Required]
+        [ForeignKey("ResourceClaimId")]
         public ResourceClaim ResourceClaim { get; set; }
 
         [StringLength(255)]

--- a/Application/EdFi.Security.DataAccess/Models/ResourceClaimActionAuthorizationStrategies.cs
+++ b/Application/EdFi.Security.DataAccess/Models/ResourceClaimActionAuthorizationStrategies.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text;
+
+namespace EdFi.Security.DataAccess.Models
+{
+    public class ResourceClaimActionAuthorizationStrategies
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int ResourceClaimActionAuthorizationStrategyId { get; set; }
+
+        public int ResourceClaimActionId { get; set; }
+
+        [Required]
+        [ForeignKey("ResourceClaimActionId")]
+        public ResourceClaimAction ResourceClaimAction { get; set; }
+
+        public int AuthorizationStrategyId { get; set; }
+
+        [Required]
+        [ForeignKey("AuthorizationStrategyId")]
+        public AuthorizationStrategy AuthorizationStrategy { get; set; }
+    }
+}

--- a/Application/EdFi.Security.DataAccess/Repositories/CachedSecurityRepository.cs
+++ b/Application/EdFi.Security.DataAccess/Repositories/CachedSecurityRepository.cs
@@ -49,13 +49,13 @@ namespace EdFi.Security.DataAccess.Repositories
         public override AuthorizationStrategy GetAuthorizationStrategyByName(string authorizationStrategyName)
             => VerifyCacheAndExecute(() => base.GetAuthorizationStrategyByName(authorizationStrategyName));
 
-        public override IEnumerable<ClaimSetResourceClaim> GetClaimsForClaimSet(string claimSetName)
+        public override IEnumerable<ClaimSetResourceClaimAction> GetClaimsForClaimSet(string claimSetName)
             => VerifyCacheAndExecute(() => base.GetClaimsForClaimSet(claimSetName));
 
         public override IEnumerable<string> GetResourceClaimLineage(string resourceUri)
             => VerifyCacheAndExecute(() => base.GetResourceClaimLineage(resourceUri));
 
-        public override IEnumerable<ResourceClaimAuthorizationMetadata>
+        public override IEnumerable<ResourceClaimAction>
             GetResourceClaimLineageMetadata(string resourceClaimUri, string action)
             => VerifyCacheAndExecute(() => base.GetResourceClaimLineageMetadata(resourceClaimUri, action));
 

--- a/Application/EdFi.Security.DataAccess/Repositories/ISecurityRepository.cs
+++ b/Application/EdFi.Security.DataAccess/Repositories/ISecurityRepository.cs
@@ -16,7 +16,7 @@ namespace EdFi.Security.DataAccess.Repositories
 
         AuthorizationStrategy GetAuthorizationStrategyByName(string authorizationStrategyName);
 
-        IEnumerable<ClaimSetResourceClaim> GetClaimsForClaimSet(string claimSetName);
+        IEnumerable<ClaimSetResourceClaimAction> GetClaimsForClaimSet(string claimSetName);
 
         /// <summary>
         /// Gets the lineage up the taxonomy of resource claim URIs for the specified resource.
@@ -31,7 +31,7 @@ namespace EdFi.Security.DataAccess.Repositories
         /// </summary>
         /// <param name="resourceClaimUri">The resource claim URI representing the resource.</param>
         /// <returns>The resource claim authorization metadata.</returns>
-        IEnumerable<ResourceClaimAuthorizationMetadata> GetResourceClaimLineageMetadata(string resourceClaimUri, string action);
+        IEnumerable<ResourceClaimAction> GetResourceClaimLineageMetadata(string resourceClaimUri, string action);
 
         ResourceClaim GetResourceByResourceName(string resourceName);
     }

--- a/Application/EdFi.Security.DataAccess/Repositories/SecurityRepository.cs
+++ b/Application/EdFi.Security.DataAccess/Repositories/SecurityRepository.cs
@@ -43,18 +43,30 @@ namespace EdFi.Security.DataAccess.Repositories
                                                      .Where(auth => auth.Application.ApplicationId.Equals(application.ApplicationId))
                                                      .ToList();
 
-                var claimSetResourceClaims = context.ClaimSetResourceClaims.Include(csrc => csrc.Action)
+                var claimSetResourceClaimActions = context.ClaimSetResourceClaimActions.Include(csrc => csrc.Action)
                                                     .Include(csrc => csrc.ClaimSet)
                                                     .Include(csrc => csrc.ResourceClaim)
                                                     .Where(csrc => csrc.ResourceClaim.Application.ApplicationId.Equals(application.ApplicationId))
                                                     .ToList();
 
-                var resourceClaimAuthorizationMetadata =
-                    context.ResourceClaimAuthorizationMetadatas.Include(rcas => rcas.Action)
-                           .Include(rcas => rcas.AuthorizationStrategy)
+                var claimSetResourceClaimActionAuthorizationStrategyOverrides = context.ClaimSetResourceClaimActionAuthorizationStrategyOverrides.Include(csrcas => csrcas.AuthorizationStrategy)
+                                                   .Include(csrcas => csrcas.ClaimSetResourceClaimAction)
+                                                   .ToList();
+
+                var resourceClaimActionAuthorizationStrategies = context.ResourceClaimActionAuthorizationStrategies.Include(rcaas => rcaas.AuthorizationStrategy)
+                                    .Include(rcaas => rcaas.ResourceClaimAction)
+                                    .ToList();
+
+                var resourceClaimActionAuthorizations =
+                    context.ResourceClaimActions.Include(rcas => rcas.Action)                           
                            .Include(rcas => rcas.ResourceClaim)
                            .Where(rcas => rcas.ResourceClaim.Application.ApplicationId.Equals(application.ApplicationId))
                            .ToList();
+
+                foreach (var a in resourceClaimActionAuthorizations)
+                {
+                    a.AuthorizationStrategies = resourceClaimActionAuthorizationStrategies.Where(r => r.ResourceClaimAction.ResourceClaimActionId == a.ResourceClaimActionId).ToList();
+                }
 
                 Initialize(
                     application,
@@ -62,8 +74,8 @@ namespace EdFi.Security.DataAccess.Repositories
                     claimSets,
                     resourceClaims,
                     authorizationStrategies,
-                    claimSetResourceClaims,
-                    resourceClaimAuthorizationMetadata);
+                    claimSetResourceClaimActions,
+                    resourceClaimActionAuthorizations);
             }
         }
     }

--- a/Application/EdFi.Security.DataAccess/Repositories/SecurityRepositoryBase.cs
+++ b/Application/EdFi.Security.DataAccess/Repositories/SecurityRepositoryBase.cs
@@ -23,9 +23,9 @@ namespace EdFi.Security.DataAccess.Repositories
 
         protected List<AuthorizationStrategy> AuthorizationStrategies { get; private set; }
 
-        protected List<ClaimSetResourceClaim> ClaimSetResourceClaims { get; private set; }
+        protected List<ClaimSetResourceClaimAction> ClaimSetResourceClaimActions { get; private set; }
 
-        protected List<ResourceClaimAuthorizationMetadata> ResourceClaimAuthorizationMetadata { get; private set; }
+        protected List<ResourceClaimAction> ResourceClaimActions { get; private set; }
 
         protected void Initialize(
             Application application,
@@ -33,16 +33,16 @@ namespace EdFi.Security.DataAccess.Repositories
             List<ClaimSet> claimSets,
             List<ResourceClaim> resourceClaims,
             List<AuthorizationStrategy> authorizationStrategies,
-            List<ClaimSetResourceClaim> claimSetResourceClaims,
-            List<ResourceClaimAuthorizationMetadata> resourceClaimAuthorizationMetadata)
+            List<ClaimSetResourceClaimAction> claimSetResourceClaimActions,
+            List<ResourceClaimAction> resourceClaimActions)
         {
             Application = application;
             Actions = actions;
             ClaimSets = claimSets;
             ResourceClaims = resourceClaims;
             AuthorizationStrategies = authorizationStrategies;
-            ClaimSetResourceClaims = claimSetResourceClaims;
-            ResourceClaimAuthorizationMetadata = resourceClaimAuthorizationMetadata;
+            ClaimSetResourceClaimActions = claimSetResourceClaimActions;
+            ResourceClaimActions = resourceClaimActions;
         }
 
         public virtual Action GetActionByHttpVerb(string httpVerb)
@@ -79,9 +79,9 @@ namespace EdFi.Security.DataAccess.Repositories
                 a => a.AuthorizationStrategyName.Equals(authorizationStrategyName, StringComparison.InvariantCultureIgnoreCase));
         }
 
-        public virtual IEnumerable<ClaimSetResourceClaim> GetClaimsForClaimSet(string claimSetName)
+        public virtual IEnumerable<ClaimSetResourceClaimAction> GetClaimsForClaimSet(string claimSetName)
         {
-            return ClaimSetResourceClaims.Where(c => c.ClaimSet.ClaimSetName.Equals(claimSetName, StringComparison.InvariantCultureIgnoreCase));
+            return ClaimSetResourceClaimActions.Where(c => c.ClaimSet.ClaimSetName.Equals(claimSetName, StringComparison.InvariantCultureIgnoreCase));
         }
 
         /// <summary>
@@ -131,19 +131,19 @@ namespace EdFi.Security.DataAccess.Repositories
         /// </summary>
         /// <param name="resourceClaimUri">The resource claim URI for which metadata is to be retrieved.</param>
         /// <returns>The resource claim's lineage of authorization metadata.</returns>
-        public virtual IEnumerable<ResourceClaimAuthorizationMetadata> GetResourceClaimLineageMetadata(string resourceClaimUri, string action)
+        public virtual IEnumerable<ResourceClaimAction> GetResourceClaimLineageMetadata(string resourceClaimUri, string action)
         {
-            var strategies = new List<ResourceClaimAuthorizationMetadata>();
+            var strategies = new List<ResourceClaimAction>();
 
             AddStrategiesForResourceClaimLineage(strategies, resourceClaimUri, action);
 
             return strategies;
         }
 
-        private void AddStrategiesForResourceClaimLineage(List<ResourceClaimAuthorizationMetadata> strategies, string resourceClaimUri, string action)
+        private void AddStrategiesForResourceClaimLineage(List<ResourceClaimAction> strategies, string resourceClaimUri, string action)
         {
             //check for exact match on resource and action
-            var claimAndStrategy = ResourceClaimAuthorizationMetadata
+            var claimAndStrategy = ResourceClaimActions
                .SingleOrDefault(
                     rcas =>
                         rcas.ResourceClaim.ClaimName.Equals(resourceClaimUri, StringComparison.InvariantCultureIgnoreCase)

--- a/Application/EdFi.TestObjects/EdFi.TestObjects.csproj
+++ b/Application/EdFi.TestObjects/EdFi.TestObjects.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/Application/Test.Common/Test.Common.csproj
+++ b/Application/Test.Common/Test.Common.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.3.43" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.2" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Application/Test.Common/_Stubs/StubSecurityRepository.cs
+++ b/Application/Test.Common/_Stubs/StubSecurityRepository.cs
@@ -32,9 +32,9 @@ namespace Test.Common._Stubs
             };
         }
 
-        public IEnumerable<ClaimSetResourceClaim> GetClaimsForClaimSet(string claimSetName)
+        public IEnumerable<ClaimSetResourceClaimAction> GetClaimsForClaimSet(string claimSetName)
         {
-            return new List<ClaimSetResourceClaim>();
+            return new List<ClaimSetResourceClaimAction>();
         }
 
         public IEnumerable<string> GetResourceClaimLineage(string resourceUri)
@@ -42,9 +42,9 @@ namespace Test.Common._Stubs
             return new List<string>();
         }
 
-        public IEnumerable<ResourceClaimAuthorizationMetadata> GetResourceClaimLineageMetadata(string resourceClaimUri, string action)
+        public IEnumerable<ResourceClaimAction> GetResourceClaimLineageMetadata(string resourceClaimUri, string action)
         {
-            return new List<ResourceClaimAuthorizationMetadata>();
+            return new List<ResourceClaimAction>();
         }
 
         public Action GetActionByHttpVerb(string httpVerb)

--- a/Artifacts/MsSql/Data/Security/1000-CreateDistrictHostedSISClaimSet.sql
+++ b/Artifacts/MsSql/Data/Security/1000-CreateDistrictHostedSISClaimSet.sql
@@ -105,62 +105,62 @@ BEGIN
         WHERE rc.ResourceName = 'localEducationAgency'
     
         --Add claims from SIS Vendor ClaimSet
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @types, @read)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @systemDescriptors, @read)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @managedDescriptors, @create)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @managedDescriptors, @read)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @managedDescriptors,  @update)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @managedDescriptors, @delete)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @educationOrganizations, @read)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @people, @create)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @people, @read)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @people,  @update)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @people, @delete)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @relationshipBasedData, @create)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @relationshipBasedData, @read)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @relationshipBasedData,  @update)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @relationshipBasedData, @delete)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @assessmentMetadata, @create)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @assessmentMetadata, @read)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @assessmentMetadata,  @update)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @assessmentMetadata, @delete)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @educationStandards, @create)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @educationStandards, @read)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @educationStandards,  @update)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @educationStandards, @delete)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @primaryRelationships, @create)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @primaryRelationships, @read)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @primaryRelationships,  @update)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @primaryRelationships, @delete)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @educationContent, @create)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @educationContent, @read)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @educationContent,  @update)
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@claimSetId, @educationContent, @delete)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @types, @read)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @systemDescriptors, @read)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @managedDescriptors, @create)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @managedDescriptors, @read)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @managedDescriptors,  @update)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @managedDescriptors, @delete)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @educationOrganizations, @read)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @people, @create)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @people, @read)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @people,  @update)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @people, @delete)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @relationshipBasedData, @create)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @relationshipBasedData, @read)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @relationshipBasedData,  @update)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @relationshipBasedData, @delete)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @assessmentMetadata, @create)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @assessmentMetadata, @read)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @assessmentMetadata,  @update)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @assessmentMetadata, @delete)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @educationStandards, @create)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @educationStandards, @read)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @educationStandards,  @update)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @educationStandards, @delete)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @primaryRelationships, @create)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @primaryRelationships, @read)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @primaryRelationships,  @update)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @primaryRelationships, @delete)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @educationContent, @create)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @educationContent, @read)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @educationContent,  @update)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@claimSetId, @educationContent, @delete)
     
         --Add District Hosted SIS Vendor Claims
     
         -- Create Schools
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId)
         VALUES (@claimSetId, @schoolResourceClaimId, @create)
     
         -- Read Schools
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId)
         VALUES (@claimSetId, @schoolResourceClaimId, @read)
     
         -- Update Schools
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId)
         VALUES (@claimSetId, @schoolResourceClaimId,  @update)
     
         -- Delete Schools
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId)
         VALUES (@claimSetId, @schoolResourceClaimId, @delete)
     
         -- Read localEducationAgency
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId)
         VALUES (@claimSetId, @localEducationAgencyResourceClaimId, @read)
     
         -- Update localEducationAgency
-        INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId)
+        INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId)
         VALUES (@claimSetId, @localEducationAgencyResourceClaimId,  @update)
     END
 END

--- a/Artifacts/MsSql/Data/Security/1010-AssessmentVendorClaimSetUpdatePerformanceLevels.sql
+++ b/Artifacts/MsSql/Data/Security/1010-AssessmentVendorClaimSetUpdatePerformanceLevels.sql
@@ -78,8 +78,8 @@ WHERE rc.ResourceName = 'types'
 
 IF (@assessmentVendorClaimSetId IS NOT NULL)
  BEGIN
-    DELETE FROM [dbo].[ClaimSetResourceClaims]
-    WHERE [ClaimSet_ClaimSetId] = @assessmentVendorClaimSetId
+    DELETE FROM [dbo].[ClaimSetResourceClaimActions]
+    WHERE [ClaimSetId] = @assessmentVendorClaimSetId
  END
 
 ElSE IF (@assessmentVendorClaimSetId IS NULL )
@@ -93,37 +93,37 @@ ElSE IF (@assessmentVendorClaimSetId IS NULL )
  END
  
 --academicSubjectDescriptor CRUD--
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @academicSubjectDescriptor, @create)
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @academicSubjectDescriptor, @read)
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @academicSubjectDescriptor, @update)
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @academicSubjectDescriptor, @delete)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @academicSubjectDescriptor, @create)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @academicSubjectDescriptor, @read)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @academicSubjectDescriptor, @update)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @academicSubjectDescriptor, @delete)
 
 --assessmentMetadata CRUD--
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @assessmentMetadata, @create)
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @assessmentMetadata, @read)
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @assessmentMetadata, @update)
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @assessmentMetadata, @delete)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @assessmentMetadata, @create)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @assessmentMetadata, @read)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @assessmentMetadata, @update)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @assessmentMetadata, @delete)
 
 --learningObjective CRUD--
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @learningObjective, @create)
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @learningObjective, @read)
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @learningObjective, @update)
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @learningObjective, @delete)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @learningObjective, @create)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @learningObjective, @read)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @learningObjective, @update)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @learningObjective, @delete)
 
 --learningStandards R--
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @learningStandard, @read)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @learningStandard, @read)
 
 --managedDescriptors CRUD--
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @managedDescriptors, @create)
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @managedDescriptors, @read)
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @managedDescriptors, @update)
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @managedDescriptors, @delete)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @managedDescriptors, @create)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @managedDescriptors, @read)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @managedDescriptors, @update)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @managedDescriptors, @delete)
 
 --student R-- 
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @student, @read)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @student, @read)
 
 --systemDescriptors R--
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @systemDescriptors, @read)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @systemDescriptors, @read)
 
 --types R--
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @types, @read)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @types, @read)

--- a/Artifacts/MsSql/Data/Security/1020-DataStandard3.2b-ResourceClaimMetadata.sql
+++ b/Artifacts/MsSql/Data/Security/1020-DataStandard3.2b-ResourceClaimMetadata.sql
@@ -26,13 +26,12 @@ BEGIN
 	SELECT @ClaimSetId = (SELECT ClaimSetId FROM  dbo.ClaimSets  WHERE  ClaimSetName  = 'Bootstrap Descriptors and EdOrgs');
 	SELECT @AuthorizationStrategyId = (SELECT AuthorizationStrategyId FROM  dbo.AuthorizationStrategies  WHERE AuthorizationStrategyName = 'NoFurtherAuthorizationRequired');
 
-	INSERT INTO  dbo.ClaimSetResourceClaims 
-		( Action_ActionId 
-		, ClaimSet_ClaimSetId 
-		, ResourceClaim_ResourceClaimId 
-		, AuthorizationStrategyOverride_AuthorizationStrategyId 
+	INSERT INTO  dbo.ClaimSetResourceClaimActions 
+		( ActionId 
+		, ClaimSetId 
+		, ResourceClaimId
 		, ValidationRuleSetNameOverride )
-	SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, @AuthorizationStrategyId, null
+	SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null
 	FROM  dbo.ResourceClaims 
 	CROSS APPLY
 		(SELECT ActionId
@@ -64,6 +63,45 @@ BEGIN
 		'program',
 		'school',
 		'stateEducationAgency'
+	);
+
+	INSERT INTO [dbo].[ClaimSetResourceClaimActionAuthorizationStrategyOverrides]
+		([AuthorizationStrategyId]
+		,[ClaimSetResourceClaimActionId])
+	SELECT @AuthorizationStrategyId, crc.ClaimSetResourceClaimActionId
+	FROM [dbo].[ClaimSetResourceClaimActions] crc
+	INNER JOIN [dbo].[Actions] a ON
+		crc.ActionId=a.Actionid and 
+	    a.ActionName IN ('Create')
+	INNER JOIN [dbo].[ResourceClaims] r ON 
+	crc.ResourceClaimId = r.ResourceClaimId
+	WHERE crc.ClaimSetId = @ClaimSetId 
+		AND r.ResourceName IN  (
+			'systemDescriptors',
+			'managedDescriptors',
+			'educationOrganizations',
+			-- from Interchange-Standards.xml
+			'learningObjective',
+			'learningStandard',
+			'learningStandardEquivalenceAssociation',
+			-- from Interchange-EducationOrganization.xml
+			'accountabilityRating',
+			'classPeriod',
+			'communityOrganization',
+			'communityProvider',
+			'communityProviderLicense',
+			'course',
+			'educationOrganizationNetwork',
+			'educationOrganizationNetworkAssociation',
+			'educationOrganizationPeerAssociation',
+			'educationServiceCenter',
+			'feederSchoolAssociation',
+			'localEducationAgency',
+			'location',
+			'postSecondaryInstitution',
+			'program',
+			'school',
+			'stateEducationAgency'
 	);
 END
 

--- a/Artifacts/MsSql/Data/Security/1030-DataStandard3.3a-ResourceClaimMetadata.sql
+++ b/Artifacts/MsSql/Data/Security/1030-DataStandard3.3a-ResourceClaimMetadata.sql
@@ -44,14 +44,4 @@
         VALUES (N'assessmentScoreRangeLearningStandard', N'assessmentScoreRangeLearningStandard', N'http://ed-fi.org/ods/identity/claims/assessmentScoreRangeLearningStandard', @assessmentMetadataResourceClaimId, @applicationId);
     END
 
-    --Apply  No Further Authorization Required on this OrganizationDepartment resource
-    INSERT INTO  dbo.ClaimSetResourceClaims( Action_ActionId , ClaimSet_ClaimSetId , ResourceClaim_ResourceClaimId , AuthorizationStrategyOverride_AuthorizationStrategyId , ValidationRuleSetNameOverride )
-    SELECT ac.ActionId, cs.claimSetId, ResourceClaimId, @noFurtherAuthRequiredAuthorizationStrategyId, null
-    FROM [dbo].[ResourceClaims]
-    CROSS APPLY
-    (SELECT ActionId  FROM [dbo].[Actions]
-    WHERE ActionName IN ('Create','Read','Update','Delete')) AS ac
-   CROSS APPLY
-    (SELECT claimSetId  FROM dbo.ClaimSets
-    WHERE ClaimSetName IN ('SIS Vendor','Ed-Fi Sandbox','District Hosted SIS Vendor')) AS cs
-    WHERE ResourceName = 'organizationDepartment';
+ 

--- a/Artifacts/MsSql/Data/Security/1070-OrganizationDepartmentMetadata.sql
+++ b/Artifacts/MsSql/Data/Security/1070-OrganizationDepartmentMetadata.sql
@@ -18,15 +18,32 @@ FROM    dbo.ResourceClaims rc
 WHERE   rc.ClaimName = 'http://ed-fi.org/ods/identity/claims/domains/educationOrganizations'
 
 -- Remove existing claim set overrides for OrganizationDepartment
-DELETE FROM dbo.ClaimSetResourceClaims
-WHERE ClaimSetResourceClaimId IN (
-    SELECT  ClaimSetResourceClaimId
-    FROM    dbo.ClaimSetResourceClaims csrc
-        INNER JOIN dbo.ClaimSets cs
-            ON csrc.ClaimSet_ClaimSetId = cs.ClaimSetId
-        INNER JOIN dbo.AuthorizationStrategies strat
-            ON csrc.AuthorizationStrategyOverride_AuthorizationStrategyId = strat.AuthorizationStrategyId
-    WHERE   csrc.ResourceClaim_ResourceClaimId = @organizationDepartmentClaimId
+DELETE FROM dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides
+WHERE ClaimSetResourceClaimActionId IN (
+    SELECT  csrc.ClaimSetResourceClaimActionId
+    FROM    dbo.ClaimSetResourceClaimActions csrc
+	INNER JOIN dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides csrcaaso
+		ON csrc.ClaimSetResourceClaimActionId = csrcaaso.ClaimSetResourceClaimActionId
+    INNER JOIN dbo.ClaimSets cs
+        ON csrc.ClaimSetId = cs.ClaimSetId
+    INNER JOIN dbo.AuthorizationStrategies strat
+        ON csrcaaso.AuthorizationStrategyId = strat.AuthorizationStrategyId
+    WHERE   csrc.ResourceClaimId = @organizationDepartmentClaimId
+        AND cs.ClaimSetName IN ('SIS Vendor', 'Ed-Fi Sandbox', 'District Hosted SIS Vendor')
+        AND strat.AuthorizationStrategyName = 'NoFurtherAuthorizationRequired'
+)
+
+DELETE FROM dbo.ClaimSetResourceClaimActions
+WHERE ClaimSetResourceClaimActionId IN (
+    SELECT  csrc.ClaimSetResourceClaimActionId
+    FROM    dbo.ClaimSetResourceClaimActions csrc
+	INNER JOIN dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides csrcaaso
+		ON csrc.ClaimSetResourceClaimActionId = csrcaaso.ClaimSetResourceClaimActionId
+    INNER JOIN dbo.ClaimSets cs
+        ON csrc.ClaimSetId = cs.ClaimSetId
+    INNER JOIN dbo.AuthorizationStrategies strat
+        ON csrcaaso.AuthorizationStrategyId = strat.AuthorizationStrategyId
+    WHERE   csrc.ResourceClaimId = @organizationDepartmentClaimId
         AND cs.ClaimSetName IN ('SIS Vendor', 'Ed-Fi Sandbox', 'District Hosted SIS Vendor')
         AND strat.AuthorizationStrategyName = 'NoFurtherAuthorizationRequired'
 )
@@ -36,14 +53,21 @@ SELECT @relationshipsAuthorizationStrategyId = AuthorizationStrategyId
 FROM dbo.AuthorizationStrategies
 WHERE AuthorizationStrategyName = 'RelationshipsWithEdOrgsAndPeople'
 
-IF NOT EXISTS (SELECT 1 FROM dbo.ResourceClaimAuthorizationMetadatas WHERE ResourceClaim_ResourceClaimId = @organizationDepartmentClaimId)
+IF NOT EXISTS (SELECT 1 FROM dbo.ResourceClaimActions WHERE ResourceClaimId = @organizationDepartmentClaimId)
 BEGIN
     PRINT 'Assigning default metadata for CRUD operations on OrganizationDepartment to the relationship-based authorization strategy.'
     
-    INSERT INTO dbo.ResourceClaimAuthorizationMetadatas(ResourceClaim_ResourceClaimId, Action_ActionId, AuthorizationStrategy_AuthorizationStrategyId)
-    SELECT @organizationDepartmentClaimId, ActionId, @relationshipsAuthorizationStrategyId
+    INSERT INTO dbo.ResourceClaimActions(ResourceClaimId, ActionId)
+    SELECT @organizationDepartmentClaimId, ActionId
     FROM    dbo.Actions
     WHERE   ActionName IN ('Create', 'Read', 'Update', 'Delete')
+
+	INSERT INTO [dbo].[ResourceClaimActionAuthorizationStrategies](ResourceClaimActionId, AuthorizationStrategyId)
+	SELECT rca.ResourceClaimActionId, @relationshipsAuthorizationStrategyId
+	FROM dbo.ResourceClaimActions rca
+	INNER JOIN dbo.Actions a
+		ON rca.ActionId = a.ActionId
+	WHERE rca.ResourceClaimId = @organizationDepartmentClaimId AND a.ActionName IN ('Create', 'Read', 'Update', 'Delete')
 END
 
 -- Move OrganizationDepartment under EducationOrganizations
@@ -55,16 +79,26 @@ SELECT  @schoolClaimId = ResourceClaimId
 FROM    dbo.ResourceClaims rc 
 WHERE   rc.ClaimName = 'http://ed-fi.org/ods/identity/claims/school'
 
-IF NOT EXISTS (SELECT 1 FROM dbo.ClaimSetResourceClaims csrc INNER JOIN dbo.ClaimSets cs ON csrc.ClaimSet_ClaimSetId = cs.ClaimSetId WHERE cs.ClaimSetName = 'District Hosted SIS Vendor' AND csrc.ResourceClaim_ResourceClaimId = @schoolClaimId)
+IF NOT EXISTS (SELECT 1 FROM dbo.ClaimSetResourceClaimActions csrc INNER JOIN dbo.ClaimSets cs ON csrc.ClaimSetId = cs.ClaimSetId WHERE cs.ClaimSetName = 'District Hosted SIS Vendor' AND csrc.ResourceClaimId = @schoolClaimId)
 BEGIN
     PRINT 'Copying School overrides to OrganizationDepartment for District Hosted Vendor claim set.'
 
     -- Assign same permissions to School overrides for District Hosted SIS Vendor
-    INSERT INTO dbo.ClaimSetResourceClaims(ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId, AuthorizationStrategyOverride_AuthorizationStrategyId)
-    SELECT  csrc.ClaimSet_ClaimSetId, @organizationDepartmentClaimId, csrc.Action_ActionId, csrc.AuthorizationStrategyOverride_AuthorizationStrategyId
-    FROM    dbo.ClaimSetResourceClaims csrc
-        INNER JOIN dbo.ClaimSets cs
-            ON csrc.ClaimSet_ClaimSetId = cs.ClaimSetId
+    INSERT INTO dbo.ClaimSetResourceClaimActions(ClaimSetId, ResourceClaimId, ActionId)
+    SELECT  csrc.ClaimSetId, @organizationDepartmentClaimId, csrc.ActionId
+    FROM    dbo.ClaimSetResourceClaimActions csrc
+    INNER JOIN dbo.ClaimSets cs
+        ON csrc.ClaimSetId = cs.ClaimSetId
     WHERE   cs.ClaimSetName = 'District Hosted SIS Vendor'
-        AND csrc.ResourceClaim_ResourceClaimId = @schoolClaimId 
+        AND csrc.ResourceClaimId = @schoolClaimId 
+
+	INSERT INTO dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides(ClaimSetResourceClaimActionId, AuthorizationStrategyId)
+	SELECT csrc.ClaimSetResourceClaimActionId, csrcaaso.AuthorizationStrategyId
+	FROM dbo.ClaimSetResourceClaimActions csrc
+	INNER JOIN dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides csrcaaso
+		ON csrc.ClaimSetResourceClaimActionId = csrcaaso.ClaimSetResourceClaimActionId
+	INNER JOIN dbo.ClaimSets cs
+        ON csrc.ClaimSetId = cs.ClaimSetId
+	WHERE cs.ClaimSetName = 'District Hosted SIS Vendor'
+        AND csrc.ResourceClaimId = @schoolClaimId
 END

--- a/Artifacts/MsSql/Data/Security/1080-AssessmentVendorClaimSetUpdateLearningStandard.sql
+++ b/Artifacts/MsSql/Data/Security/1080-AssessmentVendorClaimSetUpdateLearningStandard.sql
@@ -43,8 +43,8 @@ WHERE rc.ResourceName = 'LearningStandard'
 
 IF (@assessmentVendorClaimSetId IS NOT NULL)
  BEGIN
-    DELETE FROM [dbo].[ClaimSetResourceClaims]
-    WHERE [ClaimSet_ClaimSetId] = @assessmentVendorClaimSetId AND [ResourceClaim_ResourceClaimId] = @learningStandard
+    DELETE FROM [dbo].[ClaimSetResourceClaimActions]
+    WHERE [ClaimSetId] = @assessmentVendorClaimSetId AND [ResourceClaimId] = @learningStandard
  END
 
 ElSE IF (@assessmentVendorClaimSetId IS NULL )
@@ -58,8 +58,8 @@ ElSE IF (@assessmentVendorClaimSetId IS NULL )
  END
  
 --learningStandardDescriptor CRUD--
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @learningStandard, @create)
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @learningStandard, @read)
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @learningStandard, @update)
-INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (@assessmentVendorClaimSetId, @learningStandard, @delete)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @learningStandard, @create)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @learningStandard, @read)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @learningStandard, @update)
+INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (@assessmentVendorClaimSetId, @learningStandard, @delete)
 

--- a/Artifacts/MsSql/Data/Security/2020-MigrateDataForMultipleAuthStrategies.sql
+++ b/Artifacts/MsSql/Data/Security/2020-MigrateDataForMultipleAuthStrategies.sql
@@ -1,0 +1,113 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = N'ResourceClaimAuthorizationMetadatas')
+BEGIN
+
+    -- ResourceClaimAuthorizationMetadatas -> ResourceClaimActions
+    MERGE INTO dbo.ResourceClaimActions target
+    USING (
+        SELECT
+            ResourceClaim_ResourceClaimId,
+            Action_ActionId,
+            ValidationRuleSetName
+        FROM dbo.ResourceClaimAuthorizationMetadatas
+    ) AS source
+    ON target.ResourceClaimId = source.ResourceClaim_ResourceClaimId
+        AND target.ActionId = source.Action_ActionId
+    WHEN NOT MATCHED BY TARGET THEN
+        INSERT (
+            ResourceClaimId,
+            ActionId,
+            ValidationRuleSetName
+        )
+        VALUES (
+            source.ResourceClaim_ResourceClaimId,
+            source.Action_ActionId,
+            source.ValidationRuleSetName
+        );
+
+    -- ResourceClaimAuthorizationMetadatas.AuthorizationStrategy_AuthorizationStrategyId -> ResourceClaimActionAuthorizationStrategies
+    MERGE INTO dbo.ResourceClaimActionAuthorizationStrategies target
+    USING (
+        SELECT
+            rca.ResourceClaimActionId,
+            rcam.AuthorizationStrategy_AuthorizationStrategyId
+        FROM dbo.ResourceClaimAuthorizationMetadatas rcam
+        JOIN dbo.ResourceClaimActions rca
+            ON rcam.ResourceClaim_ResourceClaimId = rca.ResourceClaimId
+                AND rcam.Action_ActionId = rca.ActionId
+        WHERE rcam.AuthorizationStrategy_AuthorizationStrategyId IS NOT NULL
+    ) AS source
+    ON target.ResourceClaimActionId = source.ResourceClaimActionId
+        AND target.AuthorizationStrategyId = source.AuthorizationStrategy_AuthorizationStrategyId
+    WHEN NOT MATCHED BY TARGET THEN
+        INSERT (
+            ResourceClaimActionId,
+            AuthorizationStrategyId
+        )
+        VALUES (
+            source.ResourceClaimActionId,
+            source.AuthorizationStrategy_AuthorizationStrategyId
+        );
+
+END
+
+IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = N'ClaimSetResourceClaims')
+BEGIN
+
+    -- ClaimSetResourceClaims -> ClaimSetResourceClaimActions
+    MERGE INTO dbo.ClaimSetResourceClaimActions target
+    USING (
+        SELECT
+            ClaimSet_ClaimSetId,
+            ResourceClaim_ResourceClaimId,
+            Action_ActionId,
+            ValidationRuleSetNameOverride
+        FROM dbo.ClaimSetResourceClaims
+    ) AS source
+    ON target.ClaimSetId = source.ClaimSet_ClaimSetId
+        AND target.ResourceClaimId = source.ResourceClaim_ResourceClaimId
+        AND target.ActionId = source.Action_ActionId
+    WHEN NOT MATCHED BY TARGET THEN
+        INSERT (
+            ClaimSetId,
+            ResourceClaimId,
+            ActionId,
+            ValidationRuleSetNameOverride
+        )
+        VALUES (
+            source.ClaimSet_ClaimSetId,
+            source.ResourceClaim_ResourceClaimId,
+            source.Action_ActionId,
+            source.ValidationRuleSetNameOverride
+        );
+
+    -- ClaimSetResourceClaims.AuthorizationStrategyOverride_AuthorizationStrategyId -> ClaimSetResourceClaimActionAuthorizationStrategyOverrides
+    MERGE INTO dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides target
+    USING (
+        SELECT
+            csrca.ClaimSetResourceClaimActionId,
+            csrc.AuthorizationStrategyOverride_AuthorizationStrategyId
+        FROM dbo.ClaimSetResourceClaims csrc
+        INNER JOIN dbo.ClaimSetResourceClaimActions csrca
+            ON csrc.ClaimSet_ClaimSetId = csrca.ClaimSetId
+                AND csrc.ResourceClaim_ResourceClaimId = csrca.ResourceClaimId
+                AND csrc.Action_ActionId = csrca.ActionId
+        WHERE csrc.AuthorizationStrategyOverride_AuthorizationStrategyId IS NOT NULL
+    ) AS source
+    ON target.ClaimSetResourceClaimActionId = source.ClaimSetResourceClaimActionId
+        AND target.AuthorizationStrategyId = source.AuthorizationStrategyOverride_AuthorizationStrategyId
+    WHEN NOT MATCHED BY TARGET THEN
+        INSERT (
+            ClaimSetResourceClaimActionId,
+            AuthorizationStrategyId
+        )
+        VALUES (
+            source.ClaimSetResourceClaimActionId,
+            source.AuthorizationStrategyOverride_AuthorizationStrategyId
+        );
+
+END

--- a/Artifacts/MsSql/Data/Security/2030-DropSingleAuthStrategyTables.sql
+++ b/Artifacts/MsSql/Data/Security/2030-DropSingleAuthStrategyTables.sql
@@ -1,0 +1,7 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+DROP TABLE IF EXISTS dbo.ResourceClaimAuthorizationMetadatas
+DROP TABLE IF EXISTS dbo.ClaimSetResourceClaims

--- a/Artifacts/MsSql/Structure/Security/0040-Tables-MultipleAuthStrats.sql
+++ b/Artifacts/MsSql/Structure/Security/0040-Tables-MultipleAuthStrats.sql
@@ -1,0 +1,133 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+------------------------------ [dbo].[ResourceClaimActions] -------------------------------------------------
+CREATE TABLE [dbo].[ResourceClaimActions](
+	[ResourceClaimActionId] [int] IDENTITY(1,1) NOT NULL,
+	[ResourceClaimId] [int] NOT NULL,
+	[ActionId] [int] NOT NULL,
+	[ValidationRuleSetName] [nvarchar](255) NULL,
+ CONSTRAINT [PK_dbo.ResourceClaimActions] PRIMARY KEY CLUSTERED 
+(
+	[ResourceClaimActionId] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+
+--UNIQUE NONCLUSTERED INDEX for [ActionId],[ResourceClaimId] columns 
+CREATE UNIQUE NONCLUSTERED INDEX [IX_ResourceClaimId_ActionId] ON [dbo].[ResourceClaimActions] (
+    [ResourceClaimId],[ActionId] ASC
+) WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+GO
+
+-- FOREIGN KEY for [ActionId]  column
+ALTER TABLE [dbo].[ResourceClaimActions]  WITH CHECK ADD  CONSTRAINT [FK_dbo.ResourceClaimActions_dbo.Actions_ActionId] FOREIGN KEY([ActionId])
+REFERENCES [dbo].[Actions] ([ActionId])
+GO
+
+-- FOREIGN KEY for [[ResourceClaimId]]  column
+ALTER TABLE [dbo].[ResourceClaimActions]  WITH CHECK ADD  CONSTRAINT [FK_dbo.ResourceClaimActions_dbo.ResourceClaims_ResourceClaimId] FOREIGN KEY([ResourceClaimId])
+REFERENCES [dbo].[ResourceClaims] ([ResourceClaimId])
+ON DELETE CASCADE
+GO
+
+---------------------------- [dbo].[ClaimSetResourceClaimActions] --------------------------------------------------------
+
+CREATE TABLE [dbo].[ClaimSetResourceClaimActions](
+	[ClaimSetResourceClaimActionId] [int] IDENTITY(1,1) NOT NULL,
+	[ClaimSetId] [int] NOT NULL,
+	[ResourceClaimId] [int] NOT NULL,
+	[ActionId] [int] NOT NULL,
+	[ValidationRuleSetNameOverride] [nvarchar](255) NULL,
+ CONSTRAINT [PK_dbo.ClaimSetResourceClaimActions] PRIMARY KEY CLUSTERED 
+(
+	[ClaimSetResourceClaimActionId] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+
+-- UNIQUE NONCLUSTERED INDEX for [ActionId],[ClaimSetId],[ResourceClaimId] columns 
+CREATE UNIQUE NONCLUSTERED INDEX [IX_ClaimSetId_ResourceClaimId_ActionId] ON [dbo].[ClaimSetResourceClaimActions] (
+    [ClaimSetId],[ResourceClaimId],[ActionId] ASC
+) WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+GO
+
+-- FOREIGN KEY for [ActionId]  column
+ALTER TABLE [dbo].[ClaimSetResourceClaimActions]  WITH CHECK ADD  CONSTRAINT [FK_dbo.ClaimSetResourceClaimActions_dbo.Actions_ActionId] FOREIGN KEY([ActionId])
+REFERENCES [dbo].[Actions] ([ActionId])
+GO
+
+-- FOREIGN KEY for [ClaimSetId]  column
+ALTER TABLE [dbo].[ClaimSetResourceClaimActions]  WITH CHECK ADD  CONSTRAINT [FK_dbo.ClaimSetResourceClaimActions_dbo.ClaimSets_ClaimSetId] FOREIGN KEY([ClaimSetId])
+REFERENCES [dbo].[ClaimSets] ([ClaimSetId])
+ON DELETE CASCADE
+GO
+
+-- FOREIGN KEY for [ResourceClaimId] column
+ALTER TABLE [dbo].[ClaimSetResourceClaimActions]  WITH CHECK ADD  CONSTRAINT [FK_dbo.ClaimSetResourceClaimActions_dbo.ResourceClaims_ResourceClaimId] FOREIGN KEY([ResourceClaimId])
+REFERENCES [dbo].[ResourceClaims] ([ResourceClaimId])
+GO
+
+---------------------------- [dbo].[ClaimSetResourceClaimActionAuthorizationStrategyOverrides] --------------------------------------------------------
+
+CREATE TABLE [dbo].[ClaimSetResourceClaimActionAuthorizationStrategyOverrides](
+	[ClaimSetResourceClaimActionAuthorizationStrategyOverrideId] [int] IDENTITY(1,1) NOT NULL,
+	[ClaimSetResourceClaimActionId] [int] NOT NULL,
+	[AuthorizationStrategyId] [int] NOT NULL,
+ CONSTRAINT [PK_dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides] PRIMARY KEY CLUSTERED 
+(
+	[ClaimSetResourceClaimActionAuthorizationStrategyOverrideId] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+
+-- UNIQUE NONCLUSTERED INDEX for [ClaimSetResourceClaimActionId],[AuthorizationStrategyId] columns 
+CREATE UNIQUE NONCLUSTERED INDEX [IX_ClaimSetResourceClaimActionId_AuthorizationStrategyId]
+    ON [dbo].[ClaimSetResourceClaimActionAuthorizationStrategyOverrides]([ClaimSetResourceClaimActionId],[AuthorizationStrategyId] ASC)
+WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+GO
+
+-- FOREIGN KEY for [AuthorizationStrategyId]  column
+ALTER TABLE [dbo].[ClaimSetResourceClaimActionAuthorizationStrategyOverrides]  WITH CHECK ADD  CONSTRAINT [FK_dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides_dbo.AuthorizationStrategies_AuthorizationStrategyId] FOREIGN KEY([AuthorizationStrategyId])
+REFERENCES [dbo].[AuthorizationStrategies] ([AuthorizationStrategyId])
+ON DELETE CASCADE
+GO
+
+-- FOREIGN KEY for [ClaimSetResourceClaimActionId]  column
+ALTER TABLE [dbo].[ClaimSetResourceClaimActionAuthorizationStrategyOverrides]  WITH CHECK ADD  CONSTRAINT [FK_dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides_dbo.ClaimSetResourceClaimActions_ClaimSetResourceClaimActionId] FOREIGN KEY([ClaimSetResourceClaimActionId])
+REFERENCES [dbo].[ClaimSetResourceClaimActions] ([ClaimSetResourceClaimActionId])
+GO
+
+------------------------------ [dbo].[ResourceClaimActionAuthorizationStrategies] -------------------------------------------------
+
+CREATE TABLE [dbo].[ResourceClaimActionAuthorizationStrategies](
+	[ResourceClaimActionAuthorizationStrategyId] [int] IDENTITY(1,1) NOT NULL,
+	[ResourceClaimActionId] [int] NOT NULL,
+	[AuthorizationStrategyId] [int] NOT NULL,
+
+ CONSTRAINT [PK_dbo.ResourceClaimActionAuthorizationStrategies] PRIMARY KEY CLUSTERED 
+(
+	[ResourceClaimActionAuthorizationStrategyId] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+
+-- UNIQUE NONCLUSTERED INDEX for [AuthorizationStrategyId],[ResourceClaimActionId] columns 
+CREATE UNIQUE NONCLUSTERED INDEX [IX_ResourceClaimActionId_AuthorizationStrategyId]
+    ON [dbo].[ResourceClaimActionAuthorizationStrategies]([ResourceClaimActionId],[AuthorizationStrategyId] ASC)
+WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+GO
+
+-- FOREIGN KEY for [AuthorizationStrategyId]  column
+ALTER TABLE [dbo].[ResourceClaimActionAuthorizationStrategies]  WITH CHECK ADD  CONSTRAINT [FK_dbo.ResourceClaimActionAuthorizationStrategies_dbo.AuthorizationStrategies_AuthorizationStrategyId] FOREIGN KEY([AuthorizationStrategyId])
+REFERENCES [dbo].[AuthorizationStrategies] ([AuthorizationStrategyId])
+ON DELETE CASCADE
+GO
+
+-- FOREIGN KEY for [ResourceClaimActionId]  column
+ALTER TABLE [dbo].[ResourceClaimActionAuthorizationStrategies]  WITH CHECK ADD  CONSTRAINT [FK_dbo.ResourceClaimActionAuthorizationStrategies_dbo.ResourceClaimActionAuthorizations_ResourceClaimActionId] FOREIGN KEY([ResourceClaimActionId])
+REFERENCES [dbo].[ResourceClaimActions] ([ResourceClaimActionId])
+GO
+

--- a/Artifacts/MsSql/Structure/Security/0050-AddUniqueConstraintResourceClaimsClaimName.sql
+++ b/Artifacts/MsSql/Structure/Security/0050-AddUniqueConstraintResourceClaimsClaimName.sql
@@ -1,0 +1,8 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+ALTER TABLE dbo.ResourceClaims ALTER COLUMN ResourceName NVARCHAR(255) NOT NULL;
+ALTER TABLE dbo.ResourceClaims ALTER COLUMN ClaimName NVARCHAR(850) NOT NULL;
+ALTER TABLE dbo.ResourceClaims ADD CONSTRAINT UC_ResourceClaims_ClaimName UNIQUE(ClaimName);

--- a/Artifacts/PgSql/Data/Security/1000-CreateDistrictHostedSISClaimSet.sql
+++ b/Artifacts/PgSql/Data/Security/1000-CreateDistrictHostedSISClaimSet.sql
@@ -5,16 +5,15 @@
 
 DO language plpgsql $$
 DECLARE
-    claim_set_name VARCHAR(75) := 'District Hosted SIS Vendor';
-    application_name VARCHAR(50) := 'Ed-Fi ODS API';
+    claim_set_name VARCHAR(255) := 'District Hosted SIS Vendor';
+    application_name VARCHAR(200) := 'Ed-Fi ODS API';
     application_id INT;
     claim_set_id INT;
     create_action_id INT;
     read_action_id INT;
     update_action_id INT;
     delete_action_id INT;
-    bulk_resource_claim_id INT;
-    typeResourceClaimId INT;
+    type_resource_claim_id INT;
     system_descriptors_resource_claim_id INT;
     managed_descriptors_resource_claim_id INT;
     relationship_based_data_resource_claim_id INT;
@@ -27,148 +26,144 @@ DECLARE
     school_resource_resource_claim_id INT;
     local_education_agency_resource_claim_id INT;
 BEGIN
-    IF NOT EXISTS (SELECT 1 FROM dbo.Applications WHERE ApplicationName = application_name)
+    IF EXISTS (SELECT 1 FROM dbo.Applications WHERE ApplicationName = application_name)
     THEN
-        RAISE NOTICE '% does not exist', application_name;
+        IF NOT EXISTS (SELECT 1 FROM dbo.ClaimSets WHERE ClaimSetName = claim_set_name)
+		THEN
+			--Create a new ClaimSet
+			SELECT ApplicationId INTO application_id
+			FROM dbo.Applications WHERE ApplicationName = application_name;
+
+			INSERT INTO dbo.ClaimSets (ClaimSetName ,Application_ApplicationId) values (claim_set_name, application_id);
+			
+			SELECT ClaimSetId INTO claim_set_id
+			FROM dbo.ClaimSets
+			WHERE ClaimSetName = claim_set_name;
+			
+			--Actions--
+			SELECT ActionId INTO create_action_id
+			FROM dbo.Actions a
+			WHERE a.ActionName = 'Create';
+			
+			SELECT ActionId INTO read_action_id
+			FROM dbo.Actions a
+			WHERE a.ActionName = 'Read';
+
+			SELECT ActionId INTO update_action_id
+			FROM dbo.Actions a
+			WHERE a.ActionName = 'Update';
+
+			SELECT ActionId INTO delete_action_id
+			FROM dbo.Actions a
+			WHERE a.ActionName = 'Delete';
+			
+			--ResourceClaims--
+			SELECT ResourceClaimId INTO type_resource_claim_id
+			FROM dbo.ResourceClaims rc
+			WHERE rc.ResourceName = 'types';
+
+			SELECT ResourceClaimId INTO system_descriptors_resource_claim_id
+			FROM dbo.ResourceClaims rc
+			WHERE rc.ResourceName = 'systemDescriptors';
+
+			SELECT ResourceClaimId INTO relationship_based_data_resource_claim_id
+			FROM dbo.ResourceClaims rc
+			WHERE rc.ResourceName = 'relationshipBasedData';
+			
+			SELECT ResourceClaimId INTO managed_descriptors_resource_claim_id
+			FROM dbo.ResourceClaims rc
+			WHERE rc.ResourceName = 'managedDescriptors';
+
+			SELECT ResourceClaimId INTO assessment_metadata_resource_claim_id
+			FROM dbo.ResourceClaims rc
+			WHERE rc.ResourceName = 'assessmentMetadata';
+
+			SELECT ResourceClaimId INTO education_organizations_resource_claim_id
+			FROM dbo.ResourceClaims rc
+			WHERE rc.ResourceName = 'educationOrganizations';
+			
+			SELECT ResourceClaimId INTO education_standards_resource_claim_id
+			FROM dbo.ResourceClaims rc
+			WHERE rc.ResourceName = 'educationStandards';
+
+			SELECT ResourceClaimId INTO people_resource_claim_id
+			FROM dbo.ResourceClaims rc
+			WHERE rc.ResourceName = 'people';
+
+			SELECT ResourceClaimId INTO primary_relationships_resource_claim_id
+			FROM dbo.ResourceClaims rc
+			WHERE rc.ResourceName = 'primaryRelationships';
+			
+			SELECT ResourceClaimId INTO education_content_resource_claim_id
+			FROM dbo.ResourceClaims rc
+			WHERE rc.ResourceName = 'educationContent';
+
+			SELECT ResourceClaimId INTO school_resource_resource_claim_id
+			FROM dbo.ResourceClaims rc
+			WHERE rc.ResourceName = 'school';
+
+			SELECT ResourceClaimId INTO local_education_agency_resource_claim_id
+			FROM dbo.ResourceClaims rc
+			WHERE rc.ResourceName = 'localEducationAgency';
+			
+			--Add claims from SIS Vendor ClaimSet
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, type_resource_claim_id, read_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, system_descriptors_resource_claim_id, read_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, managed_descriptors_resource_claim_id, create_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, managed_descriptors_resource_claim_id, read_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, managed_descriptors_resource_claim_id,  update_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, managed_descriptors_resource_claim_id, delete_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, education_organizations_resource_claim_id, read_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, people_resource_claim_id, create_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, people_resource_claim_id, read_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, people_resource_claim_id,  update_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, people_resource_claim_id, delete_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, relationship_based_data_resource_claim_id, create_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, relationship_based_data_resource_claim_id, read_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, relationship_based_data_resource_claim_id,  update_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, relationship_based_data_resource_claim_id, delete_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, assessment_metadata_resource_claim_id, create_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, assessment_metadata_resource_claim_id, read_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, assessment_metadata_resource_claim_id,  update_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, assessment_metadata_resource_claim_id, delete_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, education_standards_resource_claim_id, create_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, education_standards_resource_claim_id, read_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, education_standards_resource_claim_id,  update_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, education_standards_resource_claim_id, delete_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, primary_relationships_resource_claim_id, create_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, primary_relationships_resource_claim_id, read_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, primary_relationships_resource_claim_id,  update_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, primary_relationships_resource_claim_id, delete_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, education_content_resource_claim_id, create_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, education_content_resource_claim_id, read_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, education_content_resource_claim_id,  update_action_id);
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, education_content_resource_claim_id, delete_action_id);
+			
+			--Add District Hosted SIS Vendor Claims
+
+			-- Create Schools
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId)
+			VALUES (claim_set_id, school_resource_resource_claim_id, create_action_id);
+
+			-- Read Schools
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId)
+			VALUES (claim_set_id, school_resource_resource_claim_id, read_action_id);
+
+			-- Update Schools
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId)
+			VALUES (claim_set_id, school_resource_resource_claim_id,  update_action_id);
+
+			-- Delete Schools
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId)
+			VALUES (claim_set_id, school_resource_resource_claim_id, delete_action_id);
+
+			-- Read localEducationAgency
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId)
+			VALUES (claim_set_id, local_education_agency_resource_claim_id, read_action_id);
+
+			-- Update localEducationAgency
+			INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId)
+			VALUES (claim_set_id, local_education_agency_resource_claim_id,  update_action_id);
+		END IF;
     END IF;
-
-    IF EXISTS (SELECT 1 FROM dbo.ClaimSets WHERE ClaimSetName = claim_set_name)
-    THEN
-        RAISE NOTICE '% claimset exists', claim_set_name;
-    END IF;
-
-    --Create a new ClaimSet
-    SELECT ApplicationId INTO application_id
-    FROM dbo.Applications WHERE ApplicationName = application_name;
-
-    INSERT INTO dbo.ClaimSets (ClaimSetName ,Application_ApplicationId) values (claim_set_name, application_id);
-
-    SELECT ClaimSetId INTO claim_set_id
-    FROM dbo.ClaimSets
-    WHERE ClaimSetName = claim_set_name;
-
-    --Actions--
-    SELECT ActionId INTO create_action_id
-    FROM dbo.Actions a
-    WHERE a.ActionName = 'Create';
-
-    SELECT ActionId INTO read_action_id
-    FROM dbo.Actions a
-    WHERE a.ActionName = 'Read';
-
-    SELECT ActionId INTO update_action_id
-    FROM dbo.Actions a
-    WHERE a.ActionName = 'Update';
-
-    SELECT ActionId INTO delete_action_id
-    FROM dbo.Actions a
-    WHERE a.ActionName = 'Delete';
-
-    --ResourceClaims--
-    SELECT ResourceClaimId INTO typeResourceClaimId
-    FROM dbo.ResourceClaims rc
-    WHERE rc.ResourceName = 'types';
-
-    SELECT ResourceClaimId INTO system_descriptors_resource_claim_id
-    FROM dbo.ResourceClaims rc
-    WHERE rc.ResourceName = 'systemDescriptors';
-
-    SELECT ResourceClaimId INTO relationship_based_data_resource_claim_id
-    FROM dbo.ResourceClaims rc
-    WHERE rc.ResourceName = 'relationshipBasedData';
-
-    SELECT ResourceClaimId INTO managed_descriptors_resource_claim_id
-    FROM dbo.ResourceClaims rc
-    WHERE rc.ResourceName = 'managedDescriptors';
-
-    SELECT ResourceClaimId INTO assessment_metadata_resource_claim_id
-    FROM dbo.ResourceClaims rc
-    WHERE rc.ResourceName = 'assessmentMetadata';
-
-    SELECT ResourceClaimId INTO education_organizations_resource_claim_id
-    FROM dbo.ResourceClaims rc
-    WHERE rc.ResourceName = 'educationOrganizations';
-
-    SELECT ResourceClaimId INTO education_standards_resource_claim_id
-    FROM dbo.ResourceClaims rc
-    WHERE rc.ResourceName = 'educationStandards';
-
-    SELECT ResourceClaimId INTO people_resource_claim_id
-    FROM dbo.ResourceClaims rc
-    WHERE rc.ResourceName = 'people';
-
-    SELECT ResourceClaimId INTO primary_relationships_resource_claim_id
-    FROM dbo.ResourceClaims rc
-    WHERE rc.ResourceName = 'primaryRelationships';
-
-    SELECT ResourceClaimId INTO education_content_resource_claim_id
-    FROM dbo.ResourceClaims rc
-    WHERE rc.ResourceName = 'educationContent';
-
-    SELECT ResourceClaimId INTO school_resource_resource_claim_id
-    FROM dbo.ResourceClaims rc
-    WHERE rc.ResourceName = 'school';
-
-    SELECT ResourceClaimId INTO local_education_agency_resource_claim_id
-    FROM dbo.ResourceClaims rc
-    WHERE rc.ResourceName = 'localEducationAgency';
-
-    --Add claims from SIS Vendor ClaimSet
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, typeResourceClaimId, read_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, system_descriptors_resource_claim_id, read_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, managed_descriptors_resource_claim_id, create_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, managed_descriptors_resource_claim_id, read_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, managed_descriptors_resource_claim_id,  update_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, managed_descriptors_resource_claim_id, delete_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, education_organizations_resource_claim_id, read_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, people_resource_claim_id, create_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, people_resource_claim_id, read_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, people_resource_claim_id,  update_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, people_resource_claim_id, delete_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, relationship_based_data_resource_claim_id, create_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, relationship_based_data_resource_claim_id, read_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, relationship_based_data_resource_claim_id,  update_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, relationship_based_data_resource_claim_id, delete_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, assessment_metadata_resource_claim_id, create_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, assessment_metadata_resource_claim_id, read_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, assessment_metadata_resource_claim_id,  update_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, assessment_metadata_resource_claim_id, delete_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, education_standards_resource_claim_id, create_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, education_standards_resource_claim_id, read_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, education_standards_resource_claim_id,  update_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, education_standards_resource_claim_id, delete_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, primary_relationships_resource_claim_id, create_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, primary_relationships_resource_claim_id, read_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, primary_relationships_resource_claim_id,  update_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, primary_relationships_resource_claim_id, delete_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, education_content_resource_claim_id, create_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, education_content_resource_claim_id, read_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, education_content_resource_claim_id,  update_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId) VALUES (claim_set_id, education_content_resource_claim_id, delete_action_id);
-
-    --Add District Hosted SIS Vendor Claims
-
-    -- Create Schools
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId)
-    VALUES (claim_set_id, school_resource_resource_claim_id, create_action_id);
-
-    -- Read Schools
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId)
-    VALUES (claim_set_id, school_resource_resource_claim_id, read_action_id);
-
-    -- Update Schools
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId)
-    VALUES (claim_set_id, school_resource_resource_claim_id,  update_action_id);
-
-    -- Delete Schools
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId)
-    VALUES (claim_set_id, school_resource_resource_claim_id, delete_action_id);
-
-    -- Read localEducationAgency
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId)
-    VALUES (claim_set_id, local_education_agency_resource_claim_id, read_action_id);
-
-    -- Update localEducationAgency
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId,  Action_ActionId)
-    VALUES (claim_set_id, local_education_agency_resource_claim_id,  update_action_id);
 END $$;

--- a/Artifacts/PgSql/Data/Security/1010-AssessmentVendorClaimSetUpdatePerformanceLevels.sql
+++ b/Artifacts/PgSql/Data/Security/1010-AssessmentVendorClaimSetUpdatePerformanceLevels.sql
@@ -5,49 +5,35 @@
 
 DO language plpgsql $$
 DECLARE
-    claim_set_name VARCHAR(75) := 'Assessment Vendor';
+	claim_set_name VARCHAR(100) := 'Assessment Vendor';
     application_name VARCHAR(50) := 'Ed-Fi ODS API';
     application_id INT;
     claim_set_id INT;
-    create_action_id INT;
-    read_action_id INT;
-    update_action_id INT;
-    delete_action_id INT;
-    academic_subject_descriptor_resource_claim_id INT;
-    assessment_metadata_resource_claim_id INT;
-    learning_objective_resource_claim_id INT;
-    managed_descriptors_resource_claim_id INT;
-    student_resource_claim_id INT;
-    system_descriptors_resource_claim_id INT;
-    types_resource_claim_id INT;
-    learning_standard_resource_claim_id INT;
+	create_action_id INT;
+	read_action_id INT;
+	update_action_id INT;
+	delete_action_id INT;
+	academic_subject_descriptor_resource_claim_id INT;
+	assessment_metadata_resource_claim_id INT;
+	learning_objective_resource_claim_id INT;
+	learning_standard_resource_claim_id INT;
+	managed_descriptors_resource_claim_id INT;
+	student_resource_claim_id INT;
+	system_descriptors_resource_claim_id INT;
+	types_resource_claim_id INT;
 BEGIN
-    IF NOT EXISTS (SELECT 1 FROM dbo.Applications WHERE ApplicationName = application_name)
-    THEN
-        RAISE NOTICE '% does not exist', application_name;
-    END IF;
-
-    IF EXISTS (SELECT 1 FROM dbo.ClaimSets WHERE ClaimSetName = claim_set_name)
-    THEN
-        SELECT ClaimSetId INTO claim_set_id
-        FROM dbo.ClaimSets
-        WHERE ClaimSetName = claim_set_name;
-
-        --Remove existing claimsets--
-        DELETE FROM dbo.ClaimSetResourceClaims
-        WHERE ClaimSet_ClaimSetId = claim_set_id;
-    ElSE
-        --Create a new ClaimSet--
-        INSERT INTO dbo.ClaimSets (ClaimSetName, Application_ApplicationId) VALUES (claim_set_name,application_id);
-
-        SELECT ClaimSetId INTO claim_set_id
-        FROM dbo.ClaimSets
-        WHERE ClaimSetName = claim_set_name;
-    END IF;
-
     SELECT ApplicationId INTO application_id
-    FROM dbo.Applications
-    WHERE ApplicationName = application_name;
+	FROM dbo.Applications
+	WHERE ApplicationName = application_name;
+	
+	IF (application_id IS NULL)
+	THEN
+		RETURN;
+	END IF;
+	
+	SELECT ClaimSetId INTO claim_set_id
+	FROM dbo.ClaimSets
+	WHERE ClaimSetName = claim_set_name;
 
     --Actions--
     SELECT ActionId INTO create_action_id
@@ -99,39 +85,52 @@ BEGIN
     FROM dbo.ResourceClaims rc
     WHERE rc.ResourceName = 'types';
 
+	IF (claim_set_id IS NOT NULL)
+	THEN
+		DELETE FROM dbo.ClaimSetResourceClaimActions
+		WHERE ClaimSetId = claim_set_id;
+	ELSE
+		--Create a new ClaimSet--
+		INSERT INTO dbo.ClaimSets (ClaimSetName, Application_ApplicationId) VALUES (claim_set_name,application_id);
+		
+		SELECT ClaimSetId INTO claim_set_id
+		FROM dbo.ClaimSets
+		WHERE ClaimSetName = claim_set_name;
+	END IF;
+	
     --academicSubjectDescriptor CRUD--
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, academic_subject_descriptor_resource_claim_id, create_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, academic_subject_descriptor_resource_claim_id, read_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, academic_subject_descriptor_resource_claim_id, update_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, academic_subject_descriptor_resource_claim_id, delete_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, academic_subject_descriptor_resource_claim_id, create_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, academic_subject_descriptor_resource_claim_id, read_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, academic_subject_descriptor_resource_claim_id, update_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, academic_subject_descriptor_resource_claim_id, delete_action_id);
 
     --assessmentMetadata CRUD--
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, assessment_metadata_resource_claim_id, create_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, assessment_metadata_resource_claim_id, read_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, assessment_metadata_resource_claim_id, update_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, assessment_metadata_resource_claim_id, delete_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, assessment_metadata_resource_claim_id, create_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, assessment_metadata_resource_claim_id, read_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, assessment_metadata_resource_claim_id, update_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, assessment_metadata_resource_claim_id, delete_action_id);
 
     --learningObjective CRUD--
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, learning_objective_resource_claim_id, create_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, learning_objective_resource_claim_id, read_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, learning_objective_resource_claim_id, update_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, learning_objective_resource_claim_id, delete_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, learning_objective_resource_claim_id, create_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, learning_objective_resource_claim_id, read_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, learning_objective_resource_claim_id, update_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, learning_objective_resource_claim_id, delete_action_id);
 
     --learningStandards R--
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, learning_standard_resource_claim_id, read_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, learning_standard_resource_claim_id, read_action_id);
 
     --managedDescriptors CRUD--
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, managed_descriptors_resource_claim_id, create_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, managed_descriptors_resource_claim_id, read_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, managed_descriptors_resource_claim_id, update_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, managed_descriptors_resource_claim_id, delete_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, managed_descriptors_resource_claim_id, create_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, managed_descriptors_resource_claim_id, read_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, managed_descriptors_resource_claim_id, update_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, managed_descriptors_resource_claim_id, delete_action_id);
 
     --student R--
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, student_resource_claim_id, read_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, student_resource_claim_id, read_action_id);
 
     --systemDescriptors R--
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, system_descriptors_resource_claim_id, read_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, system_descriptors_resource_claim_id, read_action_id);
 
     --types R--
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, types_resource_claim_id, read_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, types_resource_claim_id, read_action_id);
 END $$;

--- a/Artifacts/PgSql/Data/Security/1030-DataStandard3.3a-ResourceClaimMetadata.sql
+++ b/Artifacts/PgSql/Data/Security/1030-DataStandard3.3a-ResourceClaimMetadata.sql
@@ -28,7 +28,7 @@ BEGIN
     IF  EXISTS (SELECT 1 FROM dbo.ResourceClaims WHERE ResourceName = 'relationshipBasedData' AND Application_ApplicationId = application_id)
     THEN
         SELECT ResourceClaimId INTO relationshipBasedDataResourceClaim_Id
-        FROM dbo.ResourceClaims WHERE ResourceName = 'systemDescriptors' AND Application_ApplicationId = application_id;
+        FROM dbo.ResourceClaims WHERE ResourceName = 'relationshipBasedData' AND Application_ApplicationId = application_id;
     END IF;
 
     IF  EXISTS (SELECT 1 FROM dbo.ResourceClaims WHERE ResourceName = 'assessmentMetadata' AND Application_ApplicationId = application_id)
@@ -70,18 +70,6 @@ BEGIN
         INSERT INTO dbo.ResourceClaims (DisplayName, ResourceName, ClaimName, ParentResourceClaimId, Application_ApplicationId)
         VALUES (N'assessmentScoreRangeLearningStandard', N'assessmentScoreRangeLearningStandard', N'http://ed-fi.org/ods/identity/claims/assessmentScoreRangeLearningStandard', assessmentMetadataResourceClaim_Id, application_id);
     END IF;
-
-    --Apply  No Further Authorization Required on this OrganizationDepartment resource
-        INSERT INTO dbo.ClaimSetResourceClaims(Action_ActionId,ClaimSet_ClaimSetId,ResourceClaim_ResourceClaimId,AuthorizationStrategyOverride_AuthorizationStrategyId,ValidationRuleSetNameOverride)
-        SELECT ac.ActionId, cs.claimSetId, ResourceClaimId, noFurtherAuthRequiredAuthorizationStrategy_Id, cast (null as INT)
-        FROM dbo.ResourceClaims
-        INNER JOIN lateral
-        (SELECT ActionId  FROM dbo.Actions
-        WHERE ActionName IN ('Create','Read','Update','Delete')) as ac on true
-        INNER JOIN lateral
-        (SELECT claimSetId  FROM dbo.ClaimSets
-        WHERE ClaimSetName IN ('SIS Vendor','Ed-Fi Sandbox','District Hosted SIS Vendor')) as cs on true
-        WHERE ResourceName = 'organizationDepartment';
 
 
 END $$;

--- a/Artifacts/PgSql/Data/Security/1070-OrganizationDepartmentMetadata.sql
+++ b/Artifacts/PgSql/Data/Security/1070-OrganizationDepartmentMetadata.sql
@@ -12,64 +12,98 @@ relationships_authorization_strategy_id INT;
 
 BEGIN
 
-SELECT  ResourceClaimId INTO organization_department_claim_id
-FROM    dbo.ResourceClaims rc
-WHERE   rc.ClaimName = 'http://ed-fi.org/ods/identity/claims/organizationDepartment';
+	SELECT  ResourceClaimId INTO organization_department_claim_id
+	FROM    dbo.ResourceClaims rc
+	WHERE   rc.ClaimName = 'http://ed-fi.org/ods/identity/claims/organizationDepartment';
 
-SELECT  ResourceClaimId INTO education_organizations_claim_id
-FROM    dbo.ResourceClaims rc
-WHERE   rc.ClaimName = 'http://ed-fi.org/ods/identity/claims/domains/educationOrganizations';
+	SELECT  ResourceClaimId INTO education_organizations_claim_id
+	FROM    dbo.ResourceClaims rc
+	WHERE   rc.ClaimName = 'http://ed-fi.org/ods/identity/claims/domains/educationOrganizations';
 
--- Remove existing claim set overrides for OrganizationDepartment
-DELETE FROM dbo.ClaimSetResourceClaims
-WHERE ClaimSetResourceClaimId IN (
-    SELECT  ClaimSetResourceClaimId
-    FROM    dbo.ClaimSetResourceClaims csrc
-        INNER JOIN dbo.ClaimSets cs
-            ON csrc.ClaimSet_ClaimSetId = cs.ClaimSetId
-        INNER JOIN dbo.AuthorizationStrategies strat
-            ON csrc.AuthorizationStrategyOverride_AuthorizationStrategyId = strat.AuthorizationStrategyId
-    WHERE   csrc.ResourceClaim_ResourceClaimId = organization_department_claim_id
-        AND cs.ClaimSetName IN ('SIS Vendor', 'Ed-Fi Sandbox', 'District Hosted SIS Vendor')
-        AND strat.AuthorizationStrategyName = 'NoFurtherAuthorizationRequired'
-);
+	-- Remove existing claim set overrides for OrganizationDepartment
+	DELETE FROM dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides
+	WHERE ClaimSetResourceClaimActionId IN (
+		SELECT  csrc.ClaimSetResourceClaimActionId
+		FROM    dbo.ClaimSetResourceClaimActions csrc
+		INNER JOIN dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides csrcaaso
+			ON csrc.ClaimSetResourceClaimActionId = csrcaaso.ClaimSetResourceClaimActionId
+		INNER JOIN dbo.ClaimSets cs
+			ON csrc.ClaimSetId = cs.ClaimSetId
+		INNER JOIN dbo.AuthorizationStrategies strat
+				ON csrcaaso.AuthorizationStrategyId = strat.AuthorizationStrategyId
+		WHERE   csrc.ResourceClaimId = organization_department_claim_id
+			AND cs.ClaimSetName IN ('SIS Vendor', 'Ed-Fi Sandbox', 'District Hosted SIS Vendor')
+			AND strat.AuthorizationStrategyName = 'NoFurtherAuthorizationRequired'
+	);
+	
+	DELETE FROM dbo.ClaimSetResourceClaimActions
+	WHERE ClaimSetResourceClaimActionId IN (
+		SELECT  csrc.ClaimSetResourceClaimActionId
+		FROM    dbo.ClaimSetResourceClaimActions csrc
+		INNER JOIN dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides csrcaaso
+			ON csrc.ClaimSetResourceClaimActionId = csrcaaso.ClaimSetResourceClaimActionId
+		INNER JOIN dbo.ClaimSets cs
+			ON csrc.ClaimSetId = cs.ClaimSetId
+		INNER JOIN dbo.AuthorizationStrategies strat
+				ON csrcaaso.AuthorizationStrategyId = strat.AuthorizationStrategyId
+		WHERE   csrc.ResourceClaimId = organization_department_claim_id
+			AND cs.ClaimSetName IN ('SIS Vendor', 'Ed-Fi Sandbox', 'District Hosted SIS Vendor')
+			AND strat.AuthorizationStrategyName = 'NoFurtherAuthorizationRequired'
+	);
 
--- Set default authorization strategy for OrganizationDepartment to relationship-based
-SELECT AuthorizationStrategyId INTO relationships_authorization_strategy_id
-FROM dbo.AuthorizationStrategies
-WHERE AuthorizationStrategyName = 'RelationshipsWithEdOrgsAndPeople';
+	-- Set default authorization strategy for OrganizationDepartment to relationship-based
+	SELECT AuthorizationStrategyId INTO relationships_authorization_strategy_id
+	FROM dbo.AuthorizationStrategies
+	WHERE AuthorizationStrategyName = 'RelationshipsWithEdOrgsAndPeople';
 
-IF NOT EXISTS (SELECT 1 FROM dbo.ResourceClaimAuthorizationMetadatas WHERE ResourceClaim_ResourceClaimId = organization_department_claim_id)
-THEN
-    RAISE NOTICE 'Assigning default metadata for CRUD operations on OrganizationDepartment to the relationship-based authorization strategy.';
-    
-    INSERT INTO dbo.ResourceClaimAuthorizationMetadatas(ResourceClaim_ResourceClaimId, Action_ActionId, AuthorizationStrategy_AuthorizationStrategyId)
-    SELECT  organization_department_claim_id, ActionId, relationships_authorization_strategy_id
-    FROM    dbo.Actions
-    WHERE   ActionName IN ('Create', 'Read', 'Update', 'Delete');
-END IF;
+	IF NOT EXISTS (SELECT 1 FROM dbo.ResourceClaimActions WHERE ResourceClaimId = organization_department_claim_id)
+	THEN
+		RAISE NOTICE 'Assigning default metadata for CRUD operations on OrganizationDepartment to the relationship-based authorization strategy.';
 
--- Move OrganizationDepartment under EducationOrganizations
-UPDATE  dbo.ResourceClaims
-SET     ParentResourceClaimId = education_organizations_claim_id
-WHERE   ResourceClaimId = organization_department_claim_id;
+		INSERT INTO dbo.ResourceClaimActions(ResourceClaimId, ActionId)
+		SELECT  organization_department_claim_id, ActionId
+		FROM    dbo.Actions
+		WHERE   ActionName IN ('Create', 'Read', 'Update', 'Delete');
+		
+		INSERT INTO dbo.ResourceClaimActionAuthorizationStrategies(ResourceClaimActionId, AuthorizationStrategyId)
+		SELECT rca.ResourceClaimActionId, relationships_authorization_strategy_id
+		FROM dbo.ResourceClaimActions rca
+		INNER JOIN dbo.Actions a
+			ON rca.ActionId = a.ActionId
+		WHERE rca.ResourceClaimId = organization_department_claim_id AND a.ActionName IN ('Create', 'Read', 'Update', 'Delete');
+	END IF;
 
-SELECT  ResourceClaimId INTO school_claim_id
-FROM    dbo.ResourceClaims rc
-WHERE   rc.ClaimName = 'http://ed-fi.org/ods/identity/claims/school';
+	-- Move OrganizationDepartment under EducationOrganizations
+	UPDATE  dbo.ResourceClaims
+	SET     ParentResourceClaimId = education_organizations_claim_id
+	WHERE   ResourceClaimId = organization_department_claim_id;
 
--- Assign same permissions to School overrides for District Hosted SIS Vendor
-IF NOT EXISTS (SELECT 1 FROM dbo.ClaimSetResourceClaims csrc INNER JOIN dbo.ClaimSets cs ON csrc.ClaimSet_ClaimSetId = cs.ClaimSetId WHERE cs.ClaimSetName = 'District Hosted SIS Vendor' AND csrc.ResourceClaim_ResourceClaimId = school_claim_id)
-THEN
-    RAISE NOTICE 'Copying School overrides to OrganizationDepartment for District Hosted Vendor claim set.';
-    
-    INSERT INTO dbo.ClaimSetResourceClaims(ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId, AuthorizationStrategyOverride_AuthorizationStrategyId)
-    SELECT  csrc.ClaimSet_ClaimSetId, organization_department_claim_id, csrc.Action_ActionId, csrc.AuthorizationStrategyOverride_AuthorizationStrategyId
-    FROM    dbo.ClaimSetResourceClaims csrc
-        INNER JOIN dbo.ClaimSets cs
-            ON csrc.ClaimSet_ClaimSetId = cs.ClaimSetId
-    WHERE   cs.ClaimSetName = 'District Hosted SIS Vendor'
-        AND csrc.ResourceClaim_ResourceClaimId = school_claim_id;
-END IF;
+	SELECT  ResourceClaimId INTO school_claim_id
+	FROM    dbo.ResourceClaims rc
+	WHERE   rc.ClaimName = 'http://ed-fi.org/ods/identity/claims/school';
+
+	-- Assign same permissions to School overrides for District Hosted SIS Vendor
+	IF NOT EXISTS (SELECT 1 FROM dbo.ClaimSetResourceClaimActions csrc INNER JOIN dbo.ClaimSets cs ON csrc.ClaimSetId = cs.ClaimSetId WHERE cs.ClaimSetName = 'District Hosted SIS Vendor' AND csrc.ResourceClaimId = school_claim_id)
+	THEN
+		RAISE NOTICE 'Copying School overrides to OrganizationDepartment for District Hosted Vendor claim set.';
+
+		INSERT INTO dbo.ClaimSetResourceClaimActions(ClaimSetId, ResourceClaimId, ActionId)
+		SELECT  csrc.ClaimSetId, organization_department_claim_id, csrc.ActionId
+		FROM    dbo.ClaimSetResourceClaimActions csrc
+		INNER JOIN dbo.ClaimSets cs
+			ON csrc.ClaimSetId = cs.ClaimSetId
+		WHERE   cs.ClaimSetName = 'District Hosted SIS Vendor'
+			AND csrc.ResourceClaimId = school_claim_id;
+			
+		INSERT INTO dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides(ClaimSetResourceClaimActionId, AuthorizationStrategyId)
+		SELECT csrc.ClaimSetResourceClaimActionId, csrcaaso.AuthorizationStrategyId
+		FROM dbo.ClaimSetResourceClaimActions csrc
+		INNER JOIN dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides csrcaaso
+			ON csrc.ClaimSetResourceClaimActionId = csrcaaso.ClaimSetResourceClaimActionId
+		INNER JOIN dbo.ClaimSets cs
+			ON csrc.ClaimSetId = cs.ClaimSetId
+		WHERE cs.ClaimSetName = 'District Hosted SIS Vendor'
+			AND csrc.ResourceClaimId = @schoolClaimId;
+	END IF;
 
 END $$;

--- a/Artifacts/PgSql/Data/Security/1080-AssessmentVendorClaimSetUpdateLearningStandard.sql
+++ b/Artifacts/PgSql/Data/Security/1080-AssessmentVendorClaimSetUpdateLearningStandard.sql
@@ -40,8 +40,8 @@ BEGIN
         WHERE ClaimSetName = claim_set_name;
 
         --Remove existing claimsets--
-        DELETE FROM dbo.ClaimSetResourceClaims
-        WHERE ClaimSet_ClaimSetId = claim_set_id AND ResourceClaim_ResourceClaimId = learning_standard_resource_claim_id;
+        DELETE FROM dbo.ClaimSetResourceClaimActions
+        WHERE ClaimSetId = claim_set_id AND ResourceClaimId = learning_standard_resource_claim_id;
     ElSE
         --Create a new ClaimSet--
         INSERT INTO dbo.ClaimSets (ClaimSetName, Application_ApplicationId) VALUES (claim_set_name,application_id);
@@ -72,11 +72,10 @@ BEGIN
     FROM dbo.Actions a
     WHERE a.ActionName = 'Delete';
 
-
     --LearningStandard CRUD--
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, learning_standard_resource_claim_id, create_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, learning_standard_resource_claim_id, read_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, learning_standard_resource_claim_id, update_action_id);
-    INSERT INTO dbo.ClaimSetResourceClaims (ClaimSet_ClaimSetId, ResourceClaim_ResourceClaimId, Action_ActionId) VALUES (claim_set_id, learning_standard_resource_claim_id, delete_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, learning_standard_resource_claim_id, create_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, learning_standard_resource_claim_id, read_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, learning_standard_resource_claim_id, update_action_id);
+    INSERT INTO dbo.ClaimSetResourceClaimActions (ClaimSetId, ResourceClaimId, ActionId) VALUES (claim_set_id, learning_standard_resource_claim_id, delete_action_id);
 
 END $$;

--- a/Artifacts/PgSql/Data/Security/2020-MigrateDataForMultipleAuthStrategies.sql
+++ b/Artifacts/PgSql/Data/Security/2020-MigrateDataForMultipleAuthStrategies.sql
@@ -1,0 +1,103 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+do $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE table_name = 'resourceclaimauthorizationmetadatas')
+    THEN
+
+        -- ResourceClaimAuthorizationMetadatas -> ResourceClaimActions
+        WITH source AS (
+            SELECT
+                ResourceClaim_ResourceClaimId,
+                Action_ActionId,
+                ValidationRuleSetName
+            FROM dbo.ResourceClaimAuthorizationMetadatas
+        )
+        INSERT INTO dbo.ResourceClaimActions (
+            ResourceClaimId,
+            ActionId,
+            ValidationRuleSetName
+        )
+        SELECT
+            source.ResourceClaim_ResourceClaimId,
+            source.Action_ActionId,
+            source.ValidationRuleSetName
+        FROM source
+        ON CONFLICT DO NOTHING;
+
+        -- ResourceClaimAuthorizationMetadatas.AuthorizationStrategy_AuthorizationStrategyId -> ResourceClaimActionAuthorizationStrategies
+        WITH source AS (
+            SELECT
+                rca.ResourceClaimActionId,
+                rcam.AuthorizationStrategy_AuthorizationStrategyId
+            FROM dbo.ResourceClaimAuthorizationMetadatas rcam
+            JOIN dbo.ResourceClaimActions rca
+                ON rcam.ResourceClaim_ResourceClaimId = rca.ResourceClaimId
+                    AND rcam.Action_ActionId = rca.ActionId
+            WHERE rcam.AuthorizationStrategy_AuthorizationStrategyId IS NOT NULL
+        )
+        INSERT INTO dbo.ResourceClaimActionAuthorizationStrategies (
+            ResourceClaimActionId,
+            AuthorizationStrategyId
+        )
+        SELECT
+            source.ResourceClaimActionId,
+            source.AuthorizationStrategy_AuthorizationStrategyId
+        FROM source
+        ON CONFLICT DO NOTHING;
+
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE table_name = 'claimsetresourceclaims')
+    THEN
+
+        -- ClaimSetResourceClaims -> ClaimSetResourceClaimActions
+        WITH source AS (
+            SELECT
+                ClaimSet_ClaimSetId,
+                ResourceClaim_ResourceClaimId,
+                Action_ActionId,
+                ValidationRuleSetNameOverride
+            FROM dbo.ClaimSetResourceClaims
+        )
+        INSERT INTO dbo.ClaimSetResourceClaimActions (
+            ClaimSetId,
+            ResourceClaimId,
+            ActionId,
+            ValidationRuleSetNameOverride
+        )
+        SELECT
+            source.ClaimSet_ClaimSetId,
+            source.ResourceClaim_ResourceClaimId,
+            source.Action_ActionId,
+            source.ValidationRuleSetNameOverride
+        FROM source
+        ON CONFLICT DO NOTHING;
+
+        -- ClaimSetResourceClaims.AuthorizationStrategyOverride_AuthorizationStrategyId -> ClaimSetResourceClaimActionAuthorizationStrategyOverrides
+        WITH source AS (
+            SELECT
+                csrca.ClaimSetResourceClaimActionId,
+                csrc.AuthorizationStrategyOverride_AuthorizationStrategyId
+            FROM dbo.ClaimSetResourceClaims csrc
+            INNER JOIN dbo.ClaimSetResourceClaimActions csrca
+                ON csrc.ClaimSet_ClaimSetId = csrca.ClaimSetId
+                    AND csrc.ResourceClaim_ResourceClaimId = csrca.ResourceClaimId
+                    AND csrc.Action_ActionId = csrca.ActionId
+            WHERE csrc.AuthorizationStrategyOverride_AuthorizationStrategyId IS NOT NULL
+        )
+        INSERT INTO dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides (
+            ClaimSetResourceClaimActionId,
+            AuthorizationStrategyId
+        )
+        SELECT
+            source.ClaimSetResourceClaimActionId,
+            source.AuthorizationStrategyOverride_AuthorizationStrategyId
+        FROM source
+        ON CONFLICT DO NOTHING;
+
+    END IF;
+END $$

--- a/Artifacts/PgSql/Data/Security/2030-DropSingleAuthStrategyTables.sql
+++ b/Artifacts/PgSql/Data/Security/2030-DropSingleAuthStrategyTables.sql
@@ -1,0 +1,7 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+DROP TABLE IF EXISTS dbo.ResourceClaimAuthorizationMetadatas;
+DROP TABLE IF EXISTS dbo.ClaimSetResourceClaims;

--- a/Artifacts/PgSql/Structure/Security/0050-AddUniqueConstraintResourceClaimsClaimName.sql
+++ b/Artifacts/PgSql/Structure/Security/0050-AddUniqueConstraintResourceClaimsClaimName.sql
@@ -1,0 +1,8 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+ALTER TABLE dbo.ResourceClaims ALTER COLUMN ResourceName TYPE VARCHAR(255);
+ALTER TABLE dbo.ResourceClaims ALTER COLUMN ClaimName TYPE VARCHAR(850);
+ALTER TABLE dbo.ResourceClaims ADD CONSTRAINT UC_ResourceClaims_ClaimName UNIQUE(ClaimName);

--- a/Artifacts/PgSql/Structure/Security/0050-Tables-MultipleAuthStrats.sql
+++ b/Artifacts/PgSql/Structure/Security/0050-Tables-MultipleAuthStrats.sql
@@ -1,0 +1,95 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+------------------------------ dbo.ResourceClaimActions -------------------------------------------------
+CREATE TABLE dbo.ResourceClaimActions(
+	ResourceClaimActionId SERIAL NOT NULL,
+	ResourceClaimId INT NOT NULL,
+	ActionId INT NOT NULL,
+	ValidationRuleSetName VARCHAR NULL,
+ CONSTRAINT ResourceClaimActionId_PK PRIMARY KEY
+(
+	ResourceClaimActionId 
+));
+
+CREATE UNIQUE INDEX IF NOT EXISTS ResourceClaimActions_UI_ResourceClaimId_ActionId ON dbo.ResourceClaimActions(ResourceClaimId,ActionId);
+
+ALTER TABLE dbo.ResourceClaimActions  ADD  CONSTRAINT FK_ResourceClaimActions_Actions FOREIGN KEY(ActionId)
+REFERENCES dbo.Actions (ActionId);
+
+
+ALTER TABLE dbo.ResourceClaimActions  ADD  CONSTRAINT FK_ResourceClaimActions_ResourceClaims FOREIGN KEY(ResourceClaimId)
+REFERENCES dbo.ResourceClaims (ResourceClaimId)
+ON DELETE CASCADE;
+
+---------------------------- dbo.ClaimSetResourceClaimActions --------------------------------------------------------
+
+CREATE TABLE dbo.ClaimSetResourceClaimActions(
+	ClaimSetResourceClaimActionId SERIAL NOT NULL,
+	ClaimSetId INT NOT NULL,
+	ResourceClaimId INT NOT NULL,
+	ActionId INT NOT NULL,
+	ValidationRuleSetNameOverride VARCHAR NULL,
+ CONSTRAINT ClaimSetResourceClaimActions_PK PRIMARY KEY  
+(
+	ClaimSetResourceClaimActionId 
+));
+
+CREATE UNIQUE INDEX IF NOT EXISTS ClaimSetResourceClaimActions_UI_ClaimSetId_ResourceClaimId_ActionId ON dbo.ClaimSetResourceClaimActions(ClaimSetId,ResourceClaimId,ActionId);
+
+ALTER TABLE dbo.ClaimSetResourceClaimActions ADD CONSTRAINT FK_ClaimSetResourceClaimActions_Actions FOREIGN KEY(ActionId)
+REFERENCES dbo.Actions (ActionId);
+
+
+ALTER TABLE dbo.ClaimSetResourceClaimActions ADD CONSTRAINT FK_ClaimSetResourceClaimActions_ClaimSets FOREIGN KEY(ClaimSetId)
+REFERENCES dbo.ClaimSets (ClaimSetId)
+ON DELETE CASCADE;
+
+ALTER TABLE dbo.ClaimSetResourceClaimActions  ADD  CONSTRAINT FK_ClaimSetResourceClaimActions_ResourceClaims FOREIGN KEY(ResourceClaimId)
+REFERENCES dbo.ResourceClaims (ResourceClaimId);
+
+
+
+---------------------------- dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides --------------------------------------------------------
+
+
+CREATE TABLE dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides(
+	ClaimSetResourceClaimActionAuthorizationStrategyOverrideId SERIAL NOT NULL,
+	ClaimSetResourceClaimActionId INT NOT NULL,
+	AuthorizationStrategyId INT NOT NULL,
+ CONSTRAINT ClaimSetResourceClaimActionAuthorizationStrategyOverrides_PK PRIMARY KEY  
+(
+	ClaimSetResourceClaimActionAuthorizationStrategyOverrideId 
+));
+
+CREATE UNIQUE INDEX IF NOT EXISTS ActionAuthorizationStrategyOverrides_UI_ClaimSetResourceClaimActionId_AuthorizationStrategyId ON dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides(ClaimSetResourceClaimActionId,AuthorizationStrategyId);
+
+ALTER TABLE dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides  ADD  CONSTRAINT FK_ActionAuthorizationStrategyOverrides_AuthorizationStrategies FOREIGN KEY(AuthorizationStrategyId)
+REFERENCES dbo.AuthorizationStrategies (AuthorizationStrategyId)
+ON DELETE CASCADE;
+
+
+ALTER TABLE dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides  ADD  CONSTRAINT FK_ActionAuthorizationStrategyOverrides_ActionAuthorizations FOREIGN KEY(ClaimSetResourceClaimActionId)
+REFERENCES dbo.ClaimSetResourceClaimActions (ClaimSetResourceClaimActionId);
+
+------------------------------ dbo.ResourceClaimActionAuthorizationStrategies -------------------------------------------------
+
+CREATE TABLE dbo.ResourceClaimActionAuthorizationStrategies(
+	ResourceClaimActionAuthorizationStrategyId SERIAL NOT NULL,
+	ResourceClaimActionId INT NOT NULL,
+	AuthorizationStrategyId INT NOT NULL,
+ CONSTRAINT ResourceClaimActionAuthorizationStrategies_PK PRIMARY KEY
+(
+	ResourceClaimActionAuthorizationStrategyId 
+));
+
+CREATE UNIQUE INDEX IF NOT EXISTS ResourceClaimActionAuthorizationStrategies_UI_ResourceClaimActionId_AuthorizationStrategyId ON dbo.ResourceClaimActionAuthorizationStrategies(ResourceClaimActionId,AuthorizationStrategyId);
+
+ALTER TABLE dbo.ResourceClaimActionAuthorizationStrategies   ADD  CONSTRAINT FK_ActionAuthorizationStrategies_AuthorizationStrategyId FOREIGN KEY(AuthorizationStrategyId)
+REFERENCES dbo.AuthorizationStrategies (AuthorizationStrategyId)
+ON DELETE CASCADE;
+
+ALTER TABLE dbo.ResourceClaimActionAuthorizationStrategies   ADD  CONSTRAINT FK_ActionAuthorizationStrategies_ActionAuthorizationId FOREIGN KEY(ResourceClaimActionId)
+REFERENCES dbo.ResourceClaimActions (ResourceClaimActionId);

--- a/Postman Test Suite/Ed-Fi ODS-API Integration Test Suite Multiple Edorg types.postman_collection.json
+++ b/Postman Test Suite/Ed-Fi ODS-API Integration Test Suite Multiple Edorg types.postman_collection.json
@@ -908,7 +908,7 @@
 											"",
 											"const responseItems = pm.response.json();",
 											"pm.test(\"Should match with Error Message Response \", () => {    ",
-											"        pm.expect(responseItems.message).to.equal(\"Authorization denied.  The claim does not have any established relationships with the requested resource.\");",
+											"        pm.expect(responseItems.message).to.equal(\"Authorization denied. No relationships have been established between the caller's education organization id claim (value 5001 of type 'CommunityProviderId') and one of the following properties of the requested resource: 'SchoolId', 'StudentUniqueId'.\");",
 											"});"
 										],
 										"type": "text/javascript"
@@ -1440,7 +1440,7 @@
 											"});",
 											"const responseItems = pm.response.json();",
 											"pm.test(\"Should match with Error Message Response \", () => {    ",
-											"        pm.expect(responseItems.message).to.equal(\"Authorization denied.  The claim does not have any established relationships with the requested resource.\");",
+											"        pm.expect(responseItems.message).to.equal(\"Authorization denied. No relationships have been established between the caller's education organization id claim (value 5001 of type 'CommunityProviderId') and the requested resource's 'SchoolId' value.\");",
 											"});"
 										],
 										"type": "text/javascript"
@@ -1600,7 +1600,7 @@
 											"});",
 											"const responseItems = pm.response.json();",
 											"pm.test(\"Should match with Error Message Response \", () => {    ",
-											"        pm.expect(responseItems.message).to.equal(\"Authorization denied.  The claim does not have any established relationships with the requested resource.\");",
+											"        pm.expect(responseItems.message).to.equal(\"Authorization denied. No relationships have been established between the caller's education organization id claim (value 255901001 of type 'SchoolId') and the requested resource's 'CommunityProviderId' value.\");",
 											"});"
 										],
 										"type": "text/javascript"

--- a/Postman Test Suite/Ed-Fi ODS-API Integration Test Suite.postman_collection.json
+++ b/Postman Test Suite/Ed-Fi ODS-API Integration Test Suite.postman_collection.json
@@ -468,7 +468,7 @@
 									"pm.test(\"Should return the item with Invalid SchoolId Validation string\", () => {",
 									"     ",
 									"     const responseItem = pm.response.json();",
-									"     pm.expect(responseItem.message).to.include(\"Authorization denied.  The claim does not have any established relationships with the requested resource\");",
+									"     pm.expect(responseItem.message).to.include(\"Authorization denied. No relationships have been established between the caller's education organization id claim (value 255901 of type 'LocalEducationAgencyId') and the requested resource's 'SchoolId' value.\");",
 									"      ",
 									"});"
 								],

--- a/Postman Test Suite/Record Ownership Test/Ed-Fi ODS-API Record Ownership Test Suite.postman_collection.json
+++ b/Postman Test Suite/Record Ownership Test/Ed-Fi ODS-API Record Ownership Test Suite.postman_collection.json
@@ -1,0 +1,5240 @@
+{
+	"info": {
+		"_postman_id": "11fa3e51-ecff-49d9-9b3e-ce254099602d",
+		"name": "Ed-Fi ODS/API Record Ownership Test Suite",
+		"description": "Localhost integration testing using Postman Scripts",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Record Ownership",
+			"item": [
+				{
+					"name": "Initial Setup",
+					"item": [
+						{
+							"name": "Initialize Education Organization Ids",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.environment.set('known:localEducationAgencyId',255901);\r",
+											"pm.environment.set('known:schoolId_9011',9011);\r",
+											"pm.environment.set('known:schoolId_9021',9021);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{AccessToken_255901-A}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{ApiBaseUrl}}",
+									"host": [
+										"{{ApiBaseUrl}}"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Derived Resource",
+					"item": [
+						{
+							"name": "Client 1 has full CRUD - School 1",
+							"item": [
+								{
+									"name": "Create  School",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const uuid = require('uuid');",
+													"function newGuid() { return uuid.v4().toString().replace(/[^a-zA-Z0-9 ]/g,\"\"); }",
+													"function createScenarioId() { return newGuid().substring(0,5); }",
+													"pm.environment.set('scenarioId', createScenarioId());",
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"",
+													"pm.environment.set('supplied:'+scenarioId+':nameOfInstitution', 'SCH-9011');",
+													"pm.environment.set('supplied:'+scenarioId+':educationOrganizationCategoryDescriptor', \"uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Local Education Agency\");",
+													"pm.environment.set('supplied:'+scenarioId+':gradeLevelDescriptor', \"uri://ed-fi.org/GradeLevelDescriptor#Adult Education\");",
+													"pm.environment.set('supplied:'+scenarioId+':schoolCategoryDescriptor', \"uri://ed-fi.org/SchoolCategoryDescriptor#Adult School\");",
+													"pm.environment.set('supplied:'+scenarioId+':schoolTypeDescriptor', \"uri://ed-fi.org/SchoolTypeDescriptor#Regular\");",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"    pm.expect(pm.response.code).to.equal(201);",
+													"});",
+													"",
+													"pm.environment.set('known:School1:schoolGuid',pm.response.headers.one('Location').value.split(\"/\").pop());"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"educationOrganizationCategories\": [\r\n    {\r\n      \"educationOrganizationCategoryDescriptor\":  \"{{supplied:{{scenarioId}}:educationOrganizationCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n   \"gradeLevels\": [\r\n    {\r\n      \"gradeLevelDescriptor\":  \"{{supplied:{{scenarioId}}:gradeLevelDescriptor}}\"\r\n    }\r\n  ],\r\n  \"schoolId\":  \"{{known:schoolId_9011}}\",\r\n  \"localEducationAgencyReference\": {\r\n    \"localEducationAgencyId\": \"{{known:localEducationAgencyId}}\"\r\n  },\r\n  \"nameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\",\r\n  \"schoolCategories\": [\r\n    {\r\n      \"schoolCategoryDescriptor\": \"{{supplied:{{scenarioId}}:schoolCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n  \"schoolTypeDescriptor\": \"{{supplied:{{scenarioId}}:schoolTypeDescriptor}}\",\r\n  \"shortNameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\"\r\n\r\n}"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Get School",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"",
+													"const responseItems = pm.response.json();",
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"",
+													"pm.test(\"Should match with Schools Response \", () => {    ",
+													"",
+													"        pm.expect(responseItems.nameOfInstitution).to.equal(pm.environment.get('supplied:'+scenarioId+':nameOfInstitution').toString());",
+													"        pm.expect(responseItems.educationOrganizationCategories[0].educationOrganizationCategoryDescriptor).to.equal(pm.environment.get('supplied:'+scenarioId+':educationOrganizationCategoryDescriptor'));",
+													"        pm.expect(responseItems.gradeLevels[0].gradeLevelDescriptor).to.equal(pm.environment.get('supplied:'+scenarioId+':gradeLevelDescriptor'));",
+													"        pm.expect(responseItems.schoolCategories[0].schoolCategoryDescriptor).to.equal(pm.environment.get('supplied:'+scenarioId+':schoolCategoryDescriptor'));",
+													"        pm.expect(responseItems.schoolTypeDescriptor).to.equal(pm.environment.get('supplied:'+scenarioId+':schoolTypeDescriptor'));",
+													"",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools/{{known:School1:schoolGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools",
+												"{{known:School1:schoolGuid}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update  School",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 204\", () => {",
+													"    pm.expect(pm.response.code).to.equal(204);",
+													"});",
+													"",
+													"let SchoolsGetRequest = {",
+													"    url: pm.environment.get(\"ApiBaseUrl\") + \"/data/v3/ed-fi/schools/\"+ pm.environment.get(\"known:School1:schoolGuid\"),",
+													"    method: 'GET',",
+													"    header: 'Authorization:bearer ' + pm.environment.get(\"AccessToken_255901-A\"),",
+													"    body: {}",
+													"};",
+													"",
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"pm.test('nameOfInstitution contains substring of \"updated\"  ', () => {",
+													"",
+													"    pm.sendRequest(SchoolsGetRequest, function (err, Schools) {",
+													"        if (err) {",
+													"            console.log(err);",
+													"        } else {",
+													"            const responseItem = Schools.json();",
+													"                pm.expect(responseItem.nameOfInstitution).to.equal('Updated '+pm.environment.get('supplied:'+scenarioId+':nameOfInstitution').toString());",
+													"        }",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"educationOrganizationCategories\": [\r\n    {\r\n      \"educationOrganizationCategoryDescriptor\":  \"{{supplied:{{scenarioId}}:educationOrganizationCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n   \"gradeLevels\": [\r\n    {\r\n      \"gradeLevelDescriptor\":  \"{{supplied:{{scenarioId}}:gradeLevelDescriptor}}\"\r\n    }\r\n  ],\r\n \r\n  \"nameOfInstitution\":  \"Updated {{supplied:{{scenarioId}}:nameOfInstitution}}\",\r\n  \"schoolCategories\": [\r\n    {\r\n      \"schoolCategoryDescriptor\": \"{{supplied:{{scenarioId}}:schoolCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n  \"shortNameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\",\r\n  \"schoolTypeDescriptor\": \"{{supplied:{{scenarioId}}:schoolTypeDescriptor}}\"\r\n}"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools/{{known:School1:schoolGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools",
+												"{{known:School1:schoolGuid}}"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Delete  School",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 204\", () => {",
+													"    pm.expect(pm.response.code).to.equal(204);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools/{{known:School1:schoolGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools",
+												"{{known:School1:schoolGuid}}"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Client 2 has full CRUD - School 1 also",
+							"item": [
+								{
+									"name": "Create  School using Client 1",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const uuid = require('uuid');",
+													"function newGuid() { return uuid.v4().toString().replace(/[^a-zA-Z0-9 ]/g,\"\"); }",
+													"function createScenarioId() { return newGuid().substring(0,5); }",
+													"pm.environment.set('scenarioId', createScenarioId());",
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"",
+													"pm.environment.set('supplied:'+scenarioId+':nameOfInstitution', 'SCH-9011');",
+													"pm.environment.set('supplied:'+scenarioId+':educationOrganizationCategoryDescriptor', \"uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Local Education Agency\");",
+													"pm.environment.set('supplied:'+scenarioId+':gradeLevelDescriptor', \"uri://ed-fi.org/GradeLevelDescriptor#Adult Education\");",
+													"pm.environment.set('supplied:'+scenarioId+':schoolCategoryDescriptor', \"uri://ed-fi.org/SchoolCategoryDescriptor#Adult School\");",
+													"pm.environment.set('supplied:'+scenarioId+':schoolTypeDescriptor', \"uri://ed-fi.org/SchoolTypeDescriptor#Regular\");",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"    pm.expect(pm.response.code).to.equal(201);",
+													"});",
+													"",
+													"pm.environment.set('known:School1:schoolGuid',pm.response.headers.one('Location').value.split(\"/\").pop());",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"educationOrganizationCategories\": [\r\n    {\r\n      \"educationOrganizationCategoryDescriptor\":  \"{{supplied:{{scenarioId}}:educationOrganizationCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n   \"gradeLevels\": [\r\n    {\r\n      \"gradeLevelDescriptor\":  \"{{supplied:{{scenarioId}}:gradeLevelDescriptor}}\"\r\n    }\r\n  ],\r\n  \"schoolId\":  \"{{known:schoolId_9011}}\",\r\n  \"localEducationAgencyReference\": {\r\n    \"localEducationAgencyId\": \"{{known:localEducationAgencyId}}\"\r\n  },\r\n  \"nameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\",\r\n  \"schoolCategories\": [\r\n    {\r\n      \"schoolCategoryDescriptor\": \"{{supplied:{{scenarioId}}:schoolCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n  \"schoolTypeDescriptor\": \"{{supplied:{{scenarioId}}:schoolTypeDescriptor}}\",\r\n  \"shortNameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\"\r\n\r\n}"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Update  School",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"pm.environment.set('known:School1:schoolGuid',pm.response.headers.one('Location').value.split(\"/\").pop());",
+													"",
+													"let SchoolsGetRequest = {",
+													"    url: pm.environment.get(\"ApiBaseUrl\") + \"/data/v3/ed-fi/schools/\"+ pm.environment.get(\"known:School1:schoolGuid\"),",
+													"    method: 'GET',",
+													"    header: 'Authorization:bearer ' + pm.environment.get(\"AccessToken_255901-B\"),",
+													"    body: {}",
+													"};",
+													"",
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"pm.test('nameOfInstitution contains substring of \"updated\"  ', () => {",
+													"",
+													"    pm.sendRequest(SchoolsGetRequest, function (err, Schools) {",
+													"        if (err) {",
+													"            console.log(err);",
+													"        } else {",
+													"            const responseItem = Schools.json();",
+													"                pm.expect(responseItem.nameOfInstitution).to.equal('Updated '+pm.environment.get('supplied:'+scenarioId+':nameOfInstitution').toString());",
+													"        }",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"educationOrganizationCategories\": [\r\n    {\r\n      \"educationOrganizationCategoryDescriptor\":  \"{{supplied:{{scenarioId}}:educationOrganizationCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n   \"gradeLevels\": [\r\n    {\r\n      \"gradeLevelDescriptor\":  \"{{supplied:{{scenarioId}}:gradeLevelDescriptor}}\"\r\n    }\r\n  ],\r\n  \"schoolId\":  \"{{known:schoolId_9011}}\",\r\n  \"localEducationAgencyReference\": {\r\n    \"localEducationAgencyId\": \"{{known:localEducationAgencyId}}\"\r\n  },\r\n  \"nameOfInstitution\":  \"Updated {{supplied:{{scenarioId}}:nameOfInstitution}}\",\r\n  \"schoolCategories\": [\r\n    {\r\n      \"schoolCategoryDescriptor\": \"{{supplied:{{scenarioId}}:schoolCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n  \"schoolTypeDescriptor\": \"{{supplied:{{scenarioId}}:schoolTypeDescriptor}}\",\r\n  \"shortNameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\"\r\n\r\n}"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Get School",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"",
+													"const responseItems = pm.response.json();",
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"",
+													"pm.test(\"Should match with Schools Response \", () => {    ",
+													"",
+													"        pm.expect(responseItems.nameOfInstitution).to.equal('Updated '+pm.environment.get('supplied:'+scenarioId+':nameOfInstitution').toString());",
+													"        pm.expect(responseItems.educationOrganizationCategories[0].educationOrganizationCategoryDescriptor).to.equal(pm.environment.get('supplied:'+scenarioId+':educationOrganizationCategoryDescriptor'));",
+													"        pm.expect(responseItems.gradeLevels[0].gradeLevelDescriptor).to.equal(pm.environment.get('supplied:'+scenarioId+':gradeLevelDescriptor'));",
+													"        pm.expect(responseItems.schoolCategories[0].schoolCategoryDescriptor).to.equal(pm.environment.get('supplied:'+scenarioId+':schoolCategoryDescriptor'));",
+													"        pm.expect(responseItems.schoolTypeDescriptor).to.equal(pm.environment.get('supplied:'+scenarioId+':schoolTypeDescriptor'));",
+													"",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools/{{known:School1:schoolGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools",
+												"{{known:School1:schoolGuid}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update  School",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 204\", () => {",
+													"    pm.expect(pm.response.code).to.equal(204);",
+													"});",
+													"",
+													"",
+													"let SchoolsGetRequest = {",
+													"    url: pm.environment.get(\"ApiBaseUrl\") + \"/data/v3/ed-fi/schools/\"+ pm.environment.get(\"known:School1:schoolGuid\"),",
+													"    method: 'GET',",
+													"    header: 'Authorization:bearer ' + pm.environment.get(\"AccessToken_255901-B\"),",
+													"    body: {}",
+													"};",
+													"",
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"pm.test('nameOfInstitution contains substring of \"updated\"  ', () => {",
+													"",
+													"    pm.sendRequest(SchoolsGetRequest, function (err, Schools) {",
+													"        if (err) {",
+													"            console.log(err);",
+													"        } else {",
+													"            const responseItem = Schools.json();",
+													"                pm.expect(responseItem.nameOfInstitution).to.equal('Re-Updated '+pm.environment.get('supplied:'+scenarioId+':nameOfInstitution').toString());",
+													"        }",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"educationOrganizationCategories\": [\r\n    {\r\n      \"educationOrganizationCategoryDescriptor\":  \"{{supplied:{{scenarioId}}:educationOrganizationCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n   \"gradeLevels\": [\r\n    {\r\n      \"gradeLevelDescriptor\":  \"{{supplied:{{scenarioId}}:gradeLevelDescriptor}}\"\r\n    }\r\n  ],\r\n \r\n  \"nameOfInstitution\":  \"Re-Updated {{supplied:{{scenarioId}}:nameOfInstitution}}\",\r\n\r\n  \"shortNameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\"\r\n\r\n}"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools/{{known:School1:schoolGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools",
+												"{{known:School1:schoolGuid}}"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Delete  School",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 204\", () => {",
+													"    pm.expect(pm.response.code).to.equal(204);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools/{{known:School1:schoolGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools",
+												"{{known:School1:schoolGuid}}"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Client 2 has full CRUD - School 2",
+							"item": [
+								{
+									"name": "Create  School",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const uuid = require('uuid');",
+													"function newGuid() { return uuid.v4().toString().replace(/[^a-zA-Z0-9 ]/g,\"\"); }",
+													"function createScenarioId() { return newGuid().substring(0,5); }",
+													"pm.environment.set('scenarioId', createScenarioId());",
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"pm.environment.set('supplied:'+scenarioId+':nameOfInstitution', 'SCH-9021');",
+													"pm.environment.set('supplied:'+scenarioId+':educationOrganizationCategoryDescriptor', \"uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Local Education Agency\");",
+													"pm.environment.set('supplied:'+scenarioId+':gradeLevelDescriptor', \"uri://ed-fi.org/GradeLevelDescriptor#Adult Education\");",
+													"pm.environment.set('supplied:'+scenarioId+':schoolCategoryDescriptor', \"uri://ed-fi.org/SchoolCategoryDescriptor#Adult School\");",
+													"pm.environment.set('supplied:'+scenarioId+':schoolTypeDescriptor', \"uri://ed-fi.org/SchoolTypeDescriptor#Regular\");",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"    pm.expect(pm.response.code).to.equal(201);",
+													"});",
+													"pm.environment.set('known:School2:schoolGuid',pm.response.headers.one('Location').value.split(\"/\").pop());"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"educationOrganizationCategories\": [\r\n    {\r\n      \"educationOrganizationCategoryDescriptor\":  \"{{supplied:{{scenarioId}}:educationOrganizationCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n   \"gradeLevels\": [\r\n    {\r\n      \"gradeLevelDescriptor\":  \"{{supplied:{{scenarioId}}:gradeLevelDescriptor}}\"\r\n    }\r\n  ],\r\n  \"schoolId\":  \"{{known:schoolId_9021}}\",\r\n  \"localEducationAgencyReference\": {\r\n    \"localEducationAgencyId\": \"{{known:localEducationAgencyId}}\"\r\n  },\r\n  \"nameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\",\r\n  \"schoolCategories\": [\r\n    {\r\n      \"schoolCategoryDescriptor\": \"{{supplied:{{scenarioId}}:schoolCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n  \"schoolTypeDescriptor\": \"{{supplied:{{scenarioId}}:schoolTypeDescriptor}}\",\r\n  \"shortNameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\"\r\n\r\n}"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Get School",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"",
+													"const responseItems = pm.response.json();",
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"",
+													"pm.test(\"Should match with Schools Response \", () => {    ",
+													"",
+													"        pm.expect(responseItems.nameOfInstitution).to.equal(pm.environment.get('supplied:'+scenarioId+':nameOfInstitution').toString());",
+													"        pm.expect(responseItems.educationOrganizationCategories[0].educationOrganizationCategoryDescriptor).to.equal(pm.environment.get('supplied:'+scenarioId+':educationOrganizationCategoryDescriptor'));",
+													"        pm.expect(responseItems.gradeLevels[0].gradeLevelDescriptor).to.equal(pm.environment.get('supplied:'+scenarioId+':gradeLevelDescriptor'));",
+													"        pm.expect(responseItems.schoolCategories[0].schoolCategoryDescriptor).to.equal(pm.environment.get('supplied:'+scenarioId+':schoolCategoryDescriptor'));",
+													"        pm.expect(responseItems.schoolTypeDescriptor).to.equal(pm.environment.get('supplied:'+scenarioId+':schoolTypeDescriptor'));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools/{{known:School2:schoolGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools",
+												"{{known:School2:schoolGuid}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update  School",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 204\", () => {",
+													"    pm.expect(pm.response.code).to.equal(204);",
+													"});",
+													"",
+													"let SchoolsGetRequest = {",
+													"    url: pm.environment.get(\"ApiBaseUrl\") + \"/data/v3/ed-fi/schools/\"+ pm.environment.get(\"known:School2:schoolGuid\"),",
+													"    method: 'GET',",
+													"    header: 'Authorization:bearer ' + pm.environment.get(\"AccessToken_255901-B\"),",
+													"    body: {}",
+													"};",
+													"",
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"pm.test('nameOfInstitution contains substring of \"updated\"  ', () => {",
+													"",
+													"    pm.sendRequest(SchoolsGetRequest, function (err, Schools) {",
+													"        if (err) {",
+													"            console.log(err);",
+													"        } else {",
+													"            const responseItem = Schools.json();",
+													"                pm.expect(responseItem.nameOfInstitution).to.equal('Updated '+pm.environment.get('supplied:'+scenarioId+':nameOfInstitution').toString());",
+													"        }",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"educationOrganizationCategories\": [\r\n    {\r\n      \"educationOrganizationCategoryDescriptor\":  \"{{supplied:{{scenarioId}}:educationOrganizationCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n   \"gradeLevels\": [\r\n    {\r\n      \"gradeLevelDescriptor\":  \"{{supplied:{{scenarioId}}:gradeLevelDescriptor}}\"\r\n    }\r\n  ],\r\n \r\n  \"nameOfInstitution\":  \"Updated {{supplied:{{scenarioId}}:nameOfInstitution}}\",\r\n\r\n  \"shortNameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\"\r\n\r\n}"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools/{{known:School2:schoolGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools",
+												"{{known:School2:schoolGuid}}"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Delete  School",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 204\", () => {",
+													"    pm.expect(pm.response.code).to.equal(204);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools/{{known:School2:schoolGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools",
+												"{{known:School2:schoolGuid}}"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Client 1 not full CRUD - School 2",
+							"item": [
+								{
+									"name": "Create  School using Client 2",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const uuid = require('uuid');",
+													"function newGuid() { return uuid.v4().toString().replace(/[^a-zA-Z0-9 ]/g,\"\"); }",
+													"function createScenarioId() { return newGuid().substring(0,5); }",
+													"pm.environment.set('scenarioId', createScenarioId());",
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"pm.environment.set('supplied:'+scenarioId+':nameOfInstitution', 'SCH-9021');",
+													"pm.environment.set('supplied:'+scenarioId+':educationOrganizationCategoryDescriptor', \"uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Local Education Agency\");",
+													"pm.environment.set('supplied:'+scenarioId+':gradeLevelDescriptor', \"uri://ed-fi.org/GradeLevelDescriptor#Adult Education\");",
+													"pm.environment.set('supplied:'+scenarioId+':schoolCategoryDescriptor', \"uri://ed-fi.org/SchoolCategoryDescriptor#Adult School\");",
+													"pm.environment.set('supplied:'+scenarioId+':schoolTypeDescriptor', \"uri://ed-fi.org/SchoolTypeDescriptor#Regular\");",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"    pm.expect(pm.response.code).to.equal(201);",
+													"});",
+													"",
+													"pm.environment.set('known:School2:schoolGuid',pm.response.headers.one('Location').value.split(\"/\").pop());"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"educationOrganizationCategories\": [\r\n    {\r\n      \"educationOrganizationCategoryDescriptor\":  \"{{supplied:{{scenarioId}}:educationOrganizationCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n   \"gradeLevels\": [\r\n    {\r\n      \"gradeLevelDescriptor\":  \"{{supplied:{{scenarioId}}:gradeLevelDescriptor}}\"\r\n    }\r\n  ],\r\n  \"schoolId\":  \"{{known:schoolId_9021}}\",\r\n  \"localEducationAgencyReference\": {\r\n    \"localEducationAgencyId\": \"{{known:localEducationAgencyId}}\"\r\n  },\r\n  \"nameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\",\r\n  \"schoolCategories\": [\r\n    {\r\n      \"schoolCategoryDescriptor\": \"{{supplied:{{scenarioId}}:schoolCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n  \"schoolTypeDescriptor\": \"{{supplied:{{scenarioId}}:schoolTypeDescriptor}}\",\r\n  \"shortNameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\"\r\n\r\n}"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Update  School",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 403\", () => {",
+													"    pm.expect(pm.response.code).to.equal(403);",
+													"});",
+													"",
+													"const responseItem = pm.response.json();",
+													"",
+													"pm.test(\"Should match with caller's ownership tokens Error Response \", () => {    ",
+													"    pm.expect(responseItem.message).to.equal(\"Access to the resource item could not be authorized using any of the caller's ownership tokens.\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"educationOrganizationCategories\": [\r\n    {\r\n      \"educationOrganizationCategoryDescriptor\":  \"{{supplied:{{scenarioId}}:educationOrganizationCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n   \"gradeLevels\": [\r\n    {\r\n      \"gradeLevelDescriptor\":  \"{{supplied:{{scenarioId}}:gradeLevelDescriptor}}\"\r\n    }\r\n  ],\r\n  \"schoolId\":  \"{{known:schoolId_9021}}\",\r\n  \"localEducationAgencyReference\": {\r\n    \"localEducationAgencyId\": \"{{known:localEducationAgencyId}}\"\r\n  },\r\n  \"nameOfInstitution\":  \"Updated {{supplied:{{scenarioId}}:nameOfInstitution}}\",\r\n  \"schoolCategories\": [\r\n    {\r\n      \"schoolCategoryDescriptor\": \"{{supplied:{{scenarioId}}:schoolCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n  \"schoolTypeDescriptor\": \"{{supplied:{{scenarioId}}:schoolTypeDescriptor}}\",\r\n  \"shortNameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\"\r\n\r\n}"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Get School",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 403\", () => {",
+													"    pm.expect(pm.response.code).to.equal(403);",
+													"});",
+													"",
+													"const responseItem = pm.response.json();",
+													"",
+													"pm.test(\"Should match with caller's ownership tokens Error Response \", () => {    ",
+													"    pm.expect(responseItem.message).to.equal(\"Access to the resource item could not be authorized using any of the caller's ownership tokens.\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools/{{known:School2:schoolGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools",
+												"{{known:School2:schoolGuid}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update  School",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"const uuid = require('uuid');",
+													"function newGuid() { return uuid.v4().toString().replace(/[^a-zA-Z0-9 ]/g,\"\"); }",
+													"pm.environment.set('supplied:'+scenarioId+':nameOfInstitution',newGuid());",
+													"",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 403\", () => {",
+													"    pm.expect(pm.response.code).to.equal(403);",
+													"});",
+													"",
+													"const responseItem = pm.response.json();",
+													"",
+													"pm.test(\"Should match with caller's ownership tokens Error Response \", () => {    ",
+													"    pm.expect(responseItem.message).to.equal(\"Access to the resource item could not be authorized using any of the caller's ownership tokens.\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"educationOrganizationCategories\": [\r\n    {\r\n      \"educationOrganizationCategoryDescriptor\":  \"{{supplied:{{scenarioId}}:educationOrganizationCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n   \"gradeLevels\": [\r\n    {\r\n      \"gradeLevelDescriptor\":  \"{{supplied:{{scenarioId}}:gradeLevelDescriptor}}\"\r\n    }\r\n  ],\r\n \r\n  \"nameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\",\r\n\r\n  \"shortNameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\"\r\n\r\n}"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools/{{known:School2:schoolGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools",
+												"{{known:School2:schoolGuid}}"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Delete  School",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"",
+													"",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 403\", () => {",
+													"    pm.expect(pm.response.code).to.equal(403);",
+													"});",
+													"",
+													"const responseItem = pm.response.json();",
+													"",
+													"pm.test(\"Should match with caller's ownership tokens Error Response \", () => {    ",
+													"    pm.expect(responseItem.message).to.equal(\"Access to the resource item could not be authorized using any of the caller's ownership tokens.\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools/{{known:School2:schoolGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools",
+												"{{known:School2:schoolGuid}}"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Clean up",
+							"item": [
+								{
+									"name": "Clean up School",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"",
+													"const responseItems = pm.response.json();",
+													"",
+													"pm.test('Delete schools with school Id 9021', () => {",
+													"",
+													"           responseItems.forEach(responseItem => {",
+													"            ",
+													"            if(isNaN(responseItem.id))",
+													"            {",
+													"                let SchoolDeleteRequest = {",
+													"                        url: pm.environment.get(\"ApiBaseUrl\") + \"/data/v3/ed-fi/schools/\" + responseItem.id,",
+													"                        method: 'DELETE',",
+													"                        header: 'Authorization:bearer ' + pm.environment.get(\"AccessToken_255901-B\"),",
+													"                        body: {}",
+													"                };",
+													"    ",
+													"                pm.sendRequest(SchoolDeleteRequest, function (err, SchoolDelete) {",
+													"                        if (err) {",
+													"                            console.log(err);",
+													"                        } else {}",
+													"                    });",
+													"           }",
+													"        });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools/?schoolid={{known:schoolId_9021}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools",
+												""
+											],
+											"query": [
+												{
+													"key": "schoolid",
+													"value": "{{known:schoolId_9021}}"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"  //--Client 1 should be able to full CRUD their School 1.",
+									"  //--Derived Resource -Client 1 has full CRUD - School 1",
+									" // --Client 2 should be able to full CRUD School 2.",
+									"  //--Derived Resource -Client 2 has full CRUD - School 2",
+									"  //--Assuming Client 2 is assigned the extra ownership token, it should also be able to full CRUD School 1. ",
+									"  //--But Client 1, without the assignment to Ownership Token 2, should not be able to CRUD School 2."
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Regular Resource",
+					"item": [
+						{
+							"name": "Initial Setup StudentSectionAssociation one",
+							"item": [
+								{
+									"name": "Create Student",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"        pm.expect(pm.response.code).to.equal(201);",
+													"    });   ",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const uuid = require('uuid');",
+													"function newGuid() { return uuid.v4().toString().replace(/[^a-zA-Z0-9 ]/g,\"\"); }",
+													"function createScenarioId() { return newGuid().substring(0,5); }",
+													"pm.environment.set('scenarioId', createScenarioId());",
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"pm.environment.set('supplied:'+scenarioId+':StudentUniqueId', newGuid());",
+													"pm.environment.set('known:StudentUniqueIdOne', pm.environment.get('supplied:'+scenarioId+':StudentUniqueId'));",
+													"pm.environment.set('supplied:'+scenarioId+':LastSurname',newGuid());",
+													"pm.environment.set('supplied:'+scenarioId+':FirstName',newGuid());",
+													"",
+													"const moment = require('moment');",
+													"let birthDate=new Date();",
+													"birthDate = birthDate.addYears(-20);",
+													"birthDate= moment(birthDate).format(\"YYYY-MM-DD\");",
+													"pm.environment.set('supplied:'+scenarioId+':BirthDate',birthDate);",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n   \"studentUniqueId\": \"{{supplied:{{scenarioId}}:StudentUniqueId}}\",\r\n  \"birthDate\":\"{{supplied:{{scenarioId}}:BirthDate}}\",\r\n  \"firstName\": \"{{supplied:{{scenarioId}}:FirstName}}\",\r\n  \"lastSurname\": \"{{supplied:{{scenarioId}}:LastSurname}}\"\r\n  }\r\n"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/students",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"students"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create  School",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"pm.environment.set('supplied:'+scenarioId+':nameOfInstitution', 'SCH-9011');",
+													"pm.environment.set('supplied:'+scenarioId+':educationOrganizationCategoryDescriptor', \"uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Local Education Agency\");",
+													"pm.environment.set('supplied:'+scenarioId+':gradeLevelDescriptor', \"uri://ed-fi.org/GradeLevelDescriptor#Adult Education\");",
+													"pm.environment.set('supplied:'+scenarioId+':schoolCategoryDescriptor', \"uri://ed-fi.org/SchoolCategoryDescriptor#Adult School\");",
+													"pm.environment.set('supplied:'+scenarioId+':schoolTypeDescriptor', \"uri://ed-fi.org/SchoolTypeDescriptor#Regular\");",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"    pm.expect(pm.response.code).to.equal(201);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"educationOrganizationCategories\": [\r\n    {\r\n      \"educationOrganizationCategoryDescriptor\":  \"{{supplied:{{scenarioId}}:educationOrganizationCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n   \"gradeLevels\": [\r\n    {\r\n      \"gradeLevelDescriptor\":  \"{{supplied:{{scenarioId}}:gradeLevelDescriptor}}\"\r\n    }\r\n  ],\r\n  \"schoolId\":  \"{{known:schoolId_9011}}\",\r\n  \"localEducationAgencyReference\": {\r\n    \"localEducationAgencyId\": \"{{known:localEducationAgencyId}}\"\r\n  },\r\n  \"nameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\",\r\n  \"schoolCategories\": [\r\n    {\r\n      \"schoolCategoryDescriptor\": \"{{supplied:{{scenarioId}}:schoolCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n  \"schoolTypeDescriptor\": \"{{supplied:{{scenarioId}}:schoolTypeDescriptor}}\",\r\n  \"shortNameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\"\r\n\r\n}"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Create gradingPeriods",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"        pm.expect(pm.response.code).to.equal(201);",
+													"});  "
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n        \"schoolReference\": {\r\n            \"schoolId\": \"{{known:schoolId_9011}}\"\r\n        },\r\n        \"schoolYearTypeReference\": {\r\n            \"schoolYear\": 2022\r\n        },\r\n        \"gradingPeriodDescriptor\": \"uri://ed-fi.org/GradingPeriodDescriptor#First Six Weeks\",\r\n        \"periodSequence\": 1,\r\n        \"beginDate\": \"2021-08-23\",\r\n        \"endDate\": \"2021-10-03\",\r\n        \"totalInstructionalDays\": 99\r\n    }"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/gradingPeriods",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"gradingPeriods"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Create Session",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"        pm.expect(pm.response.code).to.equal(201);",
+													"    });"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n        \"schoolReference\": {\r\n            \"schoolId\": \"{{known:schoolId_9011}}\"\r\n        },\r\n        \"schoolYearTypeReference\": {\r\n            \"schoolYear\": 2022\r\n        },\r\n        \"sessionName\": \"2021-2022 Fall Semester Record Ownership\",\r\n        \"beginDate\": \"2021-08-23\",\r\n        \"endDate\": \"2021-12-17\",\r\n        \"termDescriptor\": \"uri://ed-fi.org/TermDescriptor#Fall Semester\",\r\n        \"totalInstructionalDays\": 81,\r\n        \"academicWeeks\": [],\r\n        \"gradingPeriods\": [\r\n            {\r\n                \"gradingPeriodReference\": {\r\n                    \"schoolId\": \"{{known:schoolId_9011}}\",\r\n                    \"schoolYear\": 2022,\r\n                    \"gradingPeriodDescriptor\": \"uri://ed-fi.org/GradingPeriodDescriptor#First Six Weeks\",\r\n                    \"periodSequence\": 1\r\n                }\r\n            }\r\n        ]\r\n    }"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/sessions",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"sessions"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Create Course",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"    pm.expect(pm.response.code).to.equal(201);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n        \"educationOrganizationReference\": {\r\n            \"educationOrganizationId\": \"{{known:schoolId_9011}}\"\r\n        },\r\n        \"courseCode\": \"RecordOwnership\",\r\n        \"academicSubjectDescriptor\": \"uri://ed-fi.org/AcademicSubjectDescriptor#Mathematics\",\r\n        \"courseDefinedByDescriptor\": \"uri://ed-fi.org/CourseDefinedByDescriptor#SEA\",\r\n        \"courseDescription\": \"Algebra I\",\r\n        \"courseGPAApplicabilityDescriptor\": \"uri://ed-fi.org/CourseGPAApplicabilityDescriptor#Applicable\",\r\n        \"courseTitle\": \"Algebra I\",\r\n        \"identificationCodes\": [\r\n            {\r\n                \"courseIdentificationSystemDescriptor\": \"uri://ed-fi.org/CourseIdentificationSystemDescriptor#LEA course code\",\r\n                \"courseCatalogURL\": \"http://www.GBISD.edu/coursecatalog\",\r\n                \"identificationCode\": \"ALG-1\"\r\n            },\r\n            {\r\n                \"courseIdentificationSystemDescriptor\": \"uri://ed-fi.org/CourseIdentificationSystemDescriptor#State course code\",\r\n                \"identificationCode\": \"03100500\"\r\n            }\r\n        ]\r\n\r\n    }"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/courses",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"courses"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Create CourseOfferings",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"        pm.expect(pm.response.code).to.equal(201);",
+													"    });"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n        \"courseReference\": {\r\n            \"courseCode\": \"RecordOwnership\",\r\n            \"educationOrganizationId\": \"{{known:schoolId_9011}}\"\r\n        },\r\n        \"schoolReference\": {\r\n            \"schoolId\": \"{{known:schoolId_9011}}\"\r\n        },\r\n        \"sessionReference\": {\r\n            \"schoolId\": \"{{known:schoolId_9011}}\",\r\n            \"schoolYear\": 2022,\r\n            \"sessionName\": \"2021-2022 Fall Semester Record Ownership\"\r\n        },\r\n        \"localCourseCode\": \"RecordOwnership\"\r\n    }"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/courseOfferings",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"courseOfferings"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Create Section",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"    pm.expect(pm.response.code).to.equal(201);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const uuid = require('uuid');\r",
+													"function newGuid() { return uuid.v4().toString().replace(/[^a-zA-Z0-9 ]/g,\"\"); }\r",
+													"\r",
+													"const scenarioId = pm.environment.get('scenarioId');\r",
+													"pm.environment.set('supplied:'+scenarioId+':sectionIdentifier', newGuid());"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n        \"courseOfferingReference\": {\r\n            \"localCourseCode\": \"RecordOwnership\",\r\n            \"schoolId\": \"{{known:schoolId_9011}}\",\r\n            \"schoolYear\": 2022,\r\n            \"sessionName\": \"2021-2022 Fall Semester Record Ownership\"\r\n        },\r\n        \"sectionIdentifier\": \"{{supplied:{{scenarioId}}:sectionIdentifier}}\"\r\n}"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/sections",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"sections"
+											],
+											"query": [
+												{
+													"key": "schoolId",
+													"value": "{{known:schoolId_9011}}",
+													"disabled": true
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Initial Section Data",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"        pm.expect(pm.response.code).to.equal(200);",
+													"    });   ",
+													"const __ = require('lodash');",
+													"const responseItems = pm.response.json();",
+													"",
+													"let sectionsRecord = __.first(responseItems);",
+													"pm.environment.set('known:sectionsRecord.localCourseCode',sectionsRecord.courseOfferingReference.localCourseCode);",
+													"pm.environment.set('known:sectionsRecord.schoolId',sectionsRecord.courseOfferingReference.schoolId);",
+													"pm.environment.set('known:sectionsRecord.schoolYear',sectionsRecord.courseOfferingReference.schoolYear);",
+													"pm.environment.set('known:sectionsRecord.sectionIdentifier',sectionsRecord.sectionIdentifier);",
+													"pm.environment.set('known:sectionsRecord.sessionName',sectionsRecord.courseOfferingReference.sessionName);"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/sections?schoolId={{known:schoolId_9011}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"sections"
+											],
+											"query": [
+												{
+													"key": "schoolId",
+													"value": "{{known:schoolId_9011}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create Student School Association",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"const moment = require('moment');",
+													"let entryDate=new Date();",
+													"entryDate = entryDate.addMonths(-10);",
+													"entryDate= moment(entryDate).format(\"YYYY-MM-DD\");",
+													"pm.environment.set('supplied:'+scenarioId+':entryDate',entryDate);",
+													"pm.environment.set('supplied:'+scenarioId+':entryGradeLevelDescriptor',\"uri://ed-fi.org/GradeLevelDescriptor#Fourth grade\");",
+													" "
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"    pm.expect(pm.response.code).to.equal(201);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{ \r\n   \"schoolReference\":{ \r\n      \"schoolId\":\"{{known:schoolId_9011}}\"\r\n   },\r\n   \"studentReference\":{ \r\n      \"studentUniqueId\":\"{{known:StudentUniqueIdOne}}\"\r\n   },\r\n   \"entryDate\":\"{{supplied:{{scenarioId}}:entryDate}}\",\r\n   \"entryGradeLevelDescriptor\":\"{{supplied:{{scenarioId}}:entryGradeLevelDescriptor}}\"\r\n  \r\n}"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/StudentSchoolAssociations",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"StudentSchoolAssociations"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Initial Setup StudentSectionAssociation Two",
+							"item": [
+								{
+									"name": "Create Student",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"        pm.expect(pm.response.code).to.equal(201);",
+													"    });   ",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const uuid = require('uuid');",
+													"function newGuid() { return uuid.v4().toString().replace(/[^a-zA-Z0-9 ]/g,\"\"); }",
+													"function createScenarioId() { return newGuid().substring(0,5); }",
+													"pm.environment.set('scenarioId', createScenarioId());",
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"pm.environment.set('supplied:'+scenarioId+':StudentUniqueId', newGuid());",
+													"pm.environment.set('known:StudentUniqueIdTwo', pm.environment.get('supplied:'+scenarioId+':StudentUniqueId'));",
+													"pm.environment.set('supplied:'+scenarioId+':LastSurname',newGuid());",
+													"pm.environment.set('supplied:'+scenarioId+':FirstName',newGuid());",
+													"",
+													"const moment = require('moment');",
+													"let birthDate=new Date();",
+													"birthDate = birthDate.addYears(-20);",
+													"birthDate= moment(birthDate).format(\"YYYY-MM-DD\");",
+													"pm.environment.set('supplied:'+scenarioId+':BirthDate',birthDate);",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n   \"studentUniqueId\": \"{{supplied:{{scenarioId}}:StudentUniqueId}}\",\r\n  \"birthDate\":\"{{supplied:{{scenarioId}}:BirthDate}}\",\r\n  \"firstName\": \"{{supplied:{{scenarioId}}:FirstName}}\",\r\n  \"lastSurname\": \"{{supplied:{{scenarioId}}:LastSurname}}\"\r\n }\r\n"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/students",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"students"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create  School",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"pm.environment.set('supplied:'+scenarioId+':nameOfInstitution', 'SCH-9011');",
+													"pm.environment.set('supplied:'+scenarioId+':educationOrganizationCategoryDescriptor', \"uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Local Education Agency\");",
+													"pm.environment.set('supplied:'+scenarioId+':gradeLevelDescriptor', \"uri://ed-fi.org/GradeLevelDescriptor#Adult Education\");",
+													"pm.environment.set('supplied:'+scenarioId+':schoolCategoryDescriptor', \"uri://ed-fi.org/SchoolCategoryDescriptor#Adult School\");",
+													"pm.environment.set('supplied:'+scenarioId+':schoolTypeDescriptor', \"uri://ed-fi.org/SchoolTypeDescriptor#Regular\");",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"        pm.expect(pm.response.code).to.equal(201);",
+													"    });   ",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"educationOrganizationCategories\": [\r\n    {\r\n      \"educationOrganizationCategoryDescriptor\":  \"{{supplied:{{scenarioId}}:educationOrganizationCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n   \"gradeLevels\": [\r\n    {\r\n      \"gradeLevelDescriptor\":  \"{{supplied:{{scenarioId}}:gradeLevelDescriptor}}\"\r\n    }\r\n  ],\r\n  \"schoolId\":  \"{{known:schoolId_9021}}\",\r\n  \"localEducationAgencyReference\": {\r\n    \"localEducationAgencyId\": \"{{known:localEducationAgencyId}}\"\r\n  },\r\n  \"nameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\",\r\n  \"schoolCategories\": [\r\n    {\r\n      \"schoolCategoryDescriptor\": \"{{supplied:{{scenarioId}}:schoolCategoryDescriptor}}\"\r\n    }\r\n  ],\r\n  \"schoolTypeDescriptor\": \"{{supplied:{{scenarioId}}:schoolTypeDescriptor}}\",\r\n  \"shortNameOfInstitution\":  \"{{supplied:{{scenarioId}}:nameOfInstitution}}\"\r\n\r\n}"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Create gradingPeriods",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"        pm.expect(pm.response.code).to.equal(201);",
+													"});  "
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n        \"schoolReference\": {\r\n            \"schoolId\": \"{{known:schoolId_9021}}\"\r\n        },\r\n        \"schoolYearTypeReference\": {\r\n            \"schoolYear\": 2022\r\n        },\r\n        \"gradingPeriodDescriptor\": \"uri://ed-fi.org/GradingPeriodDescriptor#First Six Weeks\",\r\n        \"periodSequence\": 1,\r\n        \"beginDate\": \"2021-08-23\",\r\n        \"endDate\": \"2021-10-03\",\r\n        \"totalInstructionalDays\": 99\r\n    }"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/gradingPeriods",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"gradingPeriods"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Create Session",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"        pm.expect(pm.response.code).to.equal(201);",
+													"    });   "
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n        \"schoolReference\": {\r\n            \"schoolId\": \"{{known:schoolId_9021}}\"\r\n        },\r\n        \"schoolYearTypeReference\": {\r\n            \"schoolYear\": 2022\r\n        },\r\n        \"sessionName\": \"2021-2022 Fall Semester Record Ownership\",\r\n        \"beginDate\": \"2021-08-23\",\r\n        \"endDate\": \"2021-12-17\",\r\n        \"termDescriptor\": \"uri://ed-fi.org/TermDescriptor#Fall Semester\",\r\n        \"totalInstructionalDays\": 81,\r\n        \"academicWeeks\": [],\r\n        \"gradingPeriods\": [\r\n            {\r\n                \"gradingPeriodReference\": {\r\n                    \"schoolId\": \"{{known:schoolId_9021}}\",\r\n                    \"schoolYear\": 2022,\r\n                    \"gradingPeriodDescriptor\": \"uri://ed-fi.org/GradingPeriodDescriptor#First Six Weeks\",\r\n                    \"periodSequence\": 1\r\n                }\r\n            }\r\n        ]\r\n    }"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/sessions",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"sessions"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Create Course",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"    pm.expect(pm.response.code).to.equal(201);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n        \"educationOrganizationReference\": {\r\n            \"educationOrganizationId\": \"{{known:schoolId_9021}}\"\r\n        },\r\n        \"courseCode\": \"RecordOwnership\",\r\n        \"academicSubjectDescriptor\": \"uri://ed-fi.org/AcademicSubjectDescriptor#Mathematics\",\r\n        \"courseDefinedByDescriptor\": \"uri://ed-fi.org/CourseDefinedByDescriptor#SEA\",\r\n        \"courseDescription\": \"Algebra I\",\r\n        \"courseGPAApplicabilityDescriptor\": \"uri://ed-fi.org/CourseGPAApplicabilityDescriptor#Applicable\",\r\n        \"courseTitle\": \"Algebra I\",\r\n        \"identificationCodes\": [\r\n            {\r\n                \"courseIdentificationSystemDescriptor\": \"uri://ed-fi.org/CourseIdentificationSystemDescriptor#LEA course code\",\r\n                \"courseCatalogURL\": \"http://www.GBISD.edu/coursecatalog\",\r\n                \"identificationCode\": \"ALG-1\"\r\n            },\r\n            {\r\n                \"courseIdentificationSystemDescriptor\": \"uri://ed-fi.org/CourseIdentificationSystemDescriptor#State course code\",\r\n                \"identificationCode\": \"03100500\"\r\n            }\r\n        ]\r\n\r\n    }"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/courses",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"courses"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Create CourseOfferings",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"        pm.expect(pm.response.code).to.equal(201);",
+													"    });   ",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n        \"courseReference\": {\r\n            \"courseCode\": \"RecordOwnership\",\r\n            \"educationOrganizationId\": \"{{known:schoolId_9021}}\"\r\n        },\r\n        \"schoolReference\": {\r\n            \"schoolId\": \"{{known:schoolId_9021}}\"\r\n        },\r\n        \"sessionReference\": {\r\n            \"schoolId\": \"{{known:schoolId_9021}}\",\r\n            \"schoolYear\": 2022,\r\n            \"sessionName\": \"2021-2022 Fall Semester Record Ownership\"\r\n        },\r\n        \"localCourseCode\": \"RecordOwnership\"\r\n    }"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/courseOfferings",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"courseOfferings"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Create Section",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"        pm.expect(pm.response.code).to.equal(201);",
+													"    });   "
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const uuid = require('uuid');\r",
+													"function newGuid() { return uuid.v4().toString().replace(/[^a-zA-Z0-9 ]/g,\"\"); }\r",
+													"\r",
+													"const scenarioId = pm.environment.get('scenarioId');\r",
+													"pm.environment.set('supplied:'+scenarioId+':sectionIdentifier', newGuid());"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n        \"courseOfferingReference\": {\r\n            \"localCourseCode\": \"RecordOwnership\",\r\n            \"schoolId\": \"{{known:schoolId_9021}}\",\r\n            \"schoolYear\": 2022,\r\n            \"sessionName\": \"2021-2022 Fall Semester Record Ownership\"\r\n        },\r\n        \"sectionIdentifier\": \"{{supplied:{{scenarioId}}:sectionIdentifier}}\"\r\n}"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/sections",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"sections"
+											],
+											"query": [
+												{
+													"key": "schoolId",
+													"value": "{{known:schoolId_9011}}",
+													"disabled": true
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Initial Section Data",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"        pm.expect(pm.response.code).to.equal(200);",
+													"    });   ",
+													"const __ = require('lodash');",
+													"const responseItems = pm.response.json();",
+													"",
+													"sectionsRecord = __.last(responseItems);",
+													"",
+													"pm.environment.set('known:sectionsRecord2.localCourseCode',sectionsRecord.courseOfferingReference.localCourseCode);",
+													"pm.environment.set('known:sectionsRecord2.schoolId',sectionsRecord.courseOfferingReference.schoolId);",
+													"pm.environment.set('known:sectionsRecord2.schoolYear',sectionsRecord.courseOfferingReference.schoolYear);",
+													"pm.environment.set('known:sectionsRecord2.sectionIdentifier',sectionsRecord.sectionIdentifier);",
+													"pm.environment.set('known:sectionsRecord2.sessionName',sectionsRecord.courseOfferingReference.sessionName);",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/sections?schoolId={{known:schoolId_9021}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"sections"
+											],
+											"query": [
+												{
+													"key": "schoolId",
+													"value": "{{known:schoolId_9021}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create Student School Association",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"const moment = require('moment');",
+													"let entryDate=new Date();",
+													"entryDate = entryDate.addMonths(-10);",
+													"entryDate= moment(entryDate).format(\"YYYY-MM-DD\");",
+													"pm.environment.set('supplied:'+scenarioId+':entryDate',entryDate);",
+													"pm.environment.set('supplied:'+scenarioId+':entryGradeLevelDescriptor',\"uri://ed-fi.org/GradeLevelDescriptor#Fourth grade\");",
+													" "
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"    pm.expect(pm.response.code).to.equal(201);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{ \r\n   \"schoolReference\":{ \r\n      \"schoolId\":\"{{known:schoolId_9021}}\"\r\n   },\r\n   \"studentReference\":{ \r\n      \"studentUniqueId\":\"{{known:StudentUniqueIdTwo}}\"\r\n   },\r\n   \"entryDate\":\"{{supplied:{{scenarioId}}:entryDate}}\",\r\n   \"entryGradeLevelDescriptor\":\"{{supplied:{{scenarioId}}:entryGradeLevelDescriptor}}\"\r\n  \r\n}"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/StudentSchoolAssociations",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"StudentSchoolAssociations"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Client 1  Full CRUD- SSectionAssociation 1",
+							"item": [
+								{
+									"name": "Create  StudentSectionAssociation",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"        pm.expect(pm.response.code).to.equal(201);",
+													"    });   ",
+													"",
+													"pm.environment.set('known:studentSectionAssociation1:studentSectionAssociationGuid',pm.response.headers.one('Location').value.split(\"/\").pop());"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"sectionReference\": {\r\n      \"localCourseCode\": \"{{known:sectionsRecord.localCourseCode}}\",\r\n      \"schoolId\": \"{{known:sectionsRecord.schoolId}}\",\r\n      \"schoolYear\": \"{{known:sectionsRecord.schoolYear}}\",\r\n      \"sectionIdentifier\": \"{{known:sectionsRecord.sectionIdentifier}}\",\r\n      \"sessionName\": \"{{known:sectionsRecord.sessionName}}\"\r\n    },\r\n    \"studentReference\": {\r\n      \"studentUniqueId\": \"{{known:StudentUniqueIdOne}}\"\r\n    },\r\n    \"beginDate\": \"{{supplied:{{scenarioId}}:beginDate}}\",\r\n    \"endDate\": \"{{supplied:{{scenarioId}}:endDate}}\"\r\n  }"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Get StudentSectionAssociations",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"",
+													"const responseItems = pm.response.json();",
+													"",
+													"pm.test(\"Should match with studentSectionAssociations Response \", () => {    ",
+													"",
+													"    pm.expect(responseItems.sectionReference.localCourseCode).to.equal(pm.environment.get('known:sectionsRecord.localCourseCode').toString());",
+													"    pm.expect(responseItems.sectionReference.schoolId).to.equal(pm.environment.get('known:sectionsRecord.schoolId'));",
+													"    pm.expect(responseItems.sectionReference.schoolYear).to.equal(pm.environment.get('known:sectionsRecord.schoolYear'));",
+													"    pm.expect(responseItems.sectionReference.sectionIdentifier).to.equal(pm.environment.get('known:sectionsRecord.sectionIdentifier').toString());            ",
+													"    pm.expect(responseItems.sectionReference.sessionName).to.equal(pm.environment.get('known:sectionsRecord.sessionName').toString());",
+													"    pm.expect(responseItems.studentReference.studentUniqueId).to.equal(pm.environment.get('known:StudentUniqueIdOne').toString());    ",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations/{{known:studentSectionAssociation1:studentSectionAssociationGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations",
+												"{{known:studentSectionAssociation1:studentSectionAssociationGuid}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update  StudentSectionAssociations",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const moment = require('moment');",
+													"let beginDate=new Date();",
+													"beginDate = beginDate.addMonths(-24);",
+													"beginDate= moment(new Date()).format(\"YYYY-MM-DD\");",
+													"pm.environment.set(\"known:second:beginDate\",beginDate);",
+													"",
+													"let endDate=new Date();",
+													"endDate = endDate.addMonths(24);",
+													"endDate= moment(endDate).format(\"YYYY-MM-DD\");",
+													"pm.environment.set(\"known:second:endDate\",endDate);",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 204\", () => {",
+													"    pm.expect(pm.response.code).to.equal(204);",
+													"});",
+													"pm.environment.set('known:studentSectionAssociation1:studentSectionAssociationGuid',pm.response.headers.one('Location').value.split(\"/\").pop());",
+													"",
+													"let StudentSectionAssociationsGetRequest = {",
+													"    url: pm.environment.get(\"ApiBaseUrl\") + \"/data/v3/ed-fi/studentSectionAssociations/\"+ pm.environment.get(\"known:studentSectionAssociation1:studentSectionAssociationGuid\"),",
+													"    method: 'GET',",
+													"    header: 'Authorization:bearer ' + pm.environment.get(\"AccessToken_255901-A\"),",
+													"    body: {}",
+													"};",
+													"",
+													"const scenarioId = pm.environment.get('scenarioId');",
+													"pm.test('nameOfInstitution contains substring of \"updated\"  ', () => {",
+													"",
+													"    pm.sendRequest(StudentSectionAssociationsGetRequest, function (err,StudentSectionAssociations) {",
+													"        if (err) {",
+													"            console.log(err);",
+													"        } else {",
+													"            const responseItems = StudentSectionAssociations.json();",
+													"            pm.expect(responseItems.sectionReference.localCourseCode).to.equal(pm.environment.get('known:sectionsRecord2.localCourseCode').toString());",
+													"            pm.expect(responseItems.sectionReference.schoolId).to.equal(pm.environment.get('known:sectionsRecord2.schoolId'));",
+													"            pm.expect(responseItems.sectionReference.schoolYear).to.equal(pm.environment.get('known:sectionsRecord2.schoolYear'));",
+													"            pm.expect(responseItems.sectionReference.sectionIdentifier).to.equal(pm.environment.get('known:sectionsRecord2.sectionIdentifier').toString());            ",
+													"            pm.expect(responseItems.sectionReference.sessionName).to.equal(pm.environment.get('known:sectionsRecord2.sessionName').toString());",
+													"            pm.expect(responseItems.studentReference.studentUniqueId).to.equal(pm.environment.get('known:StudentUniqueIdTwo').toString());   ",
+													"        }",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n\r\n    \"sectionReference\": {\r\n      \"localCourseCode\": \"{{known:sectionsRecord2.localCourseCode}}\",\r\n      \"schoolId\": \"{{known:sectionsRecord2.schoolId}}\",\r\n      \"schoolYear\": \"{{known:sectionsRecord2.schoolYear}}\",\r\n      \"sectionIdentifier\": \"{{known:sectionsRecord2.sectionIdentifier}}\",\r\n      \"sessionName\": \"{{known:sectionsRecord2.sessionName}}\"\r\n    },\r\n    \"studentReference\": {\r\n      \"studentUniqueId\": \"{{known:StudentUniqueIdTwo}}\"\r\n    },\r\n    \"beginDate\": \"{{known:second:beginDate}}\",\r\n    \"endDate\": \"{{known:second:endDate}}\"\r\n  }"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations/{{known:studentSectionAssociation1:studentSectionAssociationGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations",
+												"{{known:studentSectionAssociation1:studentSectionAssociationGuid}}"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Delete  StudentSectionAssociation",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 204\", () => {",
+													"    pm.expect(pm.response.code).to.equal(204);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations/{{known:studentSectionAssociation1:studentSectionAssociationGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations",
+												"{{known:studentSectionAssociation1:studentSectionAssociationGuid}}"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Client 2  Full CRUD- SSectionAssociation 1 also",
+							"item": [
+								{
+									"name": "Create  StudentSectionAssociations using Client1",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const moment = require('moment');",
+													"let beginDate=new Date();",
+													"beginDate = beginDate.addMonths(-24);",
+													"beginDate= moment(new Date()).format(\"YYYY-MM-DD\");",
+													"pm.environment.set(\"known:third:beginDate\",beginDate);",
+													"",
+													"let endDate=new Date();",
+													"endDate = endDate.addMonths(24);",
+													"endDate= moment(endDate).format(\"YYYY-MM-DD\");",
+													"pm.environment.set(\"known:third:endDate\",endDate);",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"        pm.expect(pm.response.code).to.equal(201);",
+													"    });   ",
+													"",
+													"pm.environment.set('known:studentSectionAssociation1:studentSectionAssociationGuid',pm.response.headers.one('Location').value.split(\"/\").pop());"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"sectionReference\": {\r\n      \"localCourseCode\": \"{{known:sectionsRecord.localCourseCode}}\",\r\n      \"schoolId\": \"{{known:sectionsRecord.schoolId}}\",\r\n      \"schoolYear\": \"{{known:sectionsRecord.schoolYear}}\",\r\n      \"sectionIdentifier\": \"{{known:sectionsRecord.sectionIdentifier}}\",\r\n      \"sessionName\": \"{{known:sectionsRecord.sessionName}}\"\r\n    },\r\n    \"studentReference\": {\r\n      \"studentUniqueId\": \"{{known:StudentUniqueIdOne}}\"\r\n    },\r\n    \"beginDate\": \"{{known:beginDate}}\",\r\n    \"endDate\": \"{{known:endDate}}\"\r\n  }"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Update  StudentSectionAssociation",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"",
+													"const moment = require('moment');",
+													"const beginDate= moment(new Date()).format(\"YYYY-MM-DD\");",
+													"pm.environment.set(\"known:beginDate\",beginDate);",
+													"",
+													"let endDate=new Date();",
+													"endDate = endDate.addMonths(12);",
+													"endDate= moment(endDate).format(\"YYYY-MM-DD\");",
+													"pm.environment.set(\"known:endDate\",endDate);",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"        pm.expect(pm.response.code).to.equal(200);",
+													"    });   ",
+													"",
+													"pm.environment.set('known:studentSectionAssociation1:studentSectionAssociationGuid',pm.response.headers.one('Location').value.split(\"/\").pop());"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"sectionReference\": {\r\n      \"localCourseCode\": \"{{known:sectionsRecord.localCourseCode}}\",\r\n      \"schoolId\": \"{{known:sectionsRecord.schoolId}}\",\r\n      \"schoolYear\": \"{{known:sectionsRecord.schoolYear}}\",\r\n      \"sectionIdentifier\": \"{{known:sectionsRecord.sectionIdentifier}}\",\r\n      \"sessionName\": \"{{known:sectionsRecord.sessionName}}\"\r\n    },\r\n    \"studentReference\": {\r\n      \"studentUniqueId\": \"{{known:StudentUniqueIdOne}}\"\r\n    },\r\n    \"beginDate\": \"{{known:beginDate}}\",\r\n    \"endDate\": \"{{known:endDate}}\"\r\n  }"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Get StudentSectionAssociations",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"",
+													"const responseItems = pm.response.json();",
+													"",
+													"",
+													"pm.test(\"Should match with studentSectionAssociations Response \", () => {    ",
+													"",
+													"    pm.expect(responseItems.sectionReference.localCourseCode).to.equal(pm.environment.get('known:sectionsRecord.localCourseCode').toString());",
+													"    pm.expect(responseItems.sectionReference.schoolId).to.equal(pm.environment.get('known:sectionsRecord.schoolId'));",
+													"    pm.expect(responseItems.sectionReference.schoolYear).to.equal(pm.environment.get('known:sectionsRecord.schoolYear'));",
+													"    pm.expect(responseItems.sectionReference.sectionIdentifier).to.equal(pm.environment.get('known:sectionsRecord.sectionIdentifier').toString());            ",
+													"    pm.expect(responseItems.sectionReference.sessionName).to.equal(pm.environment.get('known:sectionsRecord.sessionName').toString());",
+													"    pm.expect(responseItems.studentReference.studentUniqueId).to.equal(pm.environment.get('known:StudentUniqueIdOne').toString());    ",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations/{{known:studentSectionAssociation1:studentSectionAssociationGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations",
+												"{{known:studentSectionAssociation1:studentSectionAssociationGuid}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update  StudentSectionAssociations",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const moment = require('moment');",
+													"let beginDate=new Date();",
+													"beginDate = beginDate.addMonths(-24);",
+													"beginDate= moment(new Date()).format(\"YYYY-MM-DD\");",
+													"pm.environment.set(\"known:second:beginDate\",beginDate);",
+													"",
+													"let endDate=new Date();",
+													"endDate = endDate.addMonths(24);",
+													"endDate= moment(endDate).format(\"YYYY-MM-DD\");",
+													"pm.environment.set(\"known:second:endDate\",endDate);",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 204\", () => {",
+													"    pm.expect(pm.response.code).to.equal(204);",
+													"});",
+													"pm.environment.set('known:studentSectionAssociation1:studentSectionAssociationGuid',pm.response.headers.one('Location').value.split(\"/\").pop());"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n\r\n    \"sectionReference\": {\r\n      \"localCourseCode\": \"{{known:sectionsRecord2.localCourseCode}}\",\r\n      \"schoolId\": \"{{known:sectionsRecord2.schoolId}}\",\r\n      \"schoolYear\": \"{{known:sectionsRecord2.schoolYear}}\",\r\n      \"sectionIdentifier\": \"{{known:sectionsRecord2.sectionIdentifier}}\",\r\n      \"sessionName\": \"{{known:sectionsRecord2.sessionName}}\"\r\n    },\r\n    \"studentReference\": {\r\n      \"studentUniqueId\": \"{{known:StudentUniqueIdTwo}}\"\r\n    },\r\n    \"beginDate\": \"{{known:second:beginDate}}\",\r\n    \"endDate\": \"{{known:second:endDate}}\"\r\n  }"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations/{{known:studentSectionAssociation1:studentSectionAssociationGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations",
+												"{{known:studentSectionAssociation1:studentSectionAssociationGuid}}"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Delete  StudentSectionAssociation",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 204\", () => {",
+													"    pm.expect(pm.response.code).to.equal(204);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations/{{known:studentSectionAssociation1:studentSectionAssociationGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations",
+												"{{known:studentSectionAssociation1:studentSectionAssociationGuid}}"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Client 2  Full CRUD- SSectionAssociation 2",
+							"item": [
+								{
+									"name": "Create  StudentSectionAssociation",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"",
+													"const moment = require('moment');",
+													"const beginDate= moment(new Date()).format(\"YYYY-MM-DD\");",
+													"pm.environment.set(\"known:beginDate\",beginDate);",
+													"",
+													"let endDate=new Date();",
+													"endDate = endDate.addMonths(12);",
+													"endDate= moment(endDate).format(\"YYYY-MM-DD\");",
+													"pm.environment.set(\"known:endDate\",endDate);",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"        pm.expect(pm.response.code).to.equal(201);",
+													"    });   ",
+													"pm.environment.set('known:studentSectionAssociation2:studentSectionAssociationGuid',pm.response.headers.one('Location').value.split(\"/\").pop());"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"sectionReference\": {\r\n      \"localCourseCode\": \"{{known:sectionsRecord2.localCourseCode}}\",\r\n      \"schoolId\": \"{{known:sectionsRecord2.schoolId}}\",\r\n      \"schoolYear\": \"{{known:sectionsRecord2.schoolYear}}\",\r\n      \"sectionIdentifier\": \"{{known:sectionsRecord2.sectionIdentifier}}\",\r\n      \"sessionName\": \"{{known:sectionsRecord2.sessionName}}\"\r\n    },\r\n    \"studentReference\": {\r\n      \"studentUniqueId\": \"{{known:StudentUniqueIdTwo}}\"\r\n    },\r\n    \"beginDate\": \"{{known:beginDate}}\",\r\n    \"endDate\": \"{{known:endDate}}\"\r\n  }"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Get StudentSectionAssociations",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"const responseItems = pm.response.json();",
+													"pm.test(\"Should match with studentSectionAssociations Response \", () => {    ",
+													"",
+													"    pm.expect(responseItems.sectionReference.localCourseCode).to.equal(pm.environment.get('known:sectionsRecord2.localCourseCode').toString());",
+													"    pm.expect(responseItems.sectionReference.schoolId).to.equal(pm.environment.get('known:sectionsRecord2.schoolId'));",
+													"    pm.expect(responseItems.sectionReference.schoolYear).to.equal(pm.environment.get('known:sectionsRecord2.schoolYear'));",
+													"    pm.expect(responseItems.sectionReference.sectionIdentifier).to.equal(pm.environment.get('known:sectionsRecord2.sectionIdentifier').toString());            ",
+													"    pm.expect(responseItems.sectionReference.sessionName).to.equal(pm.environment.get('known:sectionsRecord2.sessionName').toString());",
+													"    pm.expect(responseItems.studentReference.studentUniqueId).to.equal(pm.environment.get('known:StudentUniqueIdTwo').toString());    ",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations/{{known:studentSectionAssociation2:studentSectionAssociationGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations",
+												"{{known:studentSectionAssociation2:studentSectionAssociationGuid}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update  StudentSectionAssociations",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const moment = require('moment');",
+													"let beginDate=new Date();",
+													"beginDate = beginDate.addMonths(-24);",
+													"beginDate= moment(new Date()).format(\"YYYY-MM-DD\");",
+													"pm.environment.set(\"known:second:beginDate\",beginDate);",
+													"",
+													"let endDate=new Date();",
+													"endDate = endDate.addMonths(24);",
+													"endDate= moment(endDate).format(\"YYYY-MM-DD\");",
+													"pm.environment.set(\"known:second:endDate\",endDate);",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 204\", () => {",
+													"    pm.expect(pm.response.code).to.equal(204);",
+													"});",
+													"pm.environment.set('known:studentSectionAssociation2:studentSectionAssociationGuid',pm.response.headers.one('Location').value.split(\"/\").pop());"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n\r\n    \"sectionReference\": {\r\n      \"localCourseCode\": \"{{known:sectionsRecord2.localCourseCode}}\",\r\n      \"schoolId\": \"{{known:sectionsRecord2.schoolId}}\",\r\n      \"schoolYear\": \"{{known:sectionsRecord2.schoolYear}}\",\r\n      \"sectionIdentifier\": \"{{known:sectionsRecord2.sectionIdentifier}}\",\r\n      \"sessionName\": \"{{known:sectionsRecord2.sessionName}}\"\r\n    },\r\n    \"studentReference\": {\r\n      \"studentUniqueId\": \"{{known:StudentUniqueIdTwo}}\"\r\n    },\r\n    \"beginDate\": \"{{known:second:beginDate}}\",\r\n    \"endDate\": \"{{known:second:endDate}}\"\r\n  }"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations/{{known:studentSectionAssociation2:studentSectionAssociationGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations",
+												"{{known:studentSectionAssociation2:studentSectionAssociationGuid}}"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Delete  StudentSectionAssociation",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 204\", () => {",
+													"    pm.expect(pm.response.code).to.equal(204);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations/{{known:studentSectionAssociation2:studentSectionAssociationGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations",
+												"{{known:studentSectionAssociation2:studentSectionAssociationGuid}}"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Client 1  not  Full CRUD- SSectionAssociation 2",
+							"item": [
+								{
+									"name": "StudentSectionAssociation using Client2",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"",
+													"const moment = require('moment');",
+													"const beginDate= moment(new Date()).format(\"YYYY-MM-DD\");",
+													"pm.environment.set(\"known:beginDate\",beginDate);",
+													"",
+													"let endDate=new Date();",
+													"endDate = endDate.addMonths(12);",
+													"endDate= moment(endDate).format(\"YYYY-MM-DD\");",
+													"pm.environment.set(\"known:endDate\",endDate);",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 201\", () => {",
+													"        pm.expect(pm.response.code).to.equal(201);",
+													"    });",
+													"pm.environment.set('known:studentSectionAssociation2:studentSectionAssociationGuid',pm.response.headers.one('Location').value.split(\"/\").pop());"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"sectionReference\": {\r\n      \"localCourseCode\": \"{{known:sectionsRecord2.localCourseCode}}\",\r\n      \"schoolId\": \"{{known:sectionsRecord2.schoolId}}\",\r\n      \"schoolYear\": \"{{known:sectionsRecord2.schoolYear}}\",\r\n      \"sectionIdentifier\": \"{{known:sectionsRecord2.sectionIdentifier}}\",\r\n      \"sessionName\": \"{{known:sectionsRecord2.sessionName}}\"\r\n    },\r\n    \"studentReference\": {\r\n      \"studentUniqueId\": \"{{known:StudentUniqueIdTwo}}\"\r\n    },\r\n    \"beginDate\": \"{{known:beginDate}}\",\r\n    \"endDate\": \"{{known:endDate}}\"\r\n  }"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Update  StudentSectionAssociation",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"",
+													"const moment = require('moment');",
+													"const beginDate= moment(new Date()).format(\"YYYY-MM-DD\");",
+													"pm.environment.set(\"known:beginDate\",beginDate);",
+													"",
+													"let endDate=new Date();",
+													"endDate = endDate.addMonths(12);",
+													"endDate= moment(endDate).format(\"YYYY-MM-DD\");",
+													"pm.environment.set(\"known:endDate\",endDate);",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 403\", () => {",
+													"    pm.expect(pm.response.code).to.equal(403);",
+													"});",
+													"",
+													"const __ = require('lodash');",
+													"const responseItem = pm.response.json();",
+													"",
+													"pm.test(\"Should match with caller's ownership tokens Error Response \", () => {    ",
+													"    pm.expect(responseItem.message).to.equal(\"Access to the resource item could not be authorized using any of the caller's ownership tokens.\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"sectionReference\": {\r\n      \"localCourseCode\": \"{{known:sectionsRecord2.localCourseCode}}\",\r\n      \"schoolId\": \"{{known:sectionsRecord2.schoolId}}\",\r\n      \"schoolYear\": \"{{known:sectionsRecord2.schoolYear}}\",\r\n      \"sectionIdentifier\": \"{{known:sectionsRecord2.sectionIdentifier}}\",\r\n      \"sessionName\": \"{{known:sectionsRecord2.sessionName}}\"\r\n    },\r\n    \"studentReference\": {\r\n      \"studentUniqueId\": \"{{known:StudentUniqueIdTwo}}\"\r\n    },\r\n    \"beginDate\": \"{{known:beginDate}}\",\r\n    \"endDate\": \"{{known:endDate}}\"\r\n  }"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Get StudentSectionAssociations",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 403\", () => {",
+													"    pm.expect(pm.response.code).to.equal(403);",
+													"});",
+													"",
+													"const responseItem = pm.response.json();",
+													"",
+													"pm.test(\"Should match with caller's ownership tokens Error Response \", () => {    ",
+													"    pm.expect(responseItem.message).to.equal(\"Access to the resource item could not be authorized using any of the caller's ownership tokens.\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations/{{known:studentSectionAssociation2:studentSectionAssociationGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations",
+												"{{known:studentSectionAssociation2:studentSectionAssociationGuid}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update  StudentSectionAssociations",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const moment = require('moment');",
+													"let beginDate=new Date();",
+													"beginDate = beginDate.addMonths(-24);",
+													"beginDate= moment(new Date()).format(\"YYYY-MM-DD\");",
+													"pm.environment.set(\"known:second:beginDate\",beginDate);",
+													"",
+													"let endDate=new Date();",
+													"endDate = endDate.addMonths(24);",
+													"endDate= moment(endDate).format(\"YYYY-MM-DD\");",
+													"pm.environment.set(\"known:second:endDate\",endDate);",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 403\", () => {",
+													"    pm.expect(pm.response.code).to.equal(403);",
+													"});",
+													"",
+													"const responseItem = pm.response.json();",
+													"",
+													"pm.test(\"Should match with caller's ownership tokens Error Response \", () => {    ",
+													"    pm.expect(responseItem.message).to.equal(\"Access to the resource item could not be authorized using any of the caller's ownership tokens.\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"sectionReference\": {\r\n      \"localCourseCode\": \"{{known:sectionsRecord2.localCourseCode}}\",\r\n      \"schoolId\": \"{{known:sectionsRecord2.schoolId}}\",\r\n      \"schoolYear\": \"{{known:sectionsRecord2.schoolYear}}\",\r\n      \"sectionIdentifier\": \"{{known:sectionsRecord2.sectionIdentifier}}\",\r\n      \"sessionName\": \"{{known:sectionsRecord2.sessionName}}\"\r\n    },\r\n    \"studentReference\": {\r\n      \"studentUniqueId\": \"{{known:StudentUniqueIdTwo}}\"\r\n    },\r\n    \"beginDate\": \"{{known:beginDate}}\",\r\n    \"endDate\": \"{{known:endDate}}\"\r\n  }"
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations/{{known:studentSectionAssociation2:studentSectionAssociationGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations",
+												"{{known:studentSectionAssociation2:studentSectionAssociationGuid}}"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								},
+								{
+									"name": "Delete  StudentSectionAssociation",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 403\", () => {",
+													"    pm.expect(pm.response.code).to.equal(403);",
+													"});",
+													"",
+													"",
+													"const responseItem = pm.response.json();",
+													"",
+													"pm.test(\"Should match with caller's ownership tokens Error Response \", () => {    ",
+													"    pm.expect(responseItem.message).to.equal(\"Access to the resource item could not be authorized using any of the caller's ownership tokens.\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations/{{known:studentSectionAssociation2:studentSectionAssociationGuid}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations",
+												"{{known:studentSectionAssociation2:studentSectionAssociationGuid}}"
+											]
+										},
+										"description": "This api post method adds new academicWeeks for particular school .\nThis test method will throw WeekIdentifier is required error when WeekIdentifier is not passed"
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Clean Up Test Data",
+							"item": [
+								{
+									"name": "Clean up studentSectionAssociations",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"",
+													"const responseItems = pm.response.json();",
+													"",
+													"pm.test('Delete studentSectionAssociations with school Id 9021', () => {",
+													"",
+													"           responseItems.forEach(responseItem => {",
+													"            ",
+													"            if(isNaN(responseItem.id))",
+													"            {",
+													"                let StudentSectionAssociationDeleteRequest = {",
+													"                        url: pm.environment.get(\"ApiBaseUrl\") + \"/data/v3/ed-fi/studentSectionAssociations/\" + responseItem.id,",
+													"                        method: 'DELETE',",
+													"                        header: 'Authorization:bearer ' + pm.environment.get(\"AccessToken_255901-B\"),",
+													"                        body: {}",
+													"                };",
+													"    ",
+													"                pm.sendRequest(StudentSectionAssociationDeleteRequest, function (err, StudentSectionAssociationDelete) {",
+													"                        if (err) {",
+													"                            console.log(err);",
+													"                        } else {}",
+													"                    });",
+													"           }",
+													"        });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentSectionAssociations/?schoolid={{known:schoolId_9021}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentSectionAssociations",
+												""
+											],
+											"query": [
+												{
+													"key": "schoolid",
+													"value": "{{known:schoolId_9021}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Clean up StudentSchoolAssociation One",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"",
+													"const responseItems = pm.response.json();",
+													"",
+													"pm.test('Delete studentschoolassociations with school 9011', () => {",
+													"",
+													"           responseItems.forEach(responseItem => {",
+													"            ",
+													"            if(isNaN(responseItem.id))",
+													"            {",
+													"                let ProgramDeleteRequest = {",
+													"                        url: pm.environment.get(\"ApiBaseUrl\") + \"/data/v3/ed-fi/studentschoolassociations/\" + responseItem.id,",
+													"                        method: 'DELETE',",
+													"                        header: 'Authorization:bearer ' + pm.environment.get(\"AccessToken_255901-A\"),",
+													"                        body: {}",
+													"                };",
+													"    ",
+													"                pm.sendRequest(ProgramDeleteRequest, function (err, ProgramDelete) {",
+													"                        if (err) {",
+													"                            console.log(err);",
+													"                        } else {}",
+													"                    });",
+													"           }",
+													"        });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentschoolassociations/?schoolid={{known:schoolId_9011}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentschoolassociations",
+												""
+											],
+											"query": [
+												{
+													"key": "schoolid",
+													"value": "{{known:schoolId_9011}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Clean up StudentSchoolAssociation Two",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"",
+													"const responseItems = pm.response.json();",
+													"",
+													"pm.test('Delete studentschoolassociations with school 9011', () => {",
+													"",
+													"           responseItems.forEach(responseItem => {",
+													"            ",
+													"            if(isNaN(responseItem.id))",
+													"            {",
+													"                let ProgramDeleteRequest = {",
+													"                        url: pm.environment.get(\"ApiBaseUrl\") + \"/data/v3/ed-fi/studentschoolassociations/\" + responseItem.id,",
+													"                        method: 'DELETE',",
+													"                        header: 'Authorization:bearer ' + pm.environment.get(\"AccessToken_255901-A\"),",
+													"                        body: {}",
+													"                };",
+													"    ",
+													"                pm.sendRequest(ProgramDeleteRequest, function (err, ProgramDelete) {",
+													"                        if (err) {",
+													"                            console.log(err);",
+													"                        } else {}",
+													"                    });",
+													"           }",
+													"        });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/studentschoolassociations/?schoolid={{known:schoolId_9021}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"studentschoolassociations",
+												""
+											],
+											"query": [
+												{
+													"key": "schoolid",
+													"value": "{{known:schoolId_9021}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Clean up section",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"",
+													"const responseItems = pm.response.json();",
+													"",
+													"pm.test('Delete sections with SchoolID 9011 & 9021 ', () => {",
+													"",
+													"           responseItems.forEach(responseItem => {",
+													"            ",
+													"            if(isNaN(responseItem.id))",
+													"            {",
+													"                let ProgramDeleteRequest = {",
+													"                        url: pm.environment.get(\"ApiBaseUrl\") + \"/data/v3/ed-fi/sections/\" + responseItem.id,",
+													"                        method: 'DELETE',",
+													"                        header: 'Authorization:bearer ' + pm.environment.get(\"AccessToken_255901-A\"),",
+													"                        body: {}",
+													"                };",
+													"    ",
+													"                pm.sendRequest(ProgramDeleteRequest, function (err, ProgramDelete) {",
+													"                        if (err) {",
+													"                            console.log(err);",
+													"                        } else {}",
+													"                    });",
+													"           }",
+													"        });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/sections?localCourseCode=RecordOwnership",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"sections"
+											],
+											"query": [
+												{
+													"key": "localCourseCode",
+													"value": "RecordOwnership"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Clean up CourseOfferings",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"",
+													"const responseItems = pm.response.json();",
+													"",
+													"pm.test('Delete CourseOfferings with SchoolID 9011 & 9021 ', () => {",
+													"",
+													"           responseItems.forEach(responseItem => {",
+													"            ",
+													"            if(isNaN(responseItem.id))",
+													"            {",
+													"                let ProgramDeleteRequest = {",
+													"                        url: pm.environment.get(\"ApiBaseUrl\") + \"/data/v3/ed-fi/CourseOfferings/\" + responseItem.id,",
+													"                        method: 'DELETE',",
+													"                        header: 'Authorization:bearer ' + pm.environment.get(\"AccessToken_255901-A\"),",
+													"                        body: {}",
+													"                };",
+													"    ",
+													"                pm.sendRequest(ProgramDeleteRequest, function (err, ProgramDelete) {",
+													"                        if (err) {",
+													"                            console.log(err);",
+													"                        } else {}",
+													"                    });",
+													"           }",
+													"        });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/CourseOfferings?courseCode=RecordOwnership",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"CourseOfferings"
+											],
+											"query": [
+												{
+													"key": "courseCode",
+													"value": "RecordOwnership"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Clean up Sessions",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"",
+													"const responseItems = pm.response.json();",
+													"",
+													"pm.test('Delete sessions with SchoolID 9011 & 9021 ', () => {",
+													"",
+													"           responseItems.forEach(responseItem => {",
+													"            ",
+													"            if(isNaN(responseItem.id))",
+													"            {",
+													"                let ProgramDeleteRequest = {",
+													"                        url: pm.environment.get(\"ApiBaseUrl\") + \"/data/v3/ed-fi/sessions/\" + responseItem.id,",
+													"                        method: 'DELETE',",
+													"                        header: 'Authorization:bearer ' + pm.environment.get(\"AccessToken_255901-A\"),",
+													"                        body: {}",
+													"                };",
+													"    ",
+													"                pm.sendRequest(ProgramDeleteRequest, function (err, ProgramDelete) {",
+													"                        if (err) {",
+													"                            console.log(err);",
+													"                        } else {}",
+													"                    });",
+													"           }",
+													"        });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/sessions?sessionName=2021-2022 Fall Semester Record Ownership",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"sessions"
+											],
+											"query": [
+												{
+													"key": "sessionName",
+													"value": "2021-2022 Fall Semester Record Ownership"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Clean up Course",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"",
+													"const responseItems = pm.response.json();",
+													"",
+													"pm.test('Delete all Courses with SchoolID 9011 & 9021 ', () => {",
+													"",
+													"           responseItems.forEach(responseItem => {",
+													"            ",
+													"            if(isNaN(responseItem.id))",
+													"            {",
+													"                let ProgramDeleteRequest = {",
+													"                        url: pm.environment.get(\"ApiBaseUrl\") + \"/data/v3/ed-fi/Courses/\" + responseItem.id,",
+													"                        method: 'DELETE',",
+													"                        header: 'Authorization:bearer ' + pm.environment.get(\"AccessToken_255901-A\"),",
+													"                        body: {}",
+													"                };",
+													"    ",
+													"                pm.sendRequest(ProgramDeleteRequest, function (err, ProgramDelete) {",
+													"                        if (err) {",
+													"                            console.log(err);",
+													"                        } else {}",
+													"                    });",
+													"           }",
+													"        });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/Courses?courseCode=RecordOwnership",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"Courses"
+											],
+											"query": [
+												{
+													"key": "courseCode",
+													"value": "RecordOwnership"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Clean up gradingperiods",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {\r",
+													"    pm.expect(pm.response.code).to.equal(200);\r",
+													"});\r",
+													"\r",
+													"const responseItems = pm.response.json();\r",
+													"\r",
+													"pm.test('Delete all gradingperiods with SchoolID 9011 & 9021 ', () => {\r",
+													"\r",
+													"           responseItems.forEach(responseItem => {\r",
+													"            \r",
+													"            if(isNaN(responseItem.id))\r",
+													"            {\r",
+													"                let ProgramDeleteRequest = {\r",
+													"                        url: pm.environment.get(\"ApiBaseUrl\") + \"/data/v3/ed-fi/gradingperiods/\" + responseItem.id,\r",
+													"                        method: 'DELETE',\r",
+													"                        header: 'Authorization:bearer ' + pm.environment.get(\"AccessToken_255901-A\"),\r",
+													"                        body: {}\r",
+													"                };\r",
+													"    \r",
+													"                pm.sendRequest(ProgramDeleteRequest, function (err, ProgramDelete) {\r",
+													"                        if (err) {\r",
+													"                            console.log(err);\r",
+													"                        } else {}\r",
+													"                    });\r",
+													"           }\r",
+													"        });\r",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/gradingperiods/?totalInstructionalDays=99",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"gradingperiods",
+												""
+											],
+											"query": [
+												{
+													"key": "totalInstructionalDays",
+													"value": "99"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Clean up School One",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"",
+													"const responseItems = pm.response.json();",
+													"",
+													"pm.test('Delete 9011 school', () => {",
+													"",
+													"           responseItems.forEach(responseItem => {",
+													"            ",
+													"            if(isNaN(responseItem.id))",
+													"            {",
+													"                let ProgramDeleteRequest = {",
+													"                        url: pm.environment.get(\"ApiBaseUrl\") + \"/data/v3/ed-fi/schools/\" + responseItem.id,",
+													"                        method: 'DELETE',",
+													"                        header: 'Authorization:bearer ' + pm.environment.get(\"AccessToken_255901-A\"),",
+													"                        body: {}",
+													"                };",
+													"    ",
+													"                pm.sendRequest(ProgramDeleteRequest, function (err, ProgramDelete) {",
+													"                        if (err) {",
+													"                            console.log(err);",
+													"                        } else {}",
+													"                    });",
+													"           }",
+													"        });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-A}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools/?schoolid={{known:schoolId_9011}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools",
+												""
+											],
+											"query": [
+												{
+													"key": "schoolid",
+													"value": "{{known:schoolId_9011}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Clean up School Two",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", () => {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"",
+													"const responseItems = pm.response.json();",
+													"",
+													"pm.test('Delete 9021 schools', () => {",
+													"",
+													"           responseItems.forEach(responseItem => {",
+													"            ",
+													"            if(isNaN(responseItem.id))",
+													"            {",
+													"                let ProgramDeleteRequest = {",
+													"                        url: pm.environment.get(\"ApiBaseUrl\") + \"/data/v3/ed-fi/schools/\" + responseItem.id,",
+													"                        method: 'DELETE',",
+													"                        header: 'Authorization:bearer ' + pm.environment.get(\"AccessToken_255901-B\"),",
+													"                        body: {}",
+													"                };",
+													"    ",
+													"                pm.sendRequest(ProgramDeleteRequest, function (err, ProgramDelete) {",
+													"                        if (err) {",
+													"                            console.log(err);",
+													"                        } else {}",
+													"                    });",
+													"           }",
+													"        });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{AccessToken_255901-B}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/schools/?schoolid={{known:schoolId_9021}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											],
+											"path": [
+												"data",
+												"v3",
+												"ed-fi",
+												"schools",
+												""
+											],
+											"query": [
+												{
+													"key": "schoolid",
+													"value": "{{known:schoolId_9021}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Clean up Environment Variables",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const __ = require('lodash');\r",
+													"\r",
+													"const keys = __.keys(pm.environment.toObject());\r",
+													"console.log('Initial keys: ' + JSON.stringify(keys));\r",
+													"\r",
+													"const keysToRemove = __.filter(keys, x => __.startsWith(x, 'known:') || __.startsWith(x, 'supplied:'));\r",
+													"\r",
+													"__.each(keysToRemove, k => pm.environment.unset(k));\r",
+													"\r",
+													"const remainingKeys = __.keys(pm.environment.toObject());\r",
+													"console.log('Remaining keys:' + JSON.stringify(remainingKeys));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{ApiBaseUrl}}",
+											"host": [
+												"{{ApiBaseUrl}}"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"  //--Client 1 should be able to full CRUD their School 1.",
+									"  //--Regular Resource -Client 1 has full CRUD - School 1",
+									" // --Client 2 should be able to full CRUD School 2.",
+									"  //--Regular Resource -Client 2 has full CRUD - School 2",
+									"  //--Assuming Client 2 is assigned the extra ownership token, it should also be able to full CRUD School 1. ",
+									"  //--But Client 1, without the assignment to Ownership Token 2, should not be able to CRUD School 2."
+								]
+							}
+						}
+					]
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"  //--Client 1 should be able to full CRUD their School 1.",
+							"  //--Derived Resource -Client 1 has full CRUD - School 1",
+							" // --Client 2 should be able to full CRUD School 2.",
+							"  //--Derived Resource -Client 2 has full CRUD - School 2",
+							"",
+							"  //--Assuming Client 2 is assigned the extra ownership token, it should also be able to full CRUD School 1. ",
+							"  ",
+							"  //--But Client 1, without the assignment to Ownership Token 2, should not be able to CRUD School 2."
+						]
+					}
+				}
+			]
+		}
+	],
+	"auth": {
+		"type": "bearer",
+		"bearer": [
+			{
+				"key": "token",
+				"value": "{{AccessToken_255901-A}}",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					"CreateAccessToken(\"TokenExpiry_255901-A\",",
+					"                  \"AccessToken_255901-A\",",
+					"                  \"ApiKey_255901-A\", ",
+					"                  \"ApiSecret_255901-A\")",
+					"                  ",
+					"CreateAccessToken(\"TokenExpiry_255901-B\",",
+					"                  \"AccessToken_255901-B\",",
+					"                  \"ApiKey_255901-B\", ",
+					"                  \"ApiSecret_255901-B\")",
+					"",
+					"// Adapted from: https://marcin-chwedczuk.github.io/automatically-generate-new-oauth2-tokens-when-using-postman",
+					"// Assumes Environment with Environment Variables: ApiBaseUrl, ApiKey, ApiSecret",
+					"// See https://gist.github.com/blmeyers/21138bbe6f80b8c35701a8754bfe59d5 for an environment sample for Local (NOTE: environment variable names have been changed from the gist -- you must adjust accordingly)",
+					"// Handles auto refreshing based on provided expiration, but doesn't handle the token being revoked early",
+					"// If stuck with \"Bad Token\" or \"Not Authenticated\", just delete the Token or TokenExpiry variables to force a new token",
+					"function CreateAccessToken(TokenExpiry,AccessToken,ApiKey, ApiSecret)",
+					"                  {",
+					"let tokenExpiration = pm.environment.get(TokenExpiry);",
+					"let currentToken = pm.environment.get(AccessToken);",
+					"let  getToken = true;",
+					"if (!tokenExpiration || ",
+					"    !currentToken) {",
+					"    console.log('Token or expiry date are missing, retrieving new token')",
+					"} else if (tokenExpiration <= (new Date()).getTime()) {",
+					"    console.log('Token is expired, retrieving new token')",
+					"} else {",
+					"    getToken = false;",
+					"    console.log('Token and expiration date are still valid');",
+					"}",
+					"if (getToken === true) {",
+					"    let tokenUrl = pm.environment.get('ApiBaseUrl') + '/oauth/token';",
+					"    let clientId = pm.environment.get(ApiKey);",
+					"    let clientSecret = pm.environment.get(ApiSecret);",
+					"    let grantType = 'client_credentials';",
+					"    ",
+					"    let getTokenRequest = {",
+					"        method: 'POST',",
+					"        url: tokenUrl,",
+					"        auth: {",
+					"            type: \"basic\",",
+					"            basic: [",
+					"                { key: \"username\", value: clientId },",
+					"                { key: \"password\", value: clientSecret }",
+					"            ]",
+					"        },",
+					"        header: [",
+					"            \"content-type:application/x-www-form-urlencoded\"",
+					"        ],",
+					"        body: {",
+					"            mode: \"urlencoded\",",
+					"            urlencoded: [{key: \"grant_type\", value: grantType}]",
+					"        }",
+					"    };",
+					"    ",
+					"    pm.sendRequest(getTokenRequest, (err, response) => {",
+					"        let jsonResponse = response.json(),",
+					"            newAccessToken = jsonResponse.access_token;",
+					"    ",
+					"        console.log({ err, jsonResponse, newAccessToken })",
+					"    ",
+					"        pm.environment.set(AccessToken, newAccessToken);",
+					"    ",
+					"        let expiryDate = new Date();",
+					"        expiryDate.setSeconds(expiryDate.getSeconds() + jsonResponse.expires_in);",
+					"        pm.environment.set(TokenExpiry, expiryDate.getTime());",
+					"    });",
+					"}",
+					"}",
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					"  //--Client 1 should be able to full CRUD their School 1.",
+					"  //--Derived Resource -Client 1 has full CRUD - School 1",
+					" // --Client 2 should be able to full CRUD School 2.",
+					"  //--Derived Resource -Client 2 has full CRUD - School 2",
+					"  //--Assuming Client 2 is assigned the extra ownership token, it should also be able to full CRUD School 1. ",
+					"  //--But Client 1, without the assignment to Ownership Token 2, should not be able to CRUD School 2."
+				]
+			}
+		}
+	]
+}

--- a/Postman Test Suite/Record Ownership Test/Record Ownership Manual Setup Scripts.sql
+++ b/Postman Test Suite/Record Ownership Test/Record Ownership Manual Setup Scripts.sql
@@ -1,0 +1,69 @@
+   --Client 1 should be able to full CRUD their School 1.
+  --Resource -Client 1 has full CRUD - School 1
+  --Client 2 should be able to full CRUD School 2.
+  -- Resource -Client 2 has full CRUD - School 2
+  --Assuming Client 2 is assigned the extra ownership token, it should also be able to full CRUD School 1. 
+  --But Client 1, without the assignment to Ownership Token 2, should not be able to CRUD School 2.
+
+USE EdFi_Admin_Test
+GO
+
+INSERT INTO [dbo].[OwnershipTokens] ([Description])     VALUES  ('OwnershipToken_One')
+INSERT INTO [dbo].[OwnershipTokens] ([Description])     VALUES  ('OwnershipToken_Two')
+
+DECLARE @ApiClient_ApiClientId_One INT;
+DECLARE @ApiClient_ApiClientId_Two INT;
+DECLARE @OwnershipToken_OwnershipTokenId_One INT;
+DECLARE @OwnershipToken_OwnershipTokenId_Two INT;
+SELECT @ApiClient_ApiClientId_One = ApiClientId FROM [dbo].[ApiClients] where Name in ('255901-A');
+
+SELECT @OwnershipToken_OwnershipTokenId_One = OwnershipTokenId FROM [dbo].[OwnershipTokens] where [Description] in ('OwnershipToken_One')
+INSERT INTO [dbo].[ApiClientOwnershipTokens]([ApiClient_ApiClientId],[OwnershipToken_OwnershipTokenId]) VALUES (@ApiClient_ApiClientId_One,@OwnershipToken_OwnershipTokenId_One)
+
+UPDATE [dbo].[ApiClients]
+   SET CreatorOwnershipTokenId_OwnershipTokenId = @OwnershipToken_OwnershipTokenId_One
+ WHERE ApiClientId =@ApiClient_ApiClientId_One
+
+
+SELECT @ApiClient_ApiClientId_Two = ApiClientId FROM [dbo].[ApiClients] where Name in ('255901-B');
+INSERT INTO [dbo].[ApiClientOwnershipTokens]([ApiClient_ApiClientId],[OwnershipToken_OwnershipTokenId]) VALUES (@ApiClient_ApiClientId_Two,@OwnershipToken_OwnershipTokenId_One)
+
+SELECT @OwnershipToken_OwnershipTokenId_Two = OwnershipTokenId FROM [dbo].[OwnershipTokens] where [Description] in ('OwnershipToken_Two')
+INSERT INTO [dbo].[ApiClientOwnershipTokens]([ApiClient_ApiClientId],[OwnershipToken_OwnershipTokenId]) VALUES (@ApiClient_ApiClientId_Two,@OwnershipToken_OwnershipTokenId_Two)
+
+UPDATE [dbo].[ApiClients]
+   SET CreatorOwnershipTokenId_OwnershipTokenId = @OwnershipToken_OwnershipTokenId_Two
+ WHERE ApiClientId =@ApiClient_ApiClientId_Two
+
+USE [EdFi_Security_Test]
+Go
+
+DECLARE @OwnershipBasedAuthorizationStrategyId INT;
+
+SELECT @OwnershipBasedAuthorizationStrategyId=  AuthorizationStrategyId FROM [dbo].[AuthorizationStrategies]
+WHERE [AuthorizationStrategyName]='OwnershipBased';
+
+ --education organization resource claims for read update and delete
+ INSERT INTO  [dbo].[ResourceClaimActionAuthorizationStrategies]
+ ([ResourceClaimActionId],[AuthorizationStrategyId]) 
+ SELECT ResourceClaimActionId,@OwnershipBasedAuthorizationStrategyId  FROM [dbo].ResourceClaimActions rca 
+INNER JOIN  [dbo].ResourceClaims rc  on rca.ResourceClaimId = rc.ResourceClaimId
+AND ClaimName='http://ed-fi.org/ods/identity/claims/domains/educationOrganizations'
+INNER JOIN  [dbo].Actions a  on a.ActionId= rca.ActionId 
+AND a.ActionName in ('Read','Update','Delete')
+
+ --studentSectionAssociation resource claims for read update and delete
+ INSERT INTO [dbo].[ResourceClaimActions]
+ ([ResourceClaimId],[ActionId])
+ SELECT ResourceClaimId,ActionId  FROM [dbo].ResourceClaims ,  [dbo].Actions 
+WHERE ActionName in ('Read','Update','Delete')
+ AND ClaimName='http://ed-fi.org/ods/identity/claims/studentSectionAssociation'
+ 
+
+  INSERT INTO  [dbo].[ResourceClaimActionAuthorizationStrategies]
+ ([ResourceClaimActionId],[AuthorizationStrategyId]) 
+ SELECT ResourceClaimActionId,@OwnershipBasedAuthorizationStrategyId  FROM [dbo].ResourceClaimActions rca 
+INNER JOIN  [dbo].ResourceClaims rc  on rca.ResourceClaimId = rc.ResourceClaimId
+AND ClaimName='http://ed-fi.org/ods/identity/claims/studentSectionAssociation'
+INNER JOIN  [dbo].Actions a  on a.ActionId= rca.ActionId 
+AND a.ActionName in ('Read','Update','Delete')

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Extensions.Homograph_Resources_Resources.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Extensions.Homograph_Resources_Resources.generated.approved.cs
@@ -176,7 +176,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Name.Homograph
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Homograph.IName;
 
             if (ReferenceEquals(this, compareTo))
@@ -187,15 +186,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Name.Homograph
 
 
             // Standard Property
-            if ((this as Entities.Common.Homograph.IName).FirstName == null
-                || !(this as Entities.Common.Homograph.IName).FirstName.Equals(compareTo.FirstName))
+             if ((this as Entities.Common.Homograph.IName).FirstName.Equals(compareTo.FirstName))
                 return false;
 
+
             // Standard Property
-            if ((this as Entities.Common.Homograph.IName).LastSurname == null
-                || !(this as Entities.Common.Homograph.IName).LastSurname.Equals(compareTo.LastSurname))
+             if ((this as Entities.Common.Homograph.IName).LastSurname.Equals(compareTo.LastSurname))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -208,21 +206,19 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Name.Homograph
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 // Standard Property
-                if ((this as Entities.Common.Homograph.IName).FirstName != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IName).FirstName.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Homograph.IName).FirstName.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.Homograph.IName).LastSurname != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IName).LastSurname.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Homograph.IName).LastSurname.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -577,7 +573,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.Homograph
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Homograph.IParent;
 
             if (ReferenceEquals(this, compareTo))
@@ -588,15 +583,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.Homograph
 
 
             // Referenced Property
-            if ((this as Entities.Common.Homograph.IParent).ParentFirstName == null
-                || !(this as Entities.Common.Homograph.IParent).ParentFirstName.Equals(compareTo.ParentFirstName))
+            if (!(this as Entities.Common.Homograph.IParent).ParentFirstName.Equals(compareTo.ParentFirstName))
                 return false;
 
+
             // Referenced Property
-            if ((this as Entities.Common.Homograph.IParent).ParentLastSurname == null
-                || !(this as Entities.Common.Homograph.IParent).ParentLastSurname.Equals(compareTo.ParentLastSurname))
+            if (!(this as Entities.Common.Homograph.IParent).ParentLastSurname.Equals(compareTo.ParentLastSurname))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -609,21 +603,17 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.Homograph
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Referenced Property
-                if ((this as Entities.Common.Homograph.IParent).ParentFirstName != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IParent).ParentFirstName.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Homograph.IParent).ParentFirstName.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Homograph.IParent).ParentLastSurname != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IParent).ParentLastSurname.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Homograph.IParent).ParentLastSurname.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -940,7 +930,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.Homograph
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Homograph.IParentAddress;
 
             if (ReferenceEquals(this, compareTo))
@@ -955,10 +944,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.Homograph
 
 
             // Standard Property
-            if ((this as Entities.Common.Homograph.IParentAddress).City == null
-                || !(this as Entities.Common.Homograph.IParentAddress).City.Equals(compareTo.City))
+             if ((this as Entities.Common.Homograph.IParentAddress).City.Equals(compareTo.City))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -971,7 +959,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.Homograph
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -980,11 +967,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.Homograph
                     hash = hash * 23 + _parent.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Homograph.IParentAddress).City != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IParentAddress).City.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Homograph.IParentAddress).City.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -1276,7 +1262,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.Homograph
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Homograph.IParentStudentSchoolAssociation;
 
             if (ReferenceEquals(this, compareTo))
@@ -1291,20 +1276,19 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.Homograph
 
 
             // Referenced Property
-            if ((this as Entities.Common.Homograph.IParentStudentSchoolAssociation).SchoolName == null
-                || !(this as Entities.Common.Homograph.IParentStudentSchoolAssociation).SchoolName.Equals(compareTo.SchoolName))
+            if (!(this as Entities.Common.Homograph.IParentStudentSchoolAssociation).SchoolName.Equals(compareTo.SchoolName))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.Homograph.IParentStudentSchoolAssociation).StudentFirstName == null
-                || !(this as Entities.Common.Homograph.IParentStudentSchoolAssociation).StudentFirstName.Equals(compareTo.StudentFirstName))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.Homograph.IParentStudentSchoolAssociation).StudentLastSurname == null
-                || !(this as Entities.Common.Homograph.IParentStudentSchoolAssociation).StudentLastSurname.Equals(compareTo.StudentLastSurname))
+            if (!(this as Entities.Common.Homograph.IParentStudentSchoolAssociation).StudentFirstName.Equals(compareTo.StudentFirstName))
                 return false;
-            #pragma warning disable 472
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.Homograph.IParentStudentSchoolAssociation).StudentLastSurname.Equals(compareTo.StudentLastSurname))
+                return false;
+
 
             return true;
         }
@@ -1317,7 +1301,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.Homograph
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -1326,19 +1309,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.Homograph
                     hash = hash * 23 + _parent.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Homograph.IParentStudentSchoolAssociation).SchoolName != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IParentStudentSchoolAssociation).SchoolName.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Homograph.IParentStudentSchoolAssociation).SchoolName.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Homograph.IParentStudentSchoolAssociation).StudentFirstName != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IParentStudentSchoolAssociation).StudentFirstName.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Homograph.IParentStudentSchoolAssociation).StudentFirstName.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Homograph.IParentStudentSchoolAssociation).StudentLastSurname != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IParentStudentSchoolAssociation).StudentLastSurname.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Homograph.IParentStudentSchoolAssociation).StudentLastSurname.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -1652,7 +1631,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.Homograph
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Homograph.ISchool;
 
             if (ReferenceEquals(this, compareTo))
@@ -1663,10 +1641,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.Homograph
 
 
             // Standard Property
-            if ((this as Entities.Common.Homograph.ISchool).SchoolName == null
-                || !(this as Entities.Common.Homograph.ISchool).SchoolName.Equals(compareTo.SchoolName))
+             if ((this as Entities.Common.Homograph.ISchool).SchoolName.Equals(compareTo.SchoolName))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -1679,17 +1656,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.Homograph
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 // Standard Property
-                if ((this as Entities.Common.Homograph.ISchool).SchoolName != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.ISchool).SchoolName.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Homograph.ISchool).SchoolName.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -1932,7 +1907,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.Homograph
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Homograph.ISchoolAddress;
 
             if (ReferenceEquals(this, compareTo))
@@ -1945,7 +1919,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.Homograph
             if (_school == null || !_school.Equals(compareTo.School))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -1958,7 +1931,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.Homograph
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -1967,7 +1939,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.Homograph
                     hash = hash * 23 + _school.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -2242,7 +2213,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SchoolYearType.Homograph
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Homograph.ISchoolYearType;
 
             if (ReferenceEquals(this, compareTo))
@@ -2253,10 +2223,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SchoolYearType.Homograph
 
 
             // Standard Property
-            if ((this as Entities.Common.Homograph.ISchoolYearType).SchoolYear == null
-                || !(this as Entities.Common.Homograph.ISchoolYearType).SchoolYear.Equals(compareTo.SchoolYear))
+             if ((this as Entities.Common.Homograph.ISchoolYearType).SchoolYear.Equals(compareTo.SchoolYear))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -2269,17 +2238,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SchoolYearType.Homograph
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 // Standard Property
-                if ((this as Entities.Common.Homograph.ISchoolYearType).SchoolYear != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.ISchoolYearType).SchoolYear.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Homograph.ISchoolYearType).SchoolYear.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -2634,7 +2601,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.Homograph
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Homograph.IStaff;
 
             if (ReferenceEquals(this, compareTo))
@@ -2645,15 +2611,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.Homograph
 
 
             // Referenced Property
-            if ((this as Entities.Common.Homograph.IStaff).StaffFirstName == null
-                || !(this as Entities.Common.Homograph.IStaff).StaffFirstName.Equals(compareTo.StaffFirstName))
+            if (!(this as Entities.Common.Homograph.IStaff).StaffFirstName.Equals(compareTo.StaffFirstName))
                 return false;
 
+
             // Referenced Property
-            if ((this as Entities.Common.Homograph.IStaff).StaffLastSurname == null
-                || !(this as Entities.Common.Homograph.IStaff).StaffLastSurname.Equals(compareTo.StaffLastSurname))
+            if (!(this as Entities.Common.Homograph.IStaff).StaffLastSurname.Equals(compareTo.StaffLastSurname))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -2666,21 +2631,17 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.Homograph
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Referenced Property
-                if ((this as Entities.Common.Homograph.IStaff).StaffFirstName != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IStaff).StaffFirstName.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Homograph.IStaff).StaffFirstName.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Homograph.IStaff).StaffLastSurname != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IStaff).StaffLastSurname.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Homograph.IStaff).StaffLastSurname.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -2997,7 +2958,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.Homograph
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Homograph.IStaffAddress;
 
             if (ReferenceEquals(this, compareTo))
@@ -3012,10 +2972,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.Homograph
 
 
             // Standard Property
-            if ((this as Entities.Common.Homograph.IStaffAddress).City == null
-                || !(this as Entities.Common.Homograph.IStaffAddress).City.Equals(compareTo.City))
+             if ((this as Entities.Common.Homograph.IStaffAddress).City.Equals(compareTo.City))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -3028,7 +2987,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.Homograph
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -3037,11 +2995,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.Homograph
                     hash = hash * 23 + _staff.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Homograph.IStaffAddress).City != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IStaffAddress).City.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Homograph.IStaffAddress).City.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -3333,7 +3290,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.Homograph
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Homograph.IStaffStudentSchoolAssociation;
 
             if (ReferenceEquals(this, compareTo))
@@ -3348,20 +3304,19 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.Homograph
 
 
             // Referenced Property
-            if ((this as Entities.Common.Homograph.IStaffStudentSchoolAssociation).SchoolName == null
-                || !(this as Entities.Common.Homograph.IStaffStudentSchoolAssociation).SchoolName.Equals(compareTo.SchoolName))
+            if (!(this as Entities.Common.Homograph.IStaffStudentSchoolAssociation).SchoolName.Equals(compareTo.SchoolName))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.Homograph.IStaffStudentSchoolAssociation).StudentFirstName == null
-                || !(this as Entities.Common.Homograph.IStaffStudentSchoolAssociation).StudentFirstName.Equals(compareTo.StudentFirstName))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.Homograph.IStaffStudentSchoolAssociation).StudentLastSurname == null
-                || !(this as Entities.Common.Homograph.IStaffStudentSchoolAssociation).StudentLastSurname.Equals(compareTo.StudentLastSurname))
+            if (!(this as Entities.Common.Homograph.IStaffStudentSchoolAssociation).StudentFirstName.Equals(compareTo.StudentFirstName))
                 return false;
-            #pragma warning disable 472
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.Homograph.IStaffStudentSchoolAssociation).StudentLastSurname.Equals(compareTo.StudentLastSurname))
+                return false;
+
 
             return true;
         }
@@ -3374,7 +3329,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.Homograph
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -3383,19 +3337,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.Homograph
                     hash = hash * 23 + _staff.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Homograph.IStaffStudentSchoolAssociation).SchoolName != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IStaffStudentSchoolAssociation).SchoolName.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Homograph.IStaffStudentSchoolAssociation).SchoolName.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Homograph.IStaffStudentSchoolAssociation).StudentFirstName != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IStaffStudentSchoolAssociation).StudentFirstName.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Homograph.IStaffStudentSchoolAssociation).StudentFirstName.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Homograph.IStaffStudentSchoolAssociation).StudentLastSurname != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IStaffStudentSchoolAssociation).StudentLastSurname.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Homograph.IStaffStudentSchoolAssociation).StudentLastSurname.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -3791,7 +3741,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.Homograph
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Homograph.IStudent;
 
             if (ReferenceEquals(this, compareTo))
@@ -3802,15 +3751,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.Homograph
 
 
             // Referenced Property
-            if ((this as Entities.Common.Homograph.IStudent).StudentFirstName == null
-                || !(this as Entities.Common.Homograph.IStudent).StudentFirstName.Equals(compareTo.StudentFirstName))
+            if (!(this as Entities.Common.Homograph.IStudent).StudentFirstName.Equals(compareTo.StudentFirstName))
                 return false;
 
+
             // Referenced Property
-            if ((this as Entities.Common.Homograph.IStudent).StudentLastSurname == null
-                || !(this as Entities.Common.Homograph.IStudent).StudentLastSurname.Equals(compareTo.StudentLastSurname))
+            if (!(this as Entities.Common.Homograph.IStudent).StudentLastSurname.Equals(compareTo.StudentLastSurname))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -3823,21 +3771,17 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.Homograph
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Referenced Property
-                if ((this as Entities.Common.Homograph.IStudent).StudentFirstName != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IStudent).StudentFirstName.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Homograph.IStudent).StudentFirstName.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Homograph.IStudent).StudentLastSurname != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IStudent).StudentLastSurname.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Homograph.IStudent).StudentLastSurname.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -4146,7 +4090,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.Homograph
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Homograph.IStudentAddress;
 
             if (ReferenceEquals(this, compareTo))
@@ -4161,10 +4104,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.Homograph
 
 
             // Standard Property
-            if ((this as Entities.Common.Homograph.IStudentAddress).City == null
-                || !(this as Entities.Common.Homograph.IStudentAddress).City.Equals(compareTo.City))
+             if ((this as Entities.Common.Homograph.IStudentAddress).City.Equals(compareTo.City))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -4177,7 +4119,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.Homograph
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -4186,11 +4127,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.Homograph
                     hash = hash * 23 + _student.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Homograph.IStudentAddress).City != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IStudentAddress).City.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Homograph.IStudentAddress).City.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -4596,7 +4536,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentSchoolAssociation.Homograp
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Homograph.IStudentSchoolAssociation;
 
             if (ReferenceEquals(this, compareTo))
@@ -4607,20 +4546,19 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentSchoolAssociation.Homograp
 
 
             // Referenced Property
-            if ((this as Entities.Common.Homograph.IStudentSchoolAssociation).SchoolName == null
-                || !(this as Entities.Common.Homograph.IStudentSchoolAssociation).SchoolName.Equals(compareTo.SchoolName))
+            if (!(this as Entities.Common.Homograph.IStudentSchoolAssociation).SchoolName.Equals(compareTo.SchoolName))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.Homograph.IStudentSchoolAssociation).StudentFirstName == null
-                || !(this as Entities.Common.Homograph.IStudentSchoolAssociation).StudentFirstName.Equals(compareTo.StudentFirstName))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.Homograph.IStudentSchoolAssociation).StudentLastSurname == null
-                || !(this as Entities.Common.Homograph.IStudentSchoolAssociation).StudentLastSurname.Equals(compareTo.StudentLastSurname))
+            if (!(this as Entities.Common.Homograph.IStudentSchoolAssociation).StudentFirstName.Equals(compareTo.StudentFirstName))
                 return false;
-            #pragma warning disable 472
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.Homograph.IStudentSchoolAssociation).StudentLastSurname.Equals(compareTo.StudentLastSurname))
+                return false;
+
 
             return true;
         }
@@ -4633,25 +4571,20 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentSchoolAssociation.Homograp
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Referenced Property
-                if ((this as Entities.Common.Homograph.IStudentSchoolAssociation).SchoolName != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IStudentSchoolAssociation).SchoolName.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Homograph.IStudentSchoolAssociation).SchoolName.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Homograph.IStudentSchoolAssociation).StudentFirstName != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IStudentSchoolAssociation).StudentFirstName.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Homograph.IStudentSchoolAssociation).StudentFirstName.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Homograph.IStudentSchoolAssociation).StudentLastSurname != null)
-                    hash = hash * 23 + (this as Entities.Common.Homograph.IStudentSchoolAssociation).StudentLastSurname.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Homograph.IStudentSchoolAssociation).StudentLastSurname.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Extensions.SampleStudentTranscript_Resources_Resources.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Extensions.SampleStudentTranscript_Resources_Resources.generated.approved.cs
@@ -90,7 +90,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.InstitutionControlDescriptor.Samp
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.SampleStudentTranscript.IInstitutionControlDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -101,10 +100,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.InstitutionControlDescriptor.Samp
 
 
             // Derived Property
-            if ((this as Entities.Common.SampleStudentTranscript.IInstitutionControlDescriptor).InstitutionControlDescriptorId == null
-                || !(this as Entities.Common.SampleStudentTranscript.IInstitutionControlDescriptor).InstitutionControlDescriptorId.Equals(compareTo.InstitutionControlDescriptorId))
+            if (!(this as Entities.Common.SampleStudentTranscript.IInstitutionControlDescriptor).InstitutionControlDescriptorId.Equals(compareTo.InstitutionControlDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -117,17 +115,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.InstitutionControlDescriptor.Samp
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.SampleStudentTranscript.IInstitutionControlDescriptor).InstitutionControlDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.SampleStudentTranscript.IInstitutionControlDescriptor).InstitutionControlDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.SampleStudentTranscript.IInstitutionControlDescriptor).InstitutionControlDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -378,7 +374,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.InstitutionLevelDescriptor.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.SampleStudentTranscript.IInstitutionLevelDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -389,10 +384,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.InstitutionLevelDescriptor.Sample
 
 
             // Derived Property
-            if ((this as Entities.Common.SampleStudentTranscript.IInstitutionLevelDescriptor).InstitutionLevelDescriptorId == null
-                || !(this as Entities.Common.SampleStudentTranscript.IInstitutionLevelDescriptor).InstitutionLevelDescriptorId.Equals(compareTo.InstitutionLevelDescriptorId))
+            if (!(this as Entities.Common.SampleStudentTranscript.IInstitutionLevelDescriptor).InstitutionLevelDescriptorId.Equals(compareTo.InstitutionLevelDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -405,17 +399,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.InstitutionLevelDescriptor.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.SampleStudentTranscript.IInstitutionLevelDescriptor).InstitutionLevelDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.SampleStudentTranscript.IInstitutionLevelDescriptor).InstitutionLevelDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.SampleStudentTranscript.IInstitutionLevelDescriptor).InstitutionLevelDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -742,7 +734,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PostSecondaryOrganization.SampleS
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.SampleStudentTranscript.IPostSecondaryOrganization;
 
             if (ReferenceEquals(this, compareTo))
@@ -753,10 +744,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PostSecondaryOrganization.SampleS
 
 
             // Standard Property
-            if ((this as Entities.Common.SampleStudentTranscript.IPostSecondaryOrganization).NameOfInstitution == null
-                || !(this as Entities.Common.SampleStudentTranscript.IPostSecondaryOrganization).NameOfInstitution.Equals(compareTo.NameOfInstitution))
+             if ((this as Entities.Common.SampleStudentTranscript.IPostSecondaryOrganization).NameOfInstitution.Equals(compareTo.NameOfInstitution))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -769,17 +759,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PostSecondaryOrganization.SampleS
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 // Standard Property
-                if ((this as Entities.Common.SampleStudentTranscript.IPostSecondaryOrganization).NameOfInstitution != null)
-                    hash = hash * 23 + (this as Entities.Common.SampleStudentTranscript.IPostSecondaryOrganization).NameOfInstitution.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.SampleStudentTranscript.IPostSecondaryOrganization).NameOfInstitution.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -998,7 +986,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SpecialEducationGraduationStatusD
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.SampleStudentTranscript.ISpecialEducationGraduationStatusDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -1009,10 +996,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SpecialEducationGraduationStatusD
 
 
             // Derived Property
-            if ((this as Entities.Common.SampleStudentTranscript.ISpecialEducationGraduationStatusDescriptor).SpecialEducationGraduationStatusDescriptorId == null
-                || !(this as Entities.Common.SampleStudentTranscript.ISpecialEducationGraduationStatusDescriptor).SpecialEducationGraduationStatusDescriptorId.Equals(compareTo.SpecialEducationGraduationStatusDescriptorId))
+            if (!(this as Entities.Common.SampleStudentTranscript.ISpecialEducationGraduationStatusDescriptor).SpecialEducationGraduationStatusDescriptorId.Equals(compareTo.SpecialEducationGraduationStatusDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -1025,17 +1011,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SpecialEducationGraduationStatusD
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.SampleStudentTranscript.ISpecialEducationGraduationStatusDescriptor).SpecialEducationGraduationStatusDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.SampleStudentTranscript.ISpecialEducationGraduationStatusDescriptor).SpecialEducationGraduationStatusDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.SampleStudentTranscript.ISpecialEducationGraduationStatusDescriptor).SpecialEducationGraduationStatusDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -1284,7 +1268,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentAcademicRecord.EdFi.Extens
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.SampleStudentTranscript.IStudentAcademicRecordClassRankingExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -1297,7 +1280,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentAcademicRecord.EdFi.Extens
             if (_studentAcademicRecordClassRanking == null || !_studentAcademicRecordClassRanking.Equals(compareTo.StudentAcademicRecordClassRanking))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -1310,7 +1292,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentAcademicRecord.EdFi.Extens
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -1319,7 +1300,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentAcademicRecord.EdFi.Extens
                     hash = hash * 23 + _studentAcademicRecordClassRanking.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -1544,7 +1524,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentAcademicRecord.EdFi.Extens
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.SampleStudentTranscript.IStudentAcademicRecordExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -1557,7 +1536,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentAcademicRecord.EdFi.Extens
             if (_studentAcademicRecord == null || !_studentAcademicRecord.Equals(compareTo.StudentAcademicRecord))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -1570,7 +1548,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentAcademicRecord.EdFi.Extens
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -1579,7 +1556,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentAcademicRecord.EdFi.Extens
                     hash = hash * 23 + _studentAcademicRecord.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -1820,7 +1796,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SubmissionCertificationDescriptor
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.SampleStudentTranscript.ISubmissionCertificationDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -1831,10 +1806,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SubmissionCertificationDescriptor
 
 
             // Derived Property
-            if ((this as Entities.Common.SampleStudentTranscript.ISubmissionCertificationDescriptor).SubmissionCertificationDescriptorId == null
-                || !(this as Entities.Common.SampleStudentTranscript.ISubmissionCertificationDescriptor).SubmissionCertificationDescriptorId.Equals(compareTo.SubmissionCertificationDescriptorId))
+            if (!(this as Entities.Common.SampleStudentTranscript.ISubmissionCertificationDescriptor).SubmissionCertificationDescriptorId.Equals(compareTo.SubmissionCertificationDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -1847,17 +1821,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SubmissionCertificationDescriptor
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.SampleStudentTranscript.ISubmissionCertificationDescriptor).SubmissionCertificationDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.SampleStudentTranscript.ISubmissionCertificationDescriptor).SubmissionCertificationDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.SampleStudentTranscript.ISubmissionCertificationDescriptor).SubmissionCertificationDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Extensions.SampleStudentTransportation_Resources_Resources.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Extensions.SampleStudentTransportation_Resources_Resources.generated.approved.cs
@@ -296,7 +296,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentTransportation.SampleStude
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.SampleStudentTransportation.IStudentTransportation;
 
             if (ReferenceEquals(this, compareTo))
@@ -307,25 +306,24 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentTransportation.SampleStude
 
 
             // Standard Property
-            if ((this as Entities.Common.SampleStudentTransportation.IStudentTransportation).AMBusNumber == null
-                || !(this as Entities.Common.SampleStudentTransportation.IStudentTransportation).AMBusNumber.Equals(compareTo.AMBusNumber))
+             if ((this as Entities.Common.SampleStudentTransportation.IStudentTransportation).AMBusNumber.Equals(compareTo.AMBusNumber))
                 return false;
+
 
             // Standard Property
-            if ((this as Entities.Common.SampleStudentTransportation.IStudentTransportation).PMBusNumber == null
-                || !(this as Entities.Common.SampleStudentTransportation.IStudentTransportation).PMBusNumber.Equals(compareTo.PMBusNumber))
+             if ((this as Entities.Common.SampleStudentTransportation.IStudentTransportation).PMBusNumber.Equals(compareTo.PMBusNumber))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.SampleStudentTransportation.IStudentTransportation).SchoolId == null
-                || !(this as Entities.Common.SampleStudentTransportation.IStudentTransportation).SchoolId.Equals(compareTo.SchoolId))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.SampleStudentTransportation.IStudentTransportation).StudentUniqueId == null
-                || !(this as Entities.Common.SampleStudentTransportation.IStudentTransportation).StudentUniqueId.Equals(compareTo.StudentUniqueId))
+            if (!(this as Entities.Common.SampleStudentTransportation.IStudentTransportation).SchoolId.Equals(compareTo.SchoolId))
                 return false;
-            #pragma warning disable 472
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.SampleStudentTransportation.IStudentTransportation).StudentUniqueId.Equals(compareTo.StudentUniqueId))
+                return false;
+
 
             return true;
         }
@@ -338,29 +336,25 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentTransportation.SampleStude
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 // Standard Property
-                if ((this as Entities.Common.SampleStudentTransportation.IStudentTransportation).AMBusNumber != null)
-                    hash = hash * 23 + (this as Entities.Common.SampleStudentTransportation.IStudentTransportation).AMBusNumber.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.SampleStudentTransportation.IStudentTransportation).AMBusNumber.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.SampleStudentTransportation.IStudentTransportation).PMBusNumber != null)
-                    hash = hash * 23 + (this as Entities.Common.SampleStudentTransportation.IStudentTransportation).PMBusNumber.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.SampleStudentTransportation.IStudentTransportation).PMBusNumber.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.SampleStudentTransportation.IStudentTransportation).SchoolId != null)
-                    hash = hash * 23 + (this as Entities.Common.SampleStudentTransportation.IStudentTransportation).SchoolId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.SampleStudentTransportation.IStudentTransportation).SchoolId.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.SampleStudentTransportation.IStudentTransportation).StudentUniqueId != null)
-                    hash = hash * 23 + (this as Entities.Common.SampleStudentTransportation.IStudentTransportation).StudentUniqueId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.SampleStudentTransportation.IStudentTransportation).StudentUniqueId.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Extensions.Sample_Resources_Resources.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Extensions.Sample_Resources_Resources.generated.approved.cs
@@ -90,7 +90,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.ArtMediumDescriptor.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IArtMediumDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -101,10 +100,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.ArtMediumDescriptor.Sample
 
 
             // Derived Property
-            if ((this as Entities.Common.Sample.IArtMediumDescriptor).ArtMediumDescriptorId == null
-                || !(this as Entities.Common.Sample.IArtMediumDescriptor).ArtMediumDescriptorId.Equals(compareTo.ArtMediumDescriptorId))
+            if (!(this as Entities.Common.Sample.IArtMediumDescriptor).ArtMediumDescriptorId.Equals(compareTo.ArtMediumDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -117,17 +115,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.ArtMediumDescriptor.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.Sample.IArtMediumDescriptor).ArtMediumDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IArtMediumDescriptor).ArtMediumDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IArtMediumDescriptor).ArtMediumDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -454,7 +450,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Bus.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IBus;
 
             if (ReferenceEquals(this, compareTo))
@@ -465,10 +460,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Bus.Sample
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IBus).BusId == null
-                || !(this as Entities.Common.Sample.IBus).BusId.Equals(compareTo.BusId))
+             if ((this as Entities.Common.Sample.IBus).BusId.Equals(compareTo.BusId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -481,17 +475,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Bus.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IBus).BusId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IBus).BusId.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IBus).BusId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -813,7 +805,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IBusRoute;
 
             if (ReferenceEquals(this, compareTo))
@@ -824,15 +815,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IBusRoute).BusId == null
-                || !(this as Entities.Common.Sample.IBusRoute).BusId.Equals(compareTo.BusId))
+             if ((this as Entities.Common.Sample.IBusRoute).BusId.Equals(compareTo.BusId))
                 return false;
 
+
             // Standard Property
-            if ((this as Entities.Common.Sample.IBusRoute).BusRouteNumber == null
-                || !(this as Entities.Common.Sample.IBusRoute).BusRouteNumber.Equals(compareTo.BusRouteNumber))
+             if ((this as Entities.Common.Sample.IBusRoute).BusRouteNumber.Equals(compareTo.BusRouteNumber))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -845,21 +835,19 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IBusRoute).BusId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IBusRoute).BusId.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IBusRoute).BusId.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IBusRoute).BusRouteNumber != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IBusRoute).BusRouteNumber.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IBusRoute).BusRouteNumber.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -1514,7 +1502,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IBusRouteBusYear;
 
             if (ReferenceEquals(this, compareTo))
@@ -1529,10 +1516,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IBusRouteBusYear).BusYear == null
-                || !(this as Entities.Common.Sample.IBusRouteBusYear).BusYear.Equals(compareTo.BusYear))
+             if ((this as Entities.Common.Sample.IBusRouteBusYear).BusYear.Equals(compareTo.BusYear))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -1545,7 +1531,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -1554,11 +1539,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
                     hash = hash * 23 + _busRoute.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IBusRouteBusYear).BusYear != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IBusRouteBusYear).BusYear.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IBusRouteBusYear).BusYear.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -1846,7 +1830,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IBusRouteProgram;
 
             if (ReferenceEquals(this, compareTo))
@@ -1861,20 +1844,19 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
 
 
             // Referenced Property
-            if ((this as Entities.Common.Sample.IBusRouteProgram).EducationOrganizationId == null
-                || !(this as Entities.Common.Sample.IBusRouteProgram).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
+            if (!(this as Entities.Common.Sample.IBusRouteProgram).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
                 return false;
+
 
             // Referenced Property
-            if ((this as Entities.Common.Sample.IBusRouteProgram).ProgramName == null
-                || !(this as Entities.Common.Sample.IBusRouteProgram).ProgramName.Equals(compareTo.ProgramName))
+            if (!(this as Entities.Common.Sample.IBusRouteProgram).ProgramName.Equals(compareTo.ProgramName))
                 return false;
 
+
             // Unified Type Property
-            if ((this as Entities.Common.Sample.IBusRouteProgram).ProgramTypeDescriptor == null
-                ||!(this as Entities.Common.Sample.IBusRouteProgram).ProgramTypeDescriptor.Equals(compareTo.ProgramTypeDescriptor))
+            if (!(this as Entities.Common.Sample.IBusRouteProgram).ProgramTypeDescriptor.Equals(compareTo.ProgramTypeDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -1887,7 +1869,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -1896,19 +1877,16 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
                     hash = hash * 23 + _busRoute.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IBusRouteProgram).EducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IBusRouteProgram).EducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IBusRouteProgram).EducationOrganizationId.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IBusRouteProgram).ProgramName != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IBusRouteProgram).ProgramName.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IBusRouteProgram).ProgramName.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.Sample.IBusRouteProgram).ProgramTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IBusRouteProgram).ProgramTypeDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IBusRouteProgram).ProgramTypeDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -2113,7 +2091,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IBusRouteServiceAreaPostalCode;
 
             if (ReferenceEquals(this, compareTo))
@@ -2128,10 +2105,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IBusRouteServiceAreaPostalCode).ServiceAreaPostalCode == null
-                || !(this as Entities.Common.Sample.IBusRouteServiceAreaPostalCode).ServiceAreaPostalCode.Equals(compareTo.ServiceAreaPostalCode))
+             if ((this as Entities.Common.Sample.IBusRouteServiceAreaPostalCode).ServiceAreaPostalCode.Equals(compareTo.ServiceAreaPostalCode))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -2144,7 +2120,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -2153,11 +2128,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
                     hash = hash * 23 + _busRoute.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IBusRouteServiceAreaPostalCode).ServiceAreaPostalCode != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IBusRouteServiceAreaPostalCode).ServiceAreaPostalCode.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IBusRouteServiceAreaPostalCode).ServiceAreaPostalCode.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -2348,7 +2322,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IBusRouteStartTime;
 
             if (ReferenceEquals(this, compareTo))
@@ -2363,10 +2336,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IBusRouteStartTime).StartTime == null
-                || !(this as Entities.Common.Sample.IBusRouteStartTime).StartTime.Equals(compareTo.StartTime))
+             if ((this as Entities.Common.Sample.IBusRouteStartTime).StartTime.Equals(compareTo.StartTime))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -2379,7 +2351,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -2388,11 +2359,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
                     hash = hash * 23 + _busRoute.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IBusRouteStartTime).StartTime != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IBusRouteStartTime).StartTime.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IBusRouteStartTime).StartTime.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -2590,7 +2560,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IBusRouteTelephone;
 
             if (ReferenceEquals(this, compareTo))
@@ -2605,15 +2574,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IBusRouteTelephone).TelephoneNumber == null
-                || !(this as Entities.Common.Sample.IBusRouteTelephone).TelephoneNumber.Equals(compareTo.TelephoneNumber))
+             if ((this as Entities.Common.Sample.IBusRouteTelephone).TelephoneNumber.Equals(compareTo.TelephoneNumber))
                 return false;
 
+
             // Standard Property
-            if ((this as Entities.Common.Sample.IBusRouteTelephone).TelephoneNumberTypeDescriptor == null
-                || !(this as Entities.Common.Sample.IBusRouteTelephone).TelephoneNumberTypeDescriptor.Equals(compareTo.TelephoneNumberTypeDescriptor))
+             if ((this as Entities.Common.Sample.IBusRouteTelephone).TelephoneNumberTypeDescriptor.Equals(compareTo.TelephoneNumberTypeDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -2626,7 +2594,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -2635,15 +2602,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.BusRoute.Sample
                     hash = hash * 23 + _busRoute.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IBusRouteTelephone).TelephoneNumber != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IBusRouteTelephone).TelephoneNumber.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IBusRouteTelephone).TelephoneNumber.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IBusRouteTelephone).TelephoneNumberTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IBusRouteTelephone).TelephoneNumberTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IBusRouteTelephone).TelephoneNumberTypeDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -2858,7 +2824,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.FavoriteBookCategoryDescriptor.Sa
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IFavoriteBookCategoryDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -2869,10 +2834,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.FavoriteBookCategoryDescriptor.Sa
 
 
             // Derived Property
-            if ((this as Entities.Common.Sample.IFavoriteBookCategoryDescriptor).FavoriteBookCategoryDescriptorId == null
-                || !(this as Entities.Common.Sample.IFavoriteBookCategoryDescriptor).FavoriteBookCategoryDescriptorId.Equals(compareTo.FavoriteBookCategoryDescriptorId))
+            if (!(this as Entities.Common.Sample.IFavoriteBookCategoryDescriptor).FavoriteBookCategoryDescriptorId.Equals(compareTo.FavoriteBookCategoryDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -2885,17 +2849,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.FavoriteBookCategoryDescriptor.Sa
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.Sample.IFavoriteBookCategoryDescriptor).FavoriteBookCategoryDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IFavoriteBookCategoryDescriptor).FavoriteBookCategoryDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IFavoriteBookCategoryDescriptor).FavoriteBookCategoryDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -3146,7 +3108,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.MembershipTypeDescriptor.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IMembershipTypeDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -3157,10 +3118,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.MembershipTypeDescriptor.Sample
 
 
             // Derived Property
-            if ((this as Entities.Common.Sample.IMembershipTypeDescriptor).MembershipTypeDescriptorId == null
-                || !(this as Entities.Common.Sample.IMembershipTypeDescriptor).MembershipTypeDescriptorId.Equals(compareTo.MembershipTypeDescriptorId))
+            if (!(this as Entities.Common.Sample.IMembershipTypeDescriptor).MembershipTypeDescriptorId.Equals(compareTo.MembershipTypeDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -3173,17 +3133,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.MembershipTypeDescriptor.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.Sample.IMembershipTypeDescriptor).MembershipTypeDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IMembershipTypeDescriptor).MembershipTypeDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IMembershipTypeDescriptor).MembershipTypeDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -3437,7 +3395,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IParentAddressExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -3450,7 +3407,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
             if (_parentAddress == null || !_parentAddress.Equals(compareTo.ParentAddress))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -3463,7 +3419,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -3472,7 +3427,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
                     hash = hash * 23 + _parentAddress.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -3787,7 +3741,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IParentAddressSchoolDistrict;
 
             if (ReferenceEquals(this, compareTo))
@@ -3802,10 +3755,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IParentAddressSchoolDistrict).SchoolDistrict == null
-                || !(this as Entities.Common.Sample.IParentAddressSchoolDistrict).SchoolDistrict.Equals(compareTo.SchoolDistrict))
+             if ((this as Entities.Common.Sample.IParentAddressSchoolDistrict).SchoolDistrict.Equals(compareTo.SchoolDistrict))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -3818,7 +3770,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -3827,11 +3778,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
                     hash = hash * 23 + _parentAddressExtension.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IParentAddressSchoolDistrict).SchoolDistrict != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IParentAddressSchoolDistrict).SchoolDistrict.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IParentAddressSchoolDistrict).SchoolDistrict.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -4022,7 +3972,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IParentAddressTerm;
 
             if (ReferenceEquals(this, compareTo))
@@ -4037,10 +3986,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IParentAddressTerm).TermDescriptor == null
-                || !(this as Entities.Common.Sample.IParentAddressTerm).TermDescriptor.Equals(compareTo.TermDescriptor))
+             if ((this as Entities.Common.Sample.IParentAddressTerm).TermDescriptor.Equals(compareTo.TermDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -4053,7 +4001,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -4062,11 +4009,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
                     hash = hash * 23 + _parentAddressExtension.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IParentAddressTerm).TermDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IParentAddressTerm).TermDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IParentAddressTerm).TermDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -4257,7 +4203,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IParentAuthor;
 
             if (ReferenceEquals(this, compareTo))
@@ -4272,10 +4217,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IParentAuthor).Author == null
-                || !(this as Entities.Common.Sample.IParentAuthor).Author.Equals(compareTo.Author))
+             if ((this as Entities.Common.Sample.IParentAuthor).Author.Equals(compareTo.Author))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -4288,7 +4232,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -4297,11 +4240,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
                     hash = hash * 23 + _parentExtension.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IParentAuthor).Author != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IParentAuthor).Author.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IParentAuthor).Author.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -4492,7 +4434,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IParentCeilingHeight;
 
             if (ReferenceEquals(this, compareTo))
@@ -4507,10 +4448,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IParentCeilingHeight).CeilingHeight == null
-                || !(this as Entities.Common.Sample.IParentCeilingHeight).CeilingHeight.Equals(compareTo.CeilingHeight))
+             if ((this as Entities.Common.Sample.IParentCeilingHeight).CeilingHeight.Equals(compareTo.CeilingHeight))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -4523,7 +4463,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -4532,11 +4471,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
                     hash = hash * 23 + _parentExtension.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IParentCeilingHeight).CeilingHeight != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IParentCeilingHeight).CeilingHeight.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IParentCeilingHeight).CeilingHeight.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -4720,7 +4658,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IParentCTEProgram;
 
             if (ReferenceEquals(this, compareTo))
@@ -4733,7 +4670,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
             if (_parentExtension == null || !_parentExtension.Equals(compareTo.ParentExtension))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -4746,7 +4682,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -4755,7 +4690,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
                     hash = hash * 23 + _parentExtension.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -5029,7 +4963,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IParentEducationContent;
 
             if (ReferenceEquals(this, compareTo))
@@ -5044,10 +4977,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
 
 
             // Referenced Property
-            if ((this as Entities.Common.Sample.IParentEducationContent).ContentIdentifier == null
-                || !(this as Entities.Common.Sample.IParentEducationContent).ContentIdentifier.Equals(compareTo.ContentIdentifier))
+            if (!(this as Entities.Common.Sample.IParentEducationContent).ContentIdentifier.Equals(compareTo.ContentIdentifier))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -5060,7 +4992,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -5069,11 +5000,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
                     hash = hash * 23 + _parentExtension.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IParentEducationContent).ContentIdentifier != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IParentEducationContent).ContentIdentifier.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IParentEducationContent).ContentIdentifier.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -5279,7 +5208,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IParentExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -5292,7 +5220,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
             if (_parent == null || !_parent.Equals(compareTo.Parent))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -5305,7 +5232,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -5314,7 +5240,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
                     hash = hash * 23 + _parent.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -5877,7 +5802,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IParentFavoriteBookTitle;
 
             if (ReferenceEquals(this, compareTo))
@@ -5892,10 +5816,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IParentFavoriteBookTitle).FavoriteBookTitle == null
-                || !(this as Entities.Common.Sample.IParentFavoriteBookTitle).FavoriteBookTitle.Equals(compareTo.FavoriteBookTitle))
+             if ((this as Entities.Common.Sample.IParentFavoriteBookTitle).FavoriteBookTitle.Equals(compareTo.FavoriteBookTitle))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -5908,7 +5831,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -5917,11 +5839,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
                     hash = hash * 23 + _parentExtension.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IParentFavoriteBookTitle).FavoriteBookTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IParentFavoriteBookTitle).FavoriteBookTitle.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IParentFavoriteBookTitle).FavoriteBookTitle.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -6284,7 +6205,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IParentStudentProgramAssociation;
 
             if (ReferenceEquals(this, compareTo))
@@ -6299,35 +6219,34 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
 
 
             // Referenced Property
-            if ((this as Entities.Common.Sample.IParentStudentProgramAssociation).BeginDate == null
-                || !(this as Entities.Common.Sample.IParentStudentProgramAssociation).BeginDate.Equals(compareTo.BeginDate))
+            if (!(this as Entities.Common.Sample.IParentStudentProgramAssociation).BeginDate.Equals(compareTo.BeginDate))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.Sample.IParentStudentProgramAssociation).EducationOrganizationId == null
-                || !(this as Entities.Common.Sample.IParentStudentProgramAssociation).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.Sample.IParentStudentProgramAssociation).ProgramEducationOrganizationId == null
-                || !(this as Entities.Common.Sample.IParentStudentProgramAssociation).ProgramEducationOrganizationId.Equals(compareTo.ProgramEducationOrganizationId))
+            if (!(this as Entities.Common.Sample.IParentStudentProgramAssociation).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
                 return false;
 
+
             // Referenced Property
-            if ((this as Entities.Common.Sample.IParentStudentProgramAssociation).ProgramName == null
-                || !(this as Entities.Common.Sample.IParentStudentProgramAssociation).ProgramName.Equals(compareTo.ProgramName))
+            if (!(this as Entities.Common.Sample.IParentStudentProgramAssociation).ProgramEducationOrganizationId.Equals(compareTo.ProgramEducationOrganizationId))
                 return false;
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.Sample.IParentStudentProgramAssociation).ProgramName.Equals(compareTo.ProgramName))
+                return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.Sample.IParentStudentProgramAssociation).ProgramTypeDescriptor == null
-                ||!(this as Entities.Common.Sample.IParentStudentProgramAssociation).ProgramTypeDescriptor.Equals(compareTo.ProgramTypeDescriptor))
+            if (!(this as Entities.Common.Sample.IParentStudentProgramAssociation).ProgramTypeDescriptor.Equals(compareTo.ProgramTypeDescriptor))
                 return false;
 
+
             // Referenced Property
-            if ((this as Entities.Common.Sample.IParentStudentProgramAssociation).StudentUniqueId == null
-                || !(this as Entities.Common.Sample.IParentStudentProgramAssociation).StudentUniqueId.Equals(compareTo.StudentUniqueId))
+            if (!(this as Entities.Common.Sample.IParentStudentProgramAssociation).StudentUniqueId.Equals(compareTo.StudentUniqueId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -6340,7 +6259,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -6349,31 +6267,25 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
                     hash = hash * 23 + _parentExtension.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IParentStudentProgramAssociation).BeginDate != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IParentStudentProgramAssociation).BeginDate.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IParentStudentProgramAssociation).BeginDate.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IParentStudentProgramAssociation).EducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IParentStudentProgramAssociation).EducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IParentStudentProgramAssociation).EducationOrganizationId.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IParentStudentProgramAssociation).ProgramEducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IParentStudentProgramAssociation).ProgramEducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IParentStudentProgramAssociation).ProgramEducationOrganizationId.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IParentStudentProgramAssociation).ProgramName != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IParentStudentProgramAssociation).ProgramName.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IParentStudentProgramAssociation).ProgramName.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.Sample.IParentStudentProgramAssociation).ProgramTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IParentStudentProgramAssociation).ProgramTypeDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IParentStudentProgramAssociation).ProgramTypeDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IParentStudentProgramAssociation).StudentUniqueId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IParentStudentProgramAssociation).StudentUniqueId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IParentStudentProgramAssociation).StudentUniqueId.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -6564,7 +6476,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IParentTeacherConference;
 
             if (ReferenceEquals(this, compareTo))
@@ -6577,7 +6488,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
             if (_parentExtension == null || !_parentExtension.Equals(compareTo.ParentExtension))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -6590,7 +6500,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -6599,7 +6508,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Parent.EdFi.Extensions.Sample
                     hash = hash * 23 + _parentExtension.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -6812,7 +6720,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.ISchoolCTEProgram;
 
             if (ReferenceEquals(this, compareTo))
@@ -6825,7 +6732,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Extensions.Sample
             if (_schoolExtension == null || !_schoolExtension.Equals(compareTo.SchoolExtension))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -6838,7 +6744,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -6847,7 +6752,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Extensions.Sample
                     hash = hash * 23 + _schoolExtension.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -7121,7 +7025,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.ISchoolDirectlyOwnedBus;
 
             if (ReferenceEquals(this, compareTo))
@@ -7136,10 +7039,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Extensions.Sample
 
 
             // Referenced Property
-            if ((this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId == null
-                || !(this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.Equals(compareTo.DirectlyOwnedBusId))
+            if (!(this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.Equals(compareTo.DirectlyOwnedBusId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -7152,7 +7054,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -7161,11 +7062,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Extensions.Sample
                     hash = hash * 23 + _schoolExtension.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -7367,7 +7266,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.ISchoolExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -7380,7 +7278,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Extensions.Sample
             if (_school == null || !_school.Equals(compareTo.School))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -7393,7 +7290,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -7402,7 +7298,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Extensions.Sample
                     hash = hash * 23 + _school.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -7674,7 +7569,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStaffExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -7687,7 +7581,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.EdFi.Extensions.Sample
             if (_staff == null || !_staff.Equals(compareTo.Staff))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -7700,7 +7593,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -7709,7 +7601,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.EdFi.Extensions.Sample
                     hash = hash * 23 + _staff.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -7979,7 +7870,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStaffPet;
 
             if (ReferenceEquals(this, compareTo))
@@ -7994,10 +7884,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.EdFi.Extensions.Sample
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStaffPet).PetName == null
-                || !(this as Entities.Common.Sample.IStaffPet).PetName.Equals(compareTo.PetName))
+             if ((this as Entities.Common.Sample.IStaffPet).PetName.Equals(compareTo.PetName))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -8010,7 +7899,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -8019,11 +7907,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.EdFi.Extensions.Sample
                     hash = hash * 23 + _staffExtension.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStaffPet).PetName != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStaffPet).PetName.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStaffPet).PetName.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -8215,7 +8102,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStaffPetPreference;
 
             if (ReferenceEquals(this, compareTo))
@@ -8228,7 +8114,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.EdFi.Extensions.Sample
             if (_staffExtension == null || !_staffExtension.Equals(compareTo.StaffExtension))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -8241,7 +8126,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -8250,7 +8134,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Staff.EdFi.Extensions.Sample
                     hash = hash * 23 + _staffExtension.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -8469,7 +8352,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentAquaticPet;
 
             if (ReferenceEquals(this, compareTo))
@@ -8484,15 +8366,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentAquaticPet).MimimumTankVolume == null
-                || !(this as Entities.Common.Sample.IStudentAquaticPet).MimimumTankVolume.Equals(compareTo.MimimumTankVolume))
+             if ((this as Entities.Common.Sample.IStudentAquaticPet).MimimumTankVolume.Equals(compareTo.MimimumTankVolume))
                 return false;
 
+
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentAquaticPet).PetName == null
-                || !(this as Entities.Common.Sample.IStudentAquaticPet).PetName.Equals(compareTo.PetName))
+             if ((this as Entities.Common.Sample.IStudentAquaticPet).PetName.Equals(compareTo.PetName))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -8505,7 +8386,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -8514,15 +8394,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
                     hash = hash * 23 + _studentExtension.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentAquaticPet).MimimumTankVolume != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentAquaticPet).MimimumTankVolume.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentAquaticPet).MimimumTankVolume.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentAquaticPet).PetName != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentAquaticPet).PetName.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentAquaticPet).PetName.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -8720,7 +8599,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -8733,7 +8611,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
             if (_student == null || !_student.Equals(compareTo.Student))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -8746,7 +8623,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -8755,7 +8631,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
                     hash = hash * 23 + _student.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -9121,7 +8996,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentFavoriteBook;
 
             if (ReferenceEquals(this, compareTo))
@@ -9136,10 +9010,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentFavoriteBook).FavoriteBookCategoryDescriptor == null
-                || !(this as Entities.Common.Sample.IStudentFavoriteBook).FavoriteBookCategoryDescriptor.Equals(compareTo.FavoriteBookCategoryDescriptor))
+             if ((this as Entities.Common.Sample.IStudentFavoriteBook).FavoriteBookCategoryDescriptor.Equals(compareTo.FavoriteBookCategoryDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -9152,7 +9025,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -9161,11 +9033,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
                     hash = hash * 23 + _studentExtension.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentFavoriteBook).FavoriteBookCategoryDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentFavoriteBook).FavoriteBookCategoryDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentFavoriteBook).FavoriteBookCategoryDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -9422,7 +9293,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentFavoriteBookArtMedium;
 
             if (ReferenceEquals(this, compareTo))
@@ -9437,10 +9307,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentFavoriteBookArtMedium).ArtMediumDescriptor == null
-                || !(this as Entities.Common.Sample.IStudentFavoriteBookArtMedium).ArtMediumDescriptor.Equals(compareTo.ArtMediumDescriptor))
+             if ((this as Entities.Common.Sample.IStudentFavoriteBookArtMedium).ArtMediumDescriptor.Equals(compareTo.ArtMediumDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -9453,7 +9322,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -9462,11 +9330,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
                     hash = hash * 23 + _studentFavoriteBook.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentFavoriteBookArtMedium).ArtMediumDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentFavoriteBookArtMedium).ArtMediumDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentFavoriteBookArtMedium).ArtMediumDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -9665,7 +9532,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentPet;
 
             if (ReferenceEquals(this, compareTo))
@@ -9680,10 +9546,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentPet).PetName == null
-                || !(this as Entities.Common.Sample.IStudentPet).PetName.Equals(compareTo.PetName))
+             if ((this as Entities.Common.Sample.IStudentPet).PetName.Equals(compareTo.PetName))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -9696,7 +9561,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -9705,11 +9569,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
                     hash = hash * 23 + _studentExtension.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentPet).PetName != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentPet).PetName.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentPet).PetName.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -9901,7 +9764,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentPetPreference;
 
             if (ReferenceEquals(this, compareTo))
@@ -9914,7 +9776,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
             if (_studentExtension == null || !_studentExtension.Equals(compareTo.StudentExtension))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -9927,7 +9788,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -9936,7 +9796,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Student.EdFi.Extensions.Sample
                     hash = hash * 23 + _studentExtension.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -10435,7 +10294,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentArtProgramAssociation;
 
             if (ReferenceEquals(this, compareTo))
@@ -10446,35 +10304,34 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentArtProgramAssociation).BeginDate == null
-                || !(this as Entities.Common.Sample.IStudentArtProgramAssociation).BeginDate.Equals(compareTo.BeginDate))
+             if ((this as Entities.Common.Sample.IStudentArtProgramAssociation).BeginDate.Equals(compareTo.BeginDate))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.Sample.IStudentArtProgramAssociation).EducationOrganizationId == null
-                || !(this as Entities.Common.Sample.IStudentArtProgramAssociation).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.Sample.IStudentArtProgramAssociation).ProgramEducationOrganizationId == null
-                || !(this as Entities.Common.Sample.IStudentArtProgramAssociation).ProgramEducationOrganizationId.Equals(compareTo.ProgramEducationOrganizationId))
+            if (!(this as Entities.Common.Sample.IStudentArtProgramAssociation).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
                 return false;
 
+
             // Referenced Property
-            if ((this as Entities.Common.Sample.IStudentArtProgramAssociation).ProgramName == null
-                || !(this as Entities.Common.Sample.IStudentArtProgramAssociation).ProgramName.Equals(compareTo.ProgramName))
+            if (!(this as Entities.Common.Sample.IStudentArtProgramAssociation).ProgramEducationOrganizationId.Equals(compareTo.ProgramEducationOrganizationId))
                 return false;
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.Sample.IStudentArtProgramAssociation).ProgramName.Equals(compareTo.ProgramName))
+                return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.Sample.IStudentArtProgramAssociation).ProgramTypeDescriptor == null
-                ||!(this as Entities.Common.Sample.IStudentArtProgramAssociation).ProgramTypeDescriptor.Equals(compareTo.ProgramTypeDescriptor))
+            if (!(this as Entities.Common.Sample.IStudentArtProgramAssociation).ProgramTypeDescriptor.Equals(compareTo.ProgramTypeDescriptor))
                 return false;
 
+
             // Referenced Property
-            if ((this as Entities.Common.Sample.IStudentArtProgramAssociation).StudentUniqueId == null
-                || !(this as Entities.Common.Sample.IStudentArtProgramAssociation).StudentUniqueId.Equals(compareTo.StudentUniqueId))
+            if (!(this as Entities.Common.Sample.IStudentArtProgramAssociation).StudentUniqueId.Equals(compareTo.StudentUniqueId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -10487,37 +10344,31 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentArtProgramAssociation).BeginDate != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociation).BeginDate.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociation).BeginDate.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IStudentArtProgramAssociation).EducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociation).EducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociation).EducationOrganizationId.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IStudentArtProgramAssociation).ProgramEducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociation).ProgramEducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociation).ProgramEducationOrganizationId.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IStudentArtProgramAssociation).ProgramName != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociation).ProgramName.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociation).ProgramName.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.Sample.IStudentArtProgramAssociation).ProgramTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociation).ProgramTypeDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociation).ProgramTypeDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IStudentArtProgramAssociation).StudentUniqueId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociation).StudentUniqueId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociation).StudentUniqueId.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -11124,7 +10975,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentArtProgramAssociationArtMedium;
 
             if (ReferenceEquals(this, compareTo))
@@ -11139,10 +10989,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentArtProgramAssociationArtMedium).ArtMediumDescriptor == null
-                || !(this as Entities.Common.Sample.IStudentArtProgramAssociationArtMedium).ArtMediumDescriptor.Equals(compareTo.ArtMediumDescriptor))
+             if ((this as Entities.Common.Sample.IStudentArtProgramAssociationArtMedium).ArtMediumDescriptor.Equals(compareTo.ArtMediumDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -11155,7 +11004,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -11164,11 +11012,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
                     hash = hash * 23 + _studentArtProgramAssociation.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentArtProgramAssociationArtMedium).ArtMediumDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociationArtMedium).ArtMediumDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociationArtMedium).ArtMediumDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -11359,7 +11206,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentArtProgramAssociationPortfolioYears;
 
             if (ReferenceEquals(this, compareTo))
@@ -11374,10 +11220,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentArtProgramAssociationPortfolioYears).PortfolioYears == null
-                || !(this as Entities.Common.Sample.IStudentArtProgramAssociationPortfolioYears).PortfolioYears.Equals(compareTo.PortfolioYears))
+             if ((this as Entities.Common.Sample.IStudentArtProgramAssociationPortfolioYears).PortfolioYears.Equals(compareTo.PortfolioYears))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -11390,7 +11235,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -11399,11 +11243,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
                     hash = hash * 23 + _studentArtProgramAssociation.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentArtProgramAssociationPortfolioYears).PortfolioYears != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociationPortfolioYears).PortfolioYears.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociationPortfolioYears).PortfolioYears.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -11594,7 +11437,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentArtProgramAssociationService;
 
             if (ReferenceEquals(this, compareTo))
@@ -11609,10 +11451,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentArtProgramAssociationService).ServiceDescriptor == null
-                || !(this as Entities.Common.Sample.IStudentArtProgramAssociationService).ServiceDescriptor.Equals(compareTo.ServiceDescriptor))
+             if ((this as Entities.Common.Sample.IStudentArtProgramAssociationService).ServiceDescriptor.Equals(compareTo.ServiceDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -11625,7 +11466,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -11634,11 +11474,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
                     hash = hash * 23 + _studentArtProgramAssociation.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentArtProgramAssociationService).ServiceDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociationService).ServiceDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociationService).ServiceDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -11853,7 +11692,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentArtProgramAssociationStyle;
 
             if (ReferenceEquals(this, compareTo))
@@ -11868,10 +11706,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentArtProgramAssociationStyle).Style == null
-                || !(this as Entities.Common.Sample.IStudentArtProgramAssociationStyle).Style.Equals(compareTo.Style))
+             if ((this as Entities.Common.Sample.IStudentArtProgramAssociationStyle).Style.Equals(compareTo.Style))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -11884,7 +11721,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -11893,11 +11729,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentArtProgramAssociation.Samp
                     hash = hash * 23 + _studentArtProgramAssociation.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentArtProgramAssociationStyle).Style != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociationStyle).Style.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentArtProgramAssociationStyle).Style.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -12086,7 +11921,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentCTEProgramAssociation.EdFi
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentCTEProgramAssociationExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -12099,7 +11933,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentCTEProgramAssociation.EdFi
             if (_studentCTEProgramAssociation == null || !_studentCTEProgramAssociation.Equals(compareTo.StudentCTEProgramAssociation))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -12112,7 +11945,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentCTEProgramAssociation.EdFi
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -12121,7 +11953,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentCTEProgramAssociation.EdFi
                     hash = hash * 23 + _studentCTEProgramAssociation.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -12331,7 +12162,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentEducationOrganizationAssociationAddressExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -12344,7 +12174,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
             if (_studentEducationOrganizationAssociationAddress == null || !_studentEducationOrganizationAssociationAddress.Equals(compareTo.StudentEducationOrganizationAssociationAddress))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -12357,7 +12186,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -12366,7 +12194,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
                     hash = hash * 23 + _studentEducationOrganizationAssociationAddress.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -12681,7 +12508,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentEducationOrganizationAssociationAddressSchoolDistrict;
 
             if (ReferenceEquals(this, compareTo))
@@ -12696,10 +12522,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentEducationOrganizationAssociationAddressSchoolDistrict).SchoolDistrict == null
-                || !(this as Entities.Common.Sample.IStudentEducationOrganizationAssociationAddressSchoolDistrict).SchoolDistrict.Equals(compareTo.SchoolDistrict))
+             if ((this as Entities.Common.Sample.IStudentEducationOrganizationAssociationAddressSchoolDistrict).SchoolDistrict.Equals(compareTo.SchoolDistrict))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -12712,7 +12537,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -12721,11 +12545,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
                     hash = hash * 23 + _studentEducationOrganizationAssociationAddressExtension.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentEducationOrganizationAssociationAddressSchoolDistrict).SchoolDistrict != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentEducationOrganizationAssociationAddressSchoolDistrict).SchoolDistrict.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentEducationOrganizationAssociationAddressSchoolDistrict).SchoolDistrict.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -12916,7 +12739,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentEducationOrganizationAssociationAddressTerm;
 
             if (ReferenceEquals(this, compareTo))
@@ -12931,10 +12753,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentEducationOrganizationAssociationAddressTerm).TermDescriptor == null
-                || !(this as Entities.Common.Sample.IStudentEducationOrganizationAssociationAddressTerm).TermDescriptor.Equals(compareTo.TermDescriptor))
+             if ((this as Entities.Common.Sample.IStudentEducationOrganizationAssociationAddressTerm).TermDescriptor.Equals(compareTo.TermDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -12947,7 +12768,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -12956,11 +12776,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
                     hash = hash * 23 + _studentEducationOrganizationAssociationAddressExtension.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentEducationOrganizationAssociationAddressTerm).TermDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentEducationOrganizationAssociationAddressTerm).TermDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentEducationOrganizationAssociationAddressTerm).TermDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -13148,7 +12967,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentEducationOrganizationAssociationStudentCharacteristicExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -13161,7 +12979,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
             if (_studentEducationOrganizationAssociationStudentCharacteristic == null || !_studentEducationOrganizationAssociationStudentCharacteristic.Equals(compareTo.StudentEducationOrganizationAssociationStudentCharacteristic))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -13174,7 +12991,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -13183,7 +12999,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
                     hash = hash * 23 + _studentEducationOrganizationAssociationStudentCharacteristic.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -13432,7 +13247,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentEducationOrganizationAssociationStudentCharacteristicStudentNeed;
 
             if (ReferenceEquals(this, compareTo))
@@ -13447,10 +13261,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentEducationOrganizationAssociationStudentCharacteristicStudentNeed).BeginDate == null
-                || !(this as Entities.Common.Sample.IStudentEducationOrganizationAssociationStudentCharacteristicStudentNeed).BeginDate.Equals(compareTo.BeginDate))
+             if ((this as Entities.Common.Sample.IStudentEducationOrganizationAssociationStudentCharacteristicStudentNeed).BeginDate.Equals(compareTo.BeginDate))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -13463,7 +13276,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -13472,11 +13284,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentEducationOrganizationAssoc
                     hash = hash * 23 + _studentEducationOrganizationAssociationStudentCharacteristicExtension.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentEducationOrganizationAssociationStudentCharacteristicStudentNeed).BeginDate != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentEducationOrganizationAssociationStudentCharacteristicStudentNeed).BeginDate.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentEducationOrganizationAssociationStudentCharacteristicStudentNeed).BeginDate.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -13964,7 +13775,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentGraduationPlanAssociation;
 
             if (ReferenceEquals(this, compareTo))
@@ -13975,25 +13785,24 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
 
 
             // Referenced Property
-            if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociation).EducationOrganizationId == null
-                || !(this as Entities.Common.Sample.IStudentGraduationPlanAssociation).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
+            if (!(this as Entities.Common.Sample.IStudentGraduationPlanAssociation).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
                 return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociation).GraduationPlanTypeDescriptor == null
-                ||!(this as Entities.Common.Sample.IStudentGraduationPlanAssociation).GraduationPlanTypeDescriptor.Equals(compareTo.GraduationPlanTypeDescriptor))
+            if (!(this as Entities.Common.Sample.IStudentGraduationPlanAssociation).GraduationPlanTypeDescriptor.Equals(compareTo.GraduationPlanTypeDescriptor))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociation).GraduationSchoolYear == null
-                || !(this as Entities.Common.Sample.IStudentGraduationPlanAssociation).GraduationSchoolYear.Equals(compareTo.GraduationSchoolYear))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociation).StudentUniqueId == null
-                || !(this as Entities.Common.Sample.IStudentGraduationPlanAssociation).StudentUniqueId.Equals(compareTo.StudentUniqueId))
+            if (!(this as Entities.Common.Sample.IStudentGraduationPlanAssociation).GraduationSchoolYear.Equals(compareTo.GraduationSchoolYear))
                 return false;
-            #pragma warning disable 472
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.Sample.IStudentGraduationPlanAssociation).StudentUniqueId.Equals(compareTo.StudentUniqueId))
+                return false;
+
 
             return true;
         }
@@ -14006,29 +13815,24 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociation).EducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociation).EducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociation).EducationOrganizationId.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociation).GraduationPlanTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociation).GraduationPlanTypeDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociation).GraduationPlanTypeDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociation).GraduationSchoolYear != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociation).GraduationSchoolYear.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociation).GraduationSchoolYear.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociation).StudentUniqueId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociation).StudentUniqueId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociation).StudentUniqueId.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -14728,7 +14532,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentGraduationPlanAssociationAcademicSubject;
 
             if (ReferenceEquals(this, compareTo))
@@ -14743,10 +14546,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationAcademicSubject).AcademicSubjectDescriptor == null
-                || !(this as Entities.Common.Sample.IStudentGraduationPlanAssociationAcademicSubject).AcademicSubjectDescriptor.Equals(compareTo.AcademicSubjectDescriptor))
+             if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationAcademicSubject).AcademicSubjectDescriptor.Equals(compareTo.AcademicSubjectDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -14759,7 +14561,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -14768,11 +14569,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
                     hash = hash * 23 + _studentGraduationPlanAssociation.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationAcademicSubject).AcademicSubjectDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociationAcademicSubject).AcademicSubjectDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociationAcademicSubject).AcademicSubjectDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -14963,7 +14763,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentGraduationPlanAssociationCareerPathwayCode;
 
             if (ReferenceEquals(this, compareTo))
@@ -14978,10 +14777,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationCareerPathwayCode).CareerPathwayCode == null
-                || !(this as Entities.Common.Sample.IStudentGraduationPlanAssociationCareerPathwayCode).CareerPathwayCode.Equals(compareTo.CareerPathwayCode))
+             if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationCareerPathwayCode).CareerPathwayCode.Equals(compareTo.CareerPathwayCode))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -14994,7 +14792,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -15003,11 +14800,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
                     hash = hash * 23 + _studentGraduationPlanAssociation.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationCareerPathwayCode).CareerPathwayCode != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociationCareerPathwayCode).CareerPathwayCode.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociationCareerPathwayCode).CareerPathwayCode.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -15191,7 +14987,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentGraduationPlanAssociationCTEProgram;
 
             if (ReferenceEquals(this, compareTo))
@@ -15204,7 +14999,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
             if (_studentGraduationPlanAssociation == null || !_studentGraduationPlanAssociation.Equals(compareTo.StudentGraduationPlanAssociation))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -15217,7 +15011,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -15226,7 +15019,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
                     hash = hash * 23 + _studentGraduationPlanAssociation.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -15449,7 +15241,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentGraduationPlanAssociationDescription;
 
             if (ReferenceEquals(this, compareTo))
@@ -15464,10 +15255,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationDescription).Description == null
-                || !(this as Entities.Common.Sample.IStudentGraduationPlanAssociationDescription).Description.Equals(compareTo.Description))
+             if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationDescription).Description.Equals(compareTo.Description))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -15480,7 +15270,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -15489,11 +15278,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
                     hash = hash * 23 + _studentGraduationPlanAssociation.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationDescription).Description != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociationDescription).Description.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociationDescription).Description.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -15684,7 +15472,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentGraduationPlanAssociationDesignatedBy;
 
             if (ReferenceEquals(this, compareTo))
@@ -15699,10 +15486,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationDesignatedBy).DesignatedBy == null
-                || !(this as Entities.Common.Sample.IStudentGraduationPlanAssociationDesignatedBy).DesignatedBy.Equals(compareTo.DesignatedBy))
+             if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationDesignatedBy).DesignatedBy.Equals(compareTo.DesignatedBy))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -15715,7 +15501,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -15724,11 +15509,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
                     hash = hash * 23 + _studentGraduationPlanAssociation.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationDesignatedBy).DesignatedBy != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociationDesignatedBy).DesignatedBy.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociationDesignatedBy).DesignatedBy.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -15919,7 +15703,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentGraduationPlanAssociationIndustryCredential;
 
             if (ReferenceEquals(this, compareTo))
@@ -15934,10 +15717,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationIndustryCredential).IndustryCredential == null
-                || !(this as Entities.Common.Sample.IStudentGraduationPlanAssociationIndustryCredential).IndustryCredential.Equals(compareTo.IndustryCredential))
+             if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationIndustryCredential).IndustryCredential.Equals(compareTo.IndustryCredential))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -15950,7 +15732,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -15959,11 +15740,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
                     hash = hash * 23 + _studentGraduationPlanAssociation.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationIndustryCredential).IndustryCredential != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociationIndustryCredential).IndustryCredential.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociationIndustryCredential).IndustryCredential.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -16327,7 +16107,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentGraduationPlanAssociationStudentParentAssociation;
 
             if (ReferenceEquals(this, compareTo))
@@ -16342,10 +16121,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
 
 
             // Referenced Property
-            if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationStudentParentAssociation).ParentUniqueId == null
-                || !(this as Entities.Common.Sample.IStudentGraduationPlanAssociationStudentParentAssociation).ParentUniqueId.Equals(compareTo.ParentUniqueId))
+            if (!(this as Entities.Common.Sample.IStudentGraduationPlanAssociationStudentParentAssociation).ParentUniqueId.Equals(compareTo.ParentUniqueId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -16358,7 +16136,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -16367,11 +16144,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
                     hash = hash * 23 + _studentGraduationPlanAssociation.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationStudentParentAssociation).ParentUniqueId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociationStudentParentAssociation).ParentUniqueId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociationStudentParentAssociation).ParentUniqueId.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -16606,7 +16381,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentGraduationPlanAssociationYearsAttended;
 
             if (ReferenceEquals(this, compareTo))
@@ -16621,10 +16395,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationYearsAttended).YearsAttended == null
-                || !(this as Entities.Common.Sample.IStudentGraduationPlanAssociationYearsAttended).YearsAttended.Equals(compareTo.YearsAttended))
+             if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationYearsAttended).YearsAttended.Equals(compareTo.YearsAttended))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -16637,7 +16410,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -16646,11 +16418,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentGraduationPlanAssociation.
                     hash = hash * 23 + _studentGraduationPlanAssociation.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentGraduationPlanAssociationYearsAttended).YearsAttended != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociationYearsAttended).YearsAttended.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentGraduationPlanAssociationYearsAttended).YearsAttended.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -16846,7 +16617,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentParentAssociationDiscipline;
 
             if (ReferenceEquals(this, compareTo))
@@ -16861,10 +16631,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentParentAssociationDiscipline).DisciplineDescriptor == null
-                || !(this as Entities.Common.Sample.IStudentParentAssociationDiscipline).DisciplineDescriptor.Equals(compareTo.DisciplineDescriptor))
+             if ((this as Entities.Common.Sample.IStudentParentAssociationDiscipline).DisciplineDescriptor.Equals(compareTo.DisciplineDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -16877,7 +16646,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -16886,11 +16654,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
                     hash = hash * 23 + _studentParentAssociationExtension.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentParentAssociationDiscipline).DisciplineDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentParentAssociationDiscipline).DisciplineDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentParentAssociationDiscipline).DisciplineDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -17115,7 +16882,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentParentAssociationExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -17128,7 +16894,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
             if (_studentParentAssociation == null || !_studentParentAssociation.Equals(compareTo.StudentParentAssociation))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -17141,7 +16906,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -17150,7 +16914,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
                     hash = hash * 23 + _studentParentAssociation.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -17770,7 +17533,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentParentAssociationFavoriteBookTitle;
 
             if (ReferenceEquals(this, compareTo))
@@ -17785,10 +17547,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentParentAssociationFavoriteBookTitle).FavoriteBookTitle == null
-                || !(this as Entities.Common.Sample.IStudentParentAssociationFavoriteBookTitle).FavoriteBookTitle.Equals(compareTo.FavoriteBookTitle))
+             if ((this as Entities.Common.Sample.IStudentParentAssociationFavoriteBookTitle).FavoriteBookTitle.Equals(compareTo.FavoriteBookTitle))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -17801,7 +17562,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -17810,11 +17570,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
                     hash = hash * 23 + _studentParentAssociationExtension.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentParentAssociationFavoriteBookTitle).FavoriteBookTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentParentAssociationFavoriteBookTitle).FavoriteBookTitle.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentParentAssociationFavoriteBookTitle).FavoriteBookTitle.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -18005,7 +17764,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentParentAssociationHoursPerWeek;
 
             if (ReferenceEquals(this, compareTo))
@@ -18020,10 +17778,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentParentAssociationHoursPerWeek).HoursPerWeek == null
-                || !(this as Entities.Common.Sample.IStudentParentAssociationHoursPerWeek).HoursPerWeek.Equals(compareTo.HoursPerWeek))
+             if ((this as Entities.Common.Sample.IStudentParentAssociationHoursPerWeek).HoursPerWeek.Equals(compareTo.HoursPerWeek))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -18036,7 +17793,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -18045,11 +17801,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
                     hash = hash * 23 + _studentParentAssociationExtension.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentParentAssociationHoursPerWeek).HoursPerWeek != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentParentAssociationHoursPerWeek).HoursPerWeek.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentParentAssociationHoursPerWeek).HoursPerWeek.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -18240,7 +17995,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentParentAssociationPagesRead;
 
             if (ReferenceEquals(this, compareTo))
@@ -18255,10 +18009,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
 
 
             // Standard Property
-            if ((this as Entities.Common.Sample.IStudentParentAssociationPagesRead).PagesRead == null
-                || !(this as Entities.Common.Sample.IStudentParentAssociationPagesRead).PagesRead.Equals(compareTo.PagesRead))
+             if ((this as Entities.Common.Sample.IStudentParentAssociationPagesRead).PagesRead.Equals(compareTo.PagesRead))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -18271,7 +18024,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -18280,11 +18032,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
                     hash = hash * 23 + _studentParentAssociationExtension.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.Sample.IStudentParentAssociationPagesRead).PagesRead != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentParentAssociationPagesRead).PagesRead.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.Sample.IStudentParentAssociationPagesRead).PagesRead.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -18597,7 +18348,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation;
 
             if (ReferenceEquals(this, compareTo))
@@ -18612,25 +18362,24 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
 
 
             // Referenced Property
-            if ((this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).EducationOrganizationId == null
-                || !(this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
+            if (!(this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
                 return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).EmploymentStatusDescriptor == null
-                ||!(this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).EmploymentStatusDescriptor.Equals(compareTo.EmploymentStatusDescriptor))
+            if (!(this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).EmploymentStatusDescriptor.Equals(compareTo.EmploymentStatusDescriptor))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).HireDate == null
-                || !(this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).HireDate.Equals(compareTo.HireDate))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).StaffUniqueId == null
-                || !(this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).StaffUniqueId.Equals(compareTo.StaffUniqueId))
+            if (!(this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).HireDate.Equals(compareTo.HireDate))
                 return false;
-            #pragma warning disable 472
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).StaffUniqueId.Equals(compareTo.StaffUniqueId))
+                return false;
+
 
             return true;
         }
@@ -18643,7 +18392,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -18652,23 +18400,19 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
                     hash = hash * 23 + _studentParentAssociationExtension.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).EducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).EducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).EducationOrganizationId.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).EmploymentStatusDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).EmploymentStatusDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).EmploymentStatusDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).HireDate != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).HireDate.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).HireDate.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).StaffUniqueId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).StaffUniqueId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentParentAssociationStaffEducationOrganizationEmploymentAssociation).StaffUniqueId.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -18866,7 +18610,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentParentAssociationTelephone;
 
             if (ReferenceEquals(this, compareTo))
@@ -18879,7 +18622,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
             if (_studentParentAssociationExtension == null || !_studentParentAssociationExtension.Equals(compareTo.StudentParentAssociationExtension))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -18892,7 +18634,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -18901,7 +18642,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentParentAssociation.EdFi.Ext
                     hash = hash * 23 + _studentParentAssociationExtension.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -19130,7 +18870,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentSchoolAssociation.EdFi.Ext
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentSchoolAssociationExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -19143,7 +18882,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentSchoolAssociation.EdFi.Ext
             if (_studentSchoolAssociation == null || !_studentSchoolAssociation.Equals(compareTo.StudentSchoolAssociation))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -19156,7 +18894,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentSchoolAssociation.EdFi.Ext
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -19165,7 +18902,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentSchoolAssociation.EdFi.Ext
                     hash = hash * 23 + _studentSchoolAssociation.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -19366,7 +19102,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentSectionAssociation.EdFi.Ex
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentSectionAssociationExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -19379,7 +19114,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentSectionAssociation.EdFi.Ex
             if (_studentSectionAssociation == null || !_studentSectionAssociation.Equals(compareTo.StudentSectionAssociation))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -19392,7 +19126,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentSectionAssociation.EdFi.Ex
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -19401,7 +19134,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentSectionAssociation.EdFi.Ex
                     hash = hash * 23 + _studentSectionAssociation.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -19935,7 +19667,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentSectionAssociation.EdFi.Ex
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation;
 
             if (ReferenceEquals(this, compareTo))
@@ -19950,30 +19681,29 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentSectionAssociation.EdFi.Ex
 
 
             // Referenced Property
-            if ((this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedBeginDate == null
-                || !(this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedBeginDate.Equals(compareTo.RelatedBeginDate))
+            if (!(this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedBeginDate.Equals(compareTo.RelatedBeginDate))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedEducationOrganizationId == null
-                || !(this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedEducationOrganizationId.Equals(compareTo.RelatedEducationOrganizationId))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedProgramEducationOrganizationId == null
-                || !(this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedProgramEducationOrganizationId.Equals(compareTo.RelatedProgramEducationOrganizationId))
+            if (!(this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedEducationOrganizationId.Equals(compareTo.RelatedEducationOrganizationId))
                 return false;
 
+
             // Referenced Property
-            if ((this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedProgramName == null
-                || !(this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedProgramName.Equals(compareTo.RelatedProgramName))
+            if (!(this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedProgramEducationOrganizationId.Equals(compareTo.RelatedProgramEducationOrganizationId))
                 return false;
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedProgramName.Equals(compareTo.RelatedProgramName))
+                return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedProgramTypeDescriptor == null
-                ||!(this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedProgramTypeDescriptor.Equals(compareTo.RelatedProgramTypeDescriptor))
+            if (!(this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedProgramTypeDescriptor.Equals(compareTo.RelatedProgramTypeDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -19986,7 +19716,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentSectionAssociation.EdFi.Ex
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -19995,27 +19724,22 @@ namespace EdFi.Ods.Api.Common.Models.Resources.StudentSectionAssociation.EdFi.Ex
                     hash = hash * 23 + _studentSectionAssociationExtension.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedBeginDate != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedBeginDate.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedBeginDate.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedEducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedEducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedEducationOrganizationId.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedProgramEducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedProgramEducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedProgramEducationOrganizationId.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedProgramName != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedProgramName.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedProgramName.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedProgramTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedProgramTypeDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.IStudentSectionAssociationRelatedGeneralStudentProgramAssociation).RelatedProgramTypeDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Extensions.TPDM_Resources_Resources.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Extensions.TPDM_Resources_Resources.generated.approved.cs
@@ -90,7 +90,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.AccreditationStatusDescriptor.TPD
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IAccreditationStatusDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -101,10 +100,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.AccreditationStatusDescriptor.TPD
 
 
             // Derived Property
-            if ((this as Entities.Common.TPDM.IAccreditationStatusDescriptor).AccreditationStatusDescriptorId == null
-                || !(this as Entities.Common.TPDM.IAccreditationStatusDescriptor).AccreditationStatusDescriptorId.Equals(compareTo.AccreditationStatusDescriptorId))
+            if (!(this as Entities.Common.TPDM.IAccreditationStatusDescriptor).AccreditationStatusDescriptorId.Equals(compareTo.AccreditationStatusDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -117,17 +115,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.AccreditationStatusDescriptor.TPD
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.TPDM.IAccreditationStatusDescriptor).AccreditationStatusDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IAccreditationStatusDescriptor).AccreditationStatusDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IAccreditationStatusDescriptor).AccreditationStatusDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -378,7 +374,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.AidTypeDescriptor.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IAidTypeDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -389,10 +384,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.AidTypeDescriptor.TPDM
 
 
             // Derived Property
-            if ((this as Entities.Common.TPDM.IAidTypeDescriptor).AidTypeDescriptorId == null
-                || !(this as Entities.Common.TPDM.IAidTypeDescriptor).AidTypeDescriptorId.Equals(compareTo.AidTypeDescriptorId))
+            if (!(this as Entities.Common.TPDM.IAidTypeDescriptor).AidTypeDescriptorId.Equals(compareTo.AidTypeDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -405,17 +399,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.AidTypeDescriptor.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.TPDM.IAidTypeDescriptor).AidTypeDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IAidTypeDescriptor).AidTypeDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IAidTypeDescriptor).AidTypeDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -786,7 +778,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICandidate;
 
             if (ReferenceEquals(this, compareTo))
@@ -797,10 +788,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidate).CandidateIdentifier == null
-                || !(this as Entities.Common.TPDM.ICandidate).CandidateIdentifier.Equals(compareTo.CandidateIdentifier))
+             if ((this as Entities.Common.TPDM.ICandidate).CandidateIdentifier.Equals(compareTo.CandidateIdentifier))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -813,17 +803,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidate).CandidateIdentifier != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidate).CandidateIdentifier.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidate).CandidateIdentifier.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -1700,7 +1688,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICandidateAddress;
 
             if (ReferenceEquals(this, compareTo))
@@ -1715,30 +1702,29 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateAddress).AddressTypeDescriptor == null
-                || !(this as Entities.Common.TPDM.ICandidateAddress).AddressTypeDescriptor.Equals(compareTo.AddressTypeDescriptor))
+             if ((this as Entities.Common.TPDM.ICandidateAddress).AddressTypeDescriptor.Equals(compareTo.AddressTypeDescriptor))
                 return false;
 
-            // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateAddress).City == null
-                || !(this as Entities.Common.TPDM.ICandidateAddress).City.Equals(compareTo.City))
-                return false;
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateAddress).PostalCode == null
-                || !(this as Entities.Common.TPDM.ICandidateAddress).PostalCode.Equals(compareTo.PostalCode))
+             if ((this as Entities.Common.TPDM.ICandidateAddress).City.Equals(compareTo.City))
                 return false;
 
-            // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateAddress).StateAbbreviationDescriptor == null
-                || !(this as Entities.Common.TPDM.ICandidateAddress).StateAbbreviationDescriptor.Equals(compareTo.StateAbbreviationDescriptor))
-                return false;
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateAddress).StreetNumberName == null
-                || !(this as Entities.Common.TPDM.ICandidateAddress).StreetNumberName.Equals(compareTo.StreetNumberName))
+             if ((this as Entities.Common.TPDM.ICandidateAddress).PostalCode.Equals(compareTo.PostalCode))
                 return false;
-            #pragma warning disable 472
+
+
+            // Standard Property
+             if ((this as Entities.Common.TPDM.ICandidateAddress).StateAbbreviationDescriptor.Equals(compareTo.StateAbbreviationDescriptor))
+                return false;
+
+
+            // Standard Property
+             if ((this as Entities.Common.TPDM.ICandidateAddress).StreetNumberName.Equals(compareTo.StreetNumberName))
+                return false;
+
 
             return true;
         }
@@ -1751,7 +1737,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -1760,27 +1745,26 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
                     hash = hash * 23 + _candidate.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateAddress).AddressTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateAddress).AddressTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateAddress).AddressTypeDescriptor.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateAddress).City != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateAddress).City.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateAddress).City.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateAddress).PostalCode != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateAddress).PostalCode.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateAddress).PostalCode.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateAddress).StateAbbreviationDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateAddress).StateAbbreviationDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateAddress).StateAbbreviationDescriptor.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateAddress).StreetNumberName != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateAddress).StreetNumberName.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateAddress).StreetNumberName.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -2101,7 +2085,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICandidateAddressPeriod;
 
             if (ReferenceEquals(this, compareTo))
@@ -2116,10 +2099,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateAddressPeriod).BeginDate == null
-                || !(this as Entities.Common.TPDM.ICandidateAddressPeriod).BeginDate.Equals(compareTo.BeginDate))
+             if ((this as Entities.Common.TPDM.ICandidateAddressPeriod).BeginDate.Equals(compareTo.BeginDate))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -2132,7 +2114,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -2141,11 +2122,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
                     hash = hash * 23 + _candidateAddress.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateAddressPeriod).BeginDate != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateAddressPeriod).BeginDate.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateAddressPeriod).BeginDate.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -2348,7 +2328,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICandidateDisability;
 
             if (ReferenceEquals(this, compareTo))
@@ -2363,10 +2342,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateDisability).DisabilityDescriptor == null
-                || !(this as Entities.Common.TPDM.ICandidateDisability).DisabilityDescriptor.Equals(compareTo.DisabilityDescriptor))
+             if ((this as Entities.Common.TPDM.ICandidateDisability).DisabilityDescriptor.Equals(compareTo.DisabilityDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -2379,7 +2357,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -2388,11 +2365,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
                     hash = hash * 23 + _candidate.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateDisability).DisabilityDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateDisability).DisabilityDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateDisability).DisabilityDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -2665,7 +2641,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICandidateDisabilityDesignation;
 
             if (ReferenceEquals(this, compareTo))
@@ -2680,10 +2655,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateDisabilityDesignation).DisabilityDesignationDescriptor == null
-                || !(this as Entities.Common.TPDM.ICandidateDisabilityDesignation).DisabilityDesignationDescriptor.Equals(compareTo.DisabilityDesignationDescriptor))
+             if ((this as Entities.Common.TPDM.ICandidateDisabilityDesignation).DisabilityDesignationDescriptor.Equals(compareTo.DisabilityDesignationDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -2696,7 +2670,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -2705,11 +2678,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
                     hash = hash * 23 + _candidateDisability.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateDisabilityDesignation).DisabilityDesignationDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateDisabilityDesignation).DisabilityDesignationDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateDisabilityDesignation).DisabilityDesignationDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -2907,7 +2879,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICandidateElectronicMail;
 
             if (ReferenceEquals(this, compareTo))
@@ -2922,15 +2893,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateElectronicMail).ElectronicMailAddress == null
-                || !(this as Entities.Common.TPDM.ICandidateElectronicMail).ElectronicMailAddress.Equals(compareTo.ElectronicMailAddress))
+             if ((this as Entities.Common.TPDM.ICandidateElectronicMail).ElectronicMailAddress.Equals(compareTo.ElectronicMailAddress))
                 return false;
 
+
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateElectronicMail).ElectronicMailTypeDescriptor == null
-                || !(this as Entities.Common.TPDM.ICandidateElectronicMail).ElectronicMailTypeDescriptor.Equals(compareTo.ElectronicMailTypeDescriptor))
+             if ((this as Entities.Common.TPDM.ICandidateElectronicMail).ElectronicMailTypeDescriptor.Equals(compareTo.ElectronicMailTypeDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -2943,7 +2913,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -2952,15 +2921,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
                     hash = hash * 23 + _candidate.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateElectronicMail).ElectronicMailAddress != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateElectronicMail).ElectronicMailAddress.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateElectronicMail).ElectronicMailAddress.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateElectronicMail).ElectronicMailTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateElectronicMail).ElectronicMailTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateElectronicMail).ElectronicMailTypeDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -3171,7 +3139,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICandidateLanguage;
 
             if (ReferenceEquals(this, compareTo))
@@ -3186,10 +3153,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateLanguage).LanguageDescriptor == null
-                || !(this as Entities.Common.TPDM.ICandidateLanguage).LanguageDescriptor.Equals(compareTo.LanguageDescriptor))
+             if ((this as Entities.Common.TPDM.ICandidateLanguage).LanguageDescriptor.Equals(compareTo.LanguageDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -3202,7 +3168,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -3211,11 +3176,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
                     hash = hash * 23 + _candidate.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateLanguage).LanguageDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateLanguage).LanguageDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateLanguage).LanguageDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -3464,7 +3428,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICandidateLanguageUse;
 
             if (ReferenceEquals(this, compareTo))
@@ -3479,10 +3442,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateLanguageUse).LanguageUseDescriptor == null
-                || !(this as Entities.Common.TPDM.ICandidateLanguageUse).LanguageUseDescriptor.Equals(compareTo.LanguageUseDescriptor))
+             if ((this as Entities.Common.TPDM.ICandidateLanguageUse).LanguageUseDescriptor.Equals(compareTo.LanguageUseDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -3495,7 +3457,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -3504,11 +3465,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
                     hash = hash * 23 + _candidateLanguage.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateLanguageUse).LanguageUseDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateLanguageUse).LanguageUseDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateLanguageUse).LanguageUseDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -3699,7 +3659,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICandidateOtherName;
 
             if (ReferenceEquals(this, compareTo))
@@ -3714,10 +3673,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateOtherName).OtherNameTypeDescriptor == null
-                || !(this as Entities.Common.TPDM.ICandidateOtherName).OtherNameTypeDescriptor.Equals(compareTo.OtherNameTypeDescriptor))
+             if ((this as Entities.Common.TPDM.ICandidateOtherName).OtherNameTypeDescriptor.Equals(compareTo.OtherNameTypeDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -3730,7 +3688,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -3739,11 +3696,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
                     hash = hash * 23 + _candidate.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateOtherName).OtherNameTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateOtherName).OtherNameTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateOtherName).OtherNameTypeDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -3981,7 +3937,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICandidatePersonalIdentificationDocument;
 
             if (ReferenceEquals(this, compareTo))
@@ -3996,15 +3951,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidatePersonalIdentificationDocument).IdentificationDocumentUseDescriptor == null
-                || !(this as Entities.Common.TPDM.ICandidatePersonalIdentificationDocument).IdentificationDocumentUseDescriptor.Equals(compareTo.IdentificationDocumentUseDescriptor))
+             if ((this as Entities.Common.TPDM.ICandidatePersonalIdentificationDocument).IdentificationDocumentUseDescriptor.Equals(compareTo.IdentificationDocumentUseDescriptor))
                 return false;
 
+
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidatePersonalIdentificationDocument).PersonalInformationVerificationDescriptor == null
-                || !(this as Entities.Common.TPDM.ICandidatePersonalIdentificationDocument).PersonalInformationVerificationDescriptor.Equals(compareTo.PersonalInformationVerificationDescriptor))
+             if ((this as Entities.Common.TPDM.ICandidatePersonalIdentificationDocument).PersonalInformationVerificationDescriptor.Equals(compareTo.PersonalInformationVerificationDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -4017,7 +3971,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -4026,15 +3979,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
                     hash = hash * 23 + _candidate.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidatePersonalIdentificationDocument).IdentificationDocumentUseDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidatePersonalIdentificationDocument).IdentificationDocumentUseDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidatePersonalIdentificationDocument).IdentificationDocumentUseDescriptor.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidatePersonalIdentificationDocument).PersonalInformationVerificationDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidatePersonalIdentificationDocument).PersonalInformationVerificationDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidatePersonalIdentificationDocument).PersonalInformationVerificationDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -4265,7 +4217,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICandidateRace;
 
             if (ReferenceEquals(this, compareTo))
@@ -4280,10 +4231,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateRace).RaceDescriptor == null
-                || !(this as Entities.Common.TPDM.ICandidateRace).RaceDescriptor.Equals(compareTo.RaceDescriptor))
+             if ((this as Entities.Common.TPDM.ICandidateRace).RaceDescriptor.Equals(compareTo.RaceDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -4296,7 +4246,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -4305,11 +4254,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
                     hash = hash * 23 + _candidate.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateRace).RaceDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateRace).RaceDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateRace).RaceDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -4507,7 +4455,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICandidateTelephone;
 
             if (ReferenceEquals(this, compareTo))
@@ -4522,15 +4469,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateTelephone).TelephoneNumber == null
-                || !(this as Entities.Common.TPDM.ICandidateTelephone).TelephoneNumber.Equals(compareTo.TelephoneNumber))
+             if ((this as Entities.Common.TPDM.ICandidateTelephone).TelephoneNumber.Equals(compareTo.TelephoneNumber))
                 return false;
 
+
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateTelephone).TelephoneNumberTypeDescriptor == null
-                || !(this as Entities.Common.TPDM.ICandidateTelephone).TelephoneNumberTypeDescriptor.Equals(compareTo.TelephoneNumberTypeDescriptor))
+             if ((this as Entities.Common.TPDM.ICandidateTelephone).TelephoneNumberTypeDescriptor.Equals(compareTo.TelephoneNumberTypeDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -4543,7 +4489,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -4552,15 +4497,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Candidate.TPDM
                     hash = hash * 23 + _candidate.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateTelephone).TelephoneNumber != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateTelephone).TelephoneNumber.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateTelephone).TelephoneNumber.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateTelephone).TelephoneNumberTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateTelephone).TelephoneNumberTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateTelephone).TelephoneNumberTypeDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -5029,7 +4973,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CandidateEducatorPreparationProgr
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation;
 
             if (ReferenceEquals(this, compareTo))
@@ -5040,30 +4983,29 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CandidateEducatorPreparationProgr
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).BeginDate == null
-                || !(this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).BeginDate.Equals(compareTo.BeginDate))
+             if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).BeginDate.Equals(compareTo.BeginDate))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).CandidateIdentifier == null
-                || !(this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).CandidateIdentifier.Equals(compareTo.CandidateIdentifier))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).EducationOrganizationId == null
-                || !(this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
+            if (!(this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).CandidateIdentifier.Equals(compareTo.CandidateIdentifier))
                 return false;
 
+
             // Referenced Property
-            if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).ProgramName == null
-                || !(this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).ProgramName.Equals(compareTo.ProgramName))
+            if (!(this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
                 return false;
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).ProgramName.Equals(compareTo.ProgramName))
+                return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).ProgramTypeDescriptor == null
-                ||!(this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).ProgramTypeDescriptor.Equals(compareTo.ProgramTypeDescriptor))
+            if (!(this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).ProgramTypeDescriptor.Equals(compareTo.ProgramTypeDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -5076,33 +5018,28 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CandidateEducatorPreparationProgr
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).BeginDate != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).BeginDate.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).BeginDate.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).CandidateIdentifier != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).CandidateIdentifier.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).CandidateIdentifier.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).EducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).EducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).EducationOrganizationId.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).ProgramName != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).ProgramName.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).ProgramName.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).ProgramTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).ProgramTypeDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociation).ProgramTypeDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -5515,7 +5452,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CandidateEducatorPreparationProgr
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationCohortYear;
 
             if (ReferenceEquals(this, compareTo))
@@ -5530,15 +5466,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CandidateEducatorPreparationProgr
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationCohortYear).CohortYearTypeDescriptor == null
-                || !(this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationCohortYear).CohortYearTypeDescriptor.Equals(compareTo.CohortYearTypeDescriptor))
+             if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationCohortYear).CohortYearTypeDescriptor.Equals(compareTo.CohortYearTypeDescriptor))
                 return false;
 
+
             // Referenced Property
-            if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationCohortYear).SchoolYear == null
-                || !(this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationCohortYear).SchoolYear.Equals(compareTo.SchoolYear))
+            if (!(this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationCohortYear).SchoolYear.Equals(compareTo.SchoolYear))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -5551,7 +5486,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CandidateEducatorPreparationProgr
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -5560,15 +5494,13 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CandidateEducatorPreparationProgr
                     hash = hash * 23 + _candidateEducatorPreparationProgramAssociation.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationCohortYear).CohortYearTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationCohortYear).CohortYearTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationCohortYear).CohortYearTypeDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationCohortYear).SchoolYear != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationCohortYear).SchoolYear.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationCohortYear).SchoolYear.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -5774,7 +5706,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CandidateEducatorPreparationProgr
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationDegreeSpecialization;
 
             if (ReferenceEquals(this, compareTo))
@@ -5789,10 +5720,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CandidateEducatorPreparationProgr
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationDegreeSpecialization).MajorSpecialization == null
-                || !(this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationDegreeSpecialization).MajorSpecialization.Equals(compareTo.MajorSpecialization))
+             if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationDegreeSpecialization).MajorSpecialization.Equals(compareTo.MajorSpecialization))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -5805,7 +5735,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CandidateEducatorPreparationProgr
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -5814,11 +5743,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CandidateEducatorPreparationProgr
                     hash = hash * 23 + _candidateEducatorPreparationProgramAssociation.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationDegreeSpecialization).MajorSpecialization != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationDegreeSpecialization).MajorSpecialization.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.ICandidateEducatorPreparationProgramAssociationDegreeSpecialization).MajorSpecialization.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -6025,7 +5953,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CertificationRouteDescriptor.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICertificationRouteDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -6036,10 +5963,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CertificationRouteDescriptor.TPDM
 
 
             // Derived Property
-            if ((this as Entities.Common.TPDM.ICertificationRouteDescriptor).CertificationRouteDescriptorId == null
-                || !(this as Entities.Common.TPDM.ICertificationRouteDescriptor).CertificationRouteDescriptorId.Equals(compareTo.CertificationRouteDescriptorId))
+            if (!(this as Entities.Common.TPDM.ICertificationRouteDescriptor).CertificationRouteDescriptorId.Equals(compareTo.CertificationRouteDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -6052,17 +5978,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CertificationRouteDescriptor.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.TPDM.ICertificationRouteDescriptor).CertificationRouteDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICertificationRouteDescriptor).CertificationRouteDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ICertificationRouteDescriptor).CertificationRouteDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -6313,7 +6237,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CoteachingStyleObservedDescriptor
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICoteachingStyleObservedDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -6324,10 +6247,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CoteachingStyleObservedDescriptor
 
 
             // Derived Property
-            if ((this as Entities.Common.TPDM.ICoteachingStyleObservedDescriptor).CoteachingStyleObservedDescriptorId == null
-                || !(this as Entities.Common.TPDM.ICoteachingStyleObservedDescriptor).CoteachingStyleObservedDescriptorId.Equals(compareTo.CoteachingStyleObservedDescriptorId))
+            if (!(this as Entities.Common.TPDM.ICoteachingStyleObservedDescriptor).CoteachingStyleObservedDescriptorId.Equals(compareTo.CoteachingStyleObservedDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -6340,17 +6262,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CoteachingStyleObservedDescriptor
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.TPDM.ICoteachingStyleObservedDescriptor).CoteachingStyleObservedDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICoteachingStyleObservedDescriptor).CoteachingStyleObservedDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ICoteachingStyleObservedDescriptor).CoteachingStyleObservedDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -6636,7 +6556,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Credential.EdFi.Extensions.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICredentialExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -6649,7 +6568,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Credential.EdFi.Extensions.TPDM
             if (_credential == null || !_credential.Equals(compareTo.Credential))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -6662,7 +6580,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Credential.EdFi.Extensions.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -6671,7 +6588,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Credential.EdFi.Extensions.TPDM
                     hash = hash * 23 + _credential.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -7156,7 +7072,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Credential.EdFi.Extensions.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICredentialStudentAcademicRecord;
 
             if (ReferenceEquals(this, compareTo))
@@ -7171,25 +7086,24 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Credential.EdFi.Extensions.TPDM
 
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).EducationOrganizationId == null
-                || !(this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
+            if (!(this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).SchoolYear == null
-                || !(this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).SchoolYear.Equals(compareTo.SchoolYear))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).StudentUniqueId == null
-                || !(this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).StudentUniqueId.Equals(compareTo.StudentUniqueId))
+            if (!(this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).SchoolYear.Equals(compareTo.SchoolYear))
                 return false;
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).StudentUniqueId.Equals(compareTo.StudentUniqueId))
+                return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).TermDescriptor == null
-                ||!(this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).TermDescriptor.Equals(compareTo.TermDescriptor))
+            if (!(this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).TermDescriptor.Equals(compareTo.TermDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -7202,7 +7116,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Credential.EdFi.Extensions.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -7211,23 +7124,19 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Credential.EdFi.Extensions.TPDM
                     hash = hash * 23 + _credentialExtension.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).EducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).EducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).EducationOrganizationId.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).SchoolYear != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).SchoolYear.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).SchoolYear.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).StudentUniqueId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).StudentUniqueId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).StudentUniqueId.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).TermDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).TermDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ICredentialStudentAcademicRecord).TermDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -7432,7 +7341,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CredentialStatusDescriptor.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ICredentialStatusDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -7443,10 +7351,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CredentialStatusDescriptor.TPDM
 
 
             // Derived Property
-            if ((this as Entities.Common.TPDM.ICredentialStatusDescriptor).CredentialStatusDescriptorId == null
-                || !(this as Entities.Common.TPDM.ICredentialStatusDescriptor).CredentialStatusDescriptorId.Equals(compareTo.CredentialStatusDescriptorId))
+            if (!(this as Entities.Common.TPDM.ICredentialStatusDescriptor).CredentialStatusDescriptorId.Equals(compareTo.CredentialStatusDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -7459,17 +7366,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.CredentialStatusDescriptor.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.TPDM.ICredentialStatusDescriptor).CredentialStatusDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ICredentialStatusDescriptor).CredentialStatusDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ICredentialStatusDescriptor).CredentialStatusDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -7871,7 +7776,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducatorPreparationProgram.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEducatorPreparationProgram;
 
             if (ReferenceEquals(this, compareTo))
@@ -7882,20 +7786,19 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducatorPreparationProgram.TPDM
 
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEducatorPreparationProgram).EducationOrganizationId == null
-                || !(this as Entities.Common.TPDM.IEducatorPreparationProgram).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
+            if (!(this as Entities.Common.TPDM.IEducatorPreparationProgram).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
                 return false;
 
-            // Standard Property
-            if ((this as Entities.Common.TPDM.IEducatorPreparationProgram).ProgramName == null
-                || !(this as Entities.Common.TPDM.IEducatorPreparationProgram).ProgramName.Equals(compareTo.ProgramName))
-                return false;
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IEducatorPreparationProgram).ProgramTypeDescriptor == null
-                || !(this as Entities.Common.TPDM.IEducatorPreparationProgram).ProgramTypeDescriptor.Equals(compareTo.ProgramTypeDescriptor))
+             if ((this as Entities.Common.TPDM.IEducatorPreparationProgram).ProgramName.Equals(compareTo.ProgramName))
                 return false;
-            #pragma warning disable 472
+
+
+            // Standard Property
+             if ((this as Entities.Common.TPDM.IEducatorPreparationProgram).ProgramTypeDescriptor.Equals(compareTo.ProgramTypeDescriptor))
+                return false;
+
 
             return true;
         }
@@ -7908,25 +7811,22 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducatorPreparationProgram.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEducatorPreparationProgram).EducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEducatorPreparationProgram).EducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEducatorPreparationProgram).EducationOrganizationId.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IEducatorPreparationProgram).ProgramName != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEducatorPreparationProgram).ProgramName.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IEducatorPreparationProgram).ProgramName.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IEducatorPreparationProgram).ProgramTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEducatorPreparationProgram).ProgramTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IEducatorPreparationProgram).ProgramTypeDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -8209,7 +8109,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducatorPreparationProgram.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEducatorPreparationProgramGradeLevel;
 
             if (ReferenceEquals(this, compareTo))
@@ -8224,10 +8123,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducatorPreparationProgram.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IEducatorPreparationProgramGradeLevel).GradeLevelDescriptor == null
-                || !(this as Entities.Common.TPDM.IEducatorPreparationProgramGradeLevel).GradeLevelDescriptor.Equals(compareTo.GradeLevelDescriptor))
+             if ((this as Entities.Common.TPDM.IEducatorPreparationProgramGradeLevel).GradeLevelDescriptor.Equals(compareTo.GradeLevelDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -8240,7 +8138,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducatorPreparationProgram.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -8249,11 +8146,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducatorPreparationProgram.TPDM
                     hash = hash * 23 + _educatorPreparationProgram.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IEducatorPreparationProgramGradeLevel).GradeLevelDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEducatorPreparationProgramGradeLevel).GradeLevelDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IEducatorPreparationProgramGradeLevel).GradeLevelDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -8444,7 +8340,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducatorRoleDescriptor.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEducatorRoleDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -8455,10 +8350,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducatorRoleDescriptor.TPDM
 
 
             // Derived Property
-            if ((this as Entities.Common.TPDM.IEducatorRoleDescriptor).EducatorRoleDescriptorId == null
-                || !(this as Entities.Common.TPDM.IEducatorRoleDescriptor).EducatorRoleDescriptorId.Equals(compareTo.EducatorRoleDescriptorId))
+            if (!(this as Entities.Common.TPDM.IEducatorRoleDescriptor).EducatorRoleDescriptorId.Equals(compareTo.EducatorRoleDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -8471,17 +8365,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducatorRoleDescriptor.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.TPDM.IEducatorRoleDescriptor).EducatorRoleDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEducatorRoleDescriptor).EducatorRoleDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEducatorRoleDescriptor).EducatorRoleDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -8732,7 +8624,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EnglishLanguageExamDescriptor.TPD
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEnglishLanguageExamDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -8743,10 +8634,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EnglishLanguageExamDescriptor.TPD
 
 
             // Derived Property
-            if ((this as Entities.Common.TPDM.IEnglishLanguageExamDescriptor).EnglishLanguageExamDescriptorId == null
-                || !(this as Entities.Common.TPDM.IEnglishLanguageExamDescriptor).EnglishLanguageExamDescriptorId.Equals(compareTo.EnglishLanguageExamDescriptorId))
+            if (!(this as Entities.Common.TPDM.IEnglishLanguageExamDescriptor).EnglishLanguageExamDescriptorId.Equals(compareTo.EnglishLanguageExamDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -8759,17 +8649,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EnglishLanguageExamDescriptor.TPD
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.TPDM.IEnglishLanguageExamDescriptor).EnglishLanguageExamDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEnglishLanguageExamDescriptor).EnglishLanguageExamDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEnglishLanguageExamDescriptor).EnglishLanguageExamDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -9020,7 +8908,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EPPProgramPathwayDescriptor.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEPPProgramPathwayDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -9031,10 +8918,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EPPProgramPathwayDescriptor.TPDM
 
 
             // Derived Property
-            if ((this as Entities.Common.TPDM.IEPPProgramPathwayDescriptor).EPPProgramPathwayDescriptorId == null
-                || !(this as Entities.Common.TPDM.IEPPProgramPathwayDescriptor).EPPProgramPathwayDescriptorId.Equals(compareTo.EPPProgramPathwayDescriptorId))
+            if (!(this as Entities.Common.TPDM.IEPPProgramPathwayDescriptor).EPPProgramPathwayDescriptorId.Equals(compareTo.EPPProgramPathwayDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -9047,17 +8933,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EPPProgramPathwayDescriptor.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.TPDM.IEPPProgramPathwayDescriptor).EPPProgramPathwayDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEPPProgramPathwayDescriptor).EPPProgramPathwayDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEPPProgramPathwayDescriptor).EPPProgramPathwayDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -9577,7 +9461,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Evaluation.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluation;
 
             if (ReferenceEquals(this, compareTo))
@@ -9588,40 +9471,39 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Evaluation.TPDM
 
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluation).EducationOrganizationId == null
-                || !(this as Entities.Common.TPDM.IEvaluation).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
+            if (!(this as Entities.Common.TPDM.IEvaluation).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
                 return false;
 
+
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluation).EvaluationPeriodDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluation).EvaluationPeriodDescriptor.Equals(compareTo.EvaluationPeriodDescriptor))
+            if (!(this as Entities.Common.TPDM.IEvaluation).EvaluationPeriodDescriptor.Equals(compareTo.EvaluationPeriodDescriptor))
                 return false;
+
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IEvaluation).EvaluationTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluation).EvaluationTitle.Equals(compareTo.EvaluationTitle))
+             if ((this as Entities.Common.TPDM.IEvaluation).EvaluationTitle.Equals(compareTo.EvaluationTitle))
                 return false;
+
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluation).PerformanceEvaluationTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluation).PerformanceEvaluationTitle.Equals(compareTo.PerformanceEvaluationTitle))
+            if (!(this as Entities.Common.TPDM.IEvaluation).PerformanceEvaluationTitle.Equals(compareTo.PerformanceEvaluationTitle))
                 return false;
 
+
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluation).PerformanceEvaluationTypeDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluation).PerformanceEvaluationTypeDescriptor.Equals(compareTo.PerformanceEvaluationTypeDescriptor))
+            if (!(this as Entities.Common.TPDM.IEvaluation).PerformanceEvaluationTypeDescriptor.Equals(compareTo.PerformanceEvaluationTypeDescriptor))
                 return false;
+
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluation).SchoolYear == null
-                || !(this as Entities.Common.TPDM.IEvaluation).SchoolYear.Equals(compareTo.SchoolYear))
+            if (!(this as Entities.Common.TPDM.IEvaluation).SchoolYear.Equals(compareTo.SchoolYear))
                 return false;
 
+
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluation).TermDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluation).TermDescriptor.Equals(compareTo.TermDescriptor))
+            if (!(this as Entities.Common.TPDM.IEvaluation).TermDescriptor.Equals(compareTo.TermDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -9634,41 +9516,36 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Evaluation.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluation).EducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluation).EducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluation).EducationOrganizationId.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluation).EvaluationPeriodDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluation).EvaluationPeriodDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluation).EvaluationPeriodDescriptor.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IEvaluation).EvaluationTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluation).EvaluationTitle.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluation).EvaluationTitle.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluation).PerformanceEvaluationTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluation).PerformanceEvaluationTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluation).PerformanceEvaluationTitle.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluation).PerformanceEvaluationTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluation).PerformanceEvaluationTypeDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluation).PerformanceEvaluationTypeDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluation).SchoolYear != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluation).SchoolYear.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluation).SchoolYear.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluation).TermDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluation).TermDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluation).TermDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -9975,7 +9852,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Evaluation.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluationRatingLevel;
 
             if (ReferenceEquals(this, compareTo))
@@ -9990,10 +9866,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Evaluation.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IEvaluationRatingLevel).EvaluationRatingLevelDescriptor == null
-                || !(this as Entities.Common.TPDM.IEvaluationRatingLevel).EvaluationRatingLevelDescriptor.Equals(compareTo.EvaluationRatingLevelDescriptor))
+             if ((this as Entities.Common.TPDM.IEvaluationRatingLevel).EvaluationRatingLevelDescriptor.Equals(compareTo.EvaluationRatingLevelDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -10006,7 +9881,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Evaluation.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -10015,11 +9889,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.Evaluation.TPDM
                     hash = hash * 23 + _evaluation.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IEvaluationRatingLevel).EvaluationRatingLevelDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRatingLevel).EvaluationRatingLevelDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRatingLevel).EvaluationRatingLevelDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -10551,7 +10424,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationElement.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluationElement;
 
             if (ReferenceEquals(this, compareTo))
@@ -10562,50 +10434,49 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationElement.TPDM
 
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationElement).EducationOrganizationId == null
-                || !(this as Entities.Common.TPDM.IEvaluationElement).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
+            if (!(this as Entities.Common.TPDM.IEvaluationElement).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
                 return false;
+
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IEvaluationElement).EvaluationElementTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationElement).EvaluationElementTitle.Equals(compareTo.EvaluationElementTitle))
+             if ((this as Entities.Common.TPDM.IEvaluationElement).EvaluationElementTitle.Equals(compareTo.EvaluationElementTitle))
                 return false;
 
+
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationElement).EvaluationObjectiveTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationElement).EvaluationObjectiveTitle.Equals(compareTo.EvaluationObjectiveTitle))
+            if (!(this as Entities.Common.TPDM.IEvaluationElement).EvaluationObjectiveTitle.Equals(compareTo.EvaluationObjectiveTitle))
                 return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluationElement).EvaluationPeriodDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluationElement).EvaluationPeriodDescriptor.Equals(compareTo.EvaluationPeriodDescriptor))
+            if (!(this as Entities.Common.TPDM.IEvaluationElement).EvaluationPeriodDescriptor.Equals(compareTo.EvaluationPeriodDescriptor))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationElement).EvaluationTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationElement).EvaluationTitle.Equals(compareTo.EvaluationTitle))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationElement).PerformanceEvaluationTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationElement).PerformanceEvaluationTitle.Equals(compareTo.PerformanceEvaluationTitle))
+            if (!(this as Entities.Common.TPDM.IEvaluationElement).EvaluationTitle.Equals(compareTo.EvaluationTitle))
                 return false;
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.TPDM.IEvaluationElement).PerformanceEvaluationTitle.Equals(compareTo.PerformanceEvaluationTitle))
+                return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluationElement).PerformanceEvaluationTypeDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluationElement).PerformanceEvaluationTypeDescriptor.Equals(compareTo.PerformanceEvaluationTypeDescriptor))
+            if (!(this as Entities.Common.TPDM.IEvaluationElement).PerformanceEvaluationTypeDescriptor.Equals(compareTo.PerformanceEvaluationTypeDescriptor))
                 return false;
+
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationElement).SchoolYear == null
-                || !(this as Entities.Common.TPDM.IEvaluationElement).SchoolYear.Equals(compareTo.SchoolYear))
+            if (!(this as Entities.Common.TPDM.IEvaluationElement).SchoolYear.Equals(compareTo.SchoolYear))
                 return false;
 
+
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluationElement).TermDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluationElement).TermDescriptor.Equals(compareTo.TermDescriptor))
+            if (!(this as Entities.Common.TPDM.IEvaluationElement).TermDescriptor.Equals(compareTo.TermDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -10618,49 +10489,42 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationElement.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationElement).EducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElement).EducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElement).EducationOrganizationId.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IEvaluationElement).EvaluationElementTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElement).EvaluationElementTitle.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElement).EvaluationElementTitle.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationElement).EvaluationObjectiveTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElement).EvaluationObjectiveTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElement).EvaluationObjectiveTitle.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluationElement).EvaluationPeriodDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElement).EvaluationPeriodDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElement).EvaluationPeriodDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationElement).EvaluationTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElement).EvaluationTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElement).EvaluationTitle.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationElement).PerformanceEvaluationTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElement).PerformanceEvaluationTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElement).PerformanceEvaluationTitle.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluationElement).PerformanceEvaluationTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElement).PerformanceEvaluationTypeDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElement).PerformanceEvaluationTypeDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationElement).SchoolYear != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElement).SchoolYear.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElement).SchoolYear.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluationElement).TermDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElement).TermDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElement).TermDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -10959,7 +10823,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationElement.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluationElementRatingLevel;
 
             if (ReferenceEquals(this, compareTo))
@@ -10974,10 +10837,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationElement.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IEvaluationElementRatingLevel).EvaluationRatingLevelDescriptor == null
-                || !(this as Entities.Common.TPDM.IEvaluationElementRatingLevel).EvaluationRatingLevelDescriptor.Equals(compareTo.EvaluationRatingLevelDescriptor))
+             if ((this as Entities.Common.TPDM.IEvaluationElementRatingLevel).EvaluationRatingLevelDescriptor.Equals(compareTo.EvaluationRatingLevelDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -10990,7 +10852,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationElement.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -10999,11 +10860,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationElement.TPDM
                     hash = hash * 23 + _evaluationElement.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IEvaluationElementRatingLevel).EvaluationRatingLevelDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRatingLevel).EvaluationRatingLevelDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRatingLevel).EvaluationRatingLevelDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -11688,7 +11548,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationElementRating.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluationElementRating;
 
             if (ReferenceEquals(this, compareTo))
@@ -11699,65 +11558,64 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationElementRating.TPDM
 
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationElementRating).EducationOrganizationId == null
-                || !(this as Entities.Common.TPDM.IEvaluationElementRating).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
+            if (!(this as Entities.Common.TPDM.IEvaluationElementRating).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationDate == null
-                || !(this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationDate.Equals(compareTo.EvaluationDate))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationElementTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationElementTitle.Equals(compareTo.EvaluationElementTitle))
+            if (!(this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationDate.Equals(compareTo.EvaluationDate))
                 return false;
 
+
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationObjectiveTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationObjectiveTitle.Equals(compareTo.EvaluationObjectiveTitle))
+            if (!(this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationElementTitle.Equals(compareTo.EvaluationElementTitle))
                 return false;
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationObjectiveTitle.Equals(compareTo.EvaluationObjectiveTitle))
+                return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationPeriodDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationPeriodDescriptor.Equals(compareTo.EvaluationPeriodDescriptor))
+            if (!(this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationPeriodDescriptor.Equals(compareTo.EvaluationPeriodDescriptor))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationTitle.Equals(compareTo.EvaluationTitle))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationElementRating).PerformanceEvaluationTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationElementRating).PerformanceEvaluationTitle.Equals(compareTo.PerformanceEvaluationTitle))
+            if (!(this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationTitle.Equals(compareTo.EvaluationTitle))
                 return false;
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.TPDM.IEvaluationElementRating).PerformanceEvaluationTitle.Equals(compareTo.PerformanceEvaluationTitle))
+                return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluationElementRating).PerformanceEvaluationTypeDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluationElementRating).PerformanceEvaluationTypeDescriptor.Equals(compareTo.PerformanceEvaluationTypeDescriptor))
+            if (!(this as Entities.Common.TPDM.IEvaluationElementRating).PerformanceEvaluationTypeDescriptor.Equals(compareTo.PerformanceEvaluationTypeDescriptor))
                 return false;
+
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationElementRating).PersonId == null
-                || !(this as Entities.Common.TPDM.IEvaluationElementRating).PersonId.Equals(compareTo.PersonId))
+            if (!(this as Entities.Common.TPDM.IEvaluationElementRating).PersonId.Equals(compareTo.PersonId))
                 return false;
+
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationElementRating).SchoolYear == null
-                || !(this as Entities.Common.TPDM.IEvaluationElementRating).SchoolYear.Equals(compareTo.SchoolYear))
+            if (!(this as Entities.Common.TPDM.IEvaluationElementRating).SchoolYear.Equals(compareTo.SchoolYear))
                 return false;
 
-            // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluationElementRating).SourceSystemDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluationElementRating).SourceSystemDescriptor.Equals(compareTo.SourceSystemDescriptor))
-                return false;
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluationElementRating).TermDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluationElementRating).TermDescriptor.Equals(compareTo.TermDescriptor))
+            if (!(this as Entities.Common.TPDM.IEvaluationElementRating).SourceSystemDescriptor.Equals(compareTo.SourceSystemDescriptor))
                 return false;
-            #pragma warning disable 472
+
+
+            // Unified Type Property
+            if (!(this as Entities.Common.TPDM.IEvaluationElementRating).TermDescriptor.Equals(compareTo.TermDescriptor))
+                return false;
+
 
             return true;
         }
@@ -11770,61 +11628,51 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationElementRating.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationElementRating).EducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).EducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).EducationOrganizationId.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationDate != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationDate.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationDate.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationElementTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationElementTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationElementTitle.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationObjectiveTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationObjectiveTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationObjectiveTitle.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationPeriodDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationPeriodDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationPeriodDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).EvaluationTitle.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationElementRating).PerformanceEvaluationTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).PerformanceEvaluationTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).PerformanceEvaluationTitle.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluationElementRating).PerformanceEvaluationTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).PerformanceEvaluationTypeDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).PerformanceEvaluationTypeDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationElementRating).PersonId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).PersonId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).PersonId.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationElementRating).SchoolYear != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).SchoolYear.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).SchoolYear.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluationElementRating).SourceSystemDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).SourceSystemDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).SourceSystemDescriptor.GetHashCode();
+
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluationElementRating).TermDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).TermDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRating).TermDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -12368,7 +12216,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationElementRating.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluationElementRatingResult;
 
             if (ReferenceEquals(this, compareTo))
@@ -12383,15 +12230,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationElementRating.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IEvaluationElementRatingResult).Rating == null
-                || !(this as Entities.Common.TPDM.IEvaluationElementRatingResult).Rating.Equals(compareTo.Rating))
+             if ((this as Entities.Common.TPDM.IEvaluationElementRatingResult).Rating.Equals(compareTo.Rating))
                 return false;
 
+
             // Standard Property
-            if ((this as Entities.Common.TPDM.IEvaluationElementRatingResult).RatingResultTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationElementRatingResult).RatingResultTitle.Equals(compareTo.RatingResultTitle))
+             if ((this as Entities.Common.TPDM.IEvaluationElementRatingResult).RatingResultTitle.Equals(compareTo.RatingResultTitle))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -12404,7 +12250,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationElementRating.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -12413,15 +12258,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationElementRating.TPDM
                     hash = hash * 23 + _evaluationElementRating.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IEvaluationElementRatingResult).Rating != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRatingResult).Rating.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRatingResult).Rating.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IEvaluationElementRatingResult).RatingResultTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRatingResult).RatingResultTitle.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRatingResult).RatingResultTitle.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -12620,7 +12464,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationElementRatingLevelDescr
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluationElementRatingLevelDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -12631,10 +12474,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationElementRatingLevelDescr
 
 
             // Derived Property
-            if ((this as Entities.Common.TPDM.IEvaluationElementRatingLevelDescriptor).EvaluationElementRatingLevelDescriptorId == null
-                || !(this as Entities.Common.TPDM.IEvaluationElementRatingLevelDescriptor).EvaluationElementRatingLevelDescriptorId.Equals(compareTo.EvaluationElementRatingLevelDescriptorId))
+            if (!(this as Entities.Common.TPDM.IEvaluationElementRatingLevelDescriptor).EvaluationElementRatingLevelDescriptorId.Equals(compareTo.EvaluationElementRatingLevelDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -12647,17 +12489,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationElementRatingLevelDescr
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.TPDM.IEvaluationElementRatingLevelDescriptor).EvaluationElementRatingLevelDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRatingLevelDescriptor).EvaluationElementRatingLevelDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationElementRatingLevelDescriptor).EvaluationElementRatingLevelDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -13205,7 +13045,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationObjective.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluationObjective;
 
             if (ReferenceEquals(this, compareTo))
@@ -13216,45 +13055,44 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationObjective.TPDM
 
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjective).EducationOrganizationId == null
-                || !(this as Entities.Common.TPDM.IEvaluationObjective).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
+            if (!(this as Entities.Common.TPDM.IEvaluationObjective).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
                 return false;
+
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjective).EvaluationObjectiveTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationObjective).EvaluationObjectiveTitle.Equals(compareTo.EvaluationObjectiveTitle))
+             if ((this as Entities.Common.TPDM.IEvaluationObjective).EvaluationObjectiveTitle.Equals(compareTo.EvaluationObjectiveTitle))
                 return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjective).EvaluationPeriodDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluationObjective).EvaluationPeriodDescriptor.Equals(compareTo.EvaluationPeriodDescriptor))
+            if (!(this as Entities.Common.TPDM.IEvaluationObjective).EvaluationPeriodDescriptor.Equals(compareTo.EvaluationPeriodDescriptor))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjective).EvaluationTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationObjective).EvaluationTitle.Equals(compareTo.EvaluationTitle))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjective).PerformanceEvaluationTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationObjective).PerformanceEvaluationTitle.Equals(compareTo.PerformanceEvaluationTitle))
+            if (!(this as Entities.Common.TPDM.IEvaluationObjective).EvaluationTitle.Equals(compareTo.EvaluationTitle))
                 return false;
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.TPDM.IEvaluationObjective).PerformanceEvaluationTitle.Equals(compareTo.PerformanceEvaluationTitle))
+                return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjective).PerformanceEvaluationTypeDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluationObjective).PerformanceEvaluationTypeDescriptor.Equals(compareTo.PerformanceEvaluationTypeDescriptor))
+            if (!(this as Entities.Common.TPDM.IEvaluationObjective).PerformanceEvaluationTypeDescriptor.Equals(compareTo.PerformanceEvaluationTypeDescriptor))
                 return false;
+
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjective).SchoolYear == null
-                || !(this as Entities.Common.TPDM.IEvaluationObjective).SchoolYear.Equals(compareTo.SchoolYear))
+            if (!(this as Entities.Common.TPDM.IEvaluationObjective).SchoolYear.Equals(compareTo.SchoolYear))
                 return false;
 
+
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjective).TermDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluationObjective).TermDescriptor.Equals(compareTo.TermDescriptor))
+            if (!(this as Entities.Common.TPDM.IEvaluationObjective).TermDescriptor.Equals(compareTo.TermDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -13267,45 +13105,39 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationObjective.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjective).EducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjective).EducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjective).EducationOrganizationId.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjective).EvaluationObjectiveTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjective).EvaluationObjectiveTitle.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjective).EvaluationObjectiveTitle.GetHashCode();
+
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjective).EvaluationPeriodDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjective).EvaluationPeriodDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjective).EvaluationPeriodDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjective).EvaluationTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjective).EvaluationTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjective).EvaluationTitle.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjective).PerformanceEvaluationTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjective).PerformanceEvaluationTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjective).PerformanceEvaluationTitle.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjective).PerformanceEvaluationTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjective).PerformanceEvaluationTypeDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjective).PerformanceEvaluationTypeDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjective).SchoolYear != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjective).SchoolYear.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjective).SchoolYear.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjective).TermDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjective).TermDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjective).TermDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -13612,7 +13444,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationObjective.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluationObjectiveRatingLevel;
 
             if (ReferenceEquals(this, compareTo))
@@ -13627,10 +13458,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationObjective.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjectiveRatingLevel).EvaluationRatingLevelDescriptor == null
-                || !(this as Entities.Common.TPDM.IEvaluationObjectiveRatingLevel).EvaluationRatingLevelDescriptor.Equals(compareTo.EvaluationRatingLevelDescriptor))
+             if ((this as Entities.Common.TPDM.IEvaluationObjectiveRatingLevel).EvaluationRatingLevelDescriptor.Equals(compareTo.EvaluationRatingLevelDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -13643,7 +13473,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationObjective.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -13652,11 +13481,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationObjective.TPDM
                     hash = hash * 23 + _evaluationObjective.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjectiveRatingLevel).EvaluationRatingLevelDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRatingLevel).EvaluationRatingLevelDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRatingLevel).EvaluationRatingLevelDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -14309,7 +14137,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationObjectiveRating.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluationObjectiveRating;
 
             if (ReferenceEquals(this, compareTo))
@@ -14320,60 +14147,59 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationObjectiveRating.TPDM
 
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).EducationOrganizationId == null
-                || !(this as Entities.Common.TPDM.IEvaluationObjectiveRating).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
+            if (!(this as Entities.Common.TPDM.IEvaluationObjectiveRating).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationDate == null
-                || !(this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationDate.Equals(compareTo.EvaluationDate))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationObjectiveTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationObjectiveTitle.Equals(compareTo.EvaluationObjectiveTitle))
+            if (!(this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationDate.Equals(compareTo.EvaluationDate))
                 return false;
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationObjectiveTitle.Equals(compareTo.EvaluationObjectiveTitle))
+                return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationPeriodDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationPeriodDescriptor.Equals(compareTo.EvaluationPeriodDescriptor))
+            if (!(this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationPeriodDescriptor.Equals(compareTo.EvaluationPeriodDescriptor))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationTitle.Equals(compareTo.EvaluationTitle))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).PerformanceEvaluationTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationObjectiveRating).PerformanceEvaluationTitle.Equals(compareTo.PerformanceEvaluationTitle))
+            if (!(this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationTitle.Equals(compareTo.EvaluationTitle))
                 return false;
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.TPDM.IEvaluationObjectiveRating).PerformanceEvaluationTitle.Equals(compareTo.PerformanceEvaluationTitle))
+                return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).PerformanceEvaluationTypeDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluationObjectiveRating).PerformanceEvaluationTypeDescriptor.Equals(compareTo.PerformanceEvaluationTypeDescriptor))
+            if (!(this as Entities.Common.TPDM.IEvaluationObjectiveRating).PerformanceEvaluationTypeDescriptor.Equals(compareTo.PerformanceEvaluationTypeDescriptor))
                 return false;
+
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).PersonId == null
-                || !(this as Entities.Common.TPDM.IEvaluationObjectiveRating).PersonId.Equals(compareTo.PersonId))
+            if (!(this as Entities.Common.TPDM.IEvaluationObjectiveRating).PersonId.Equals(compareTo.PersonId))
                 return false;
+
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).SchoolYear == null
-                || !(this as Entities.Common.TPDM.IEvaluationObjectiveRating).SchoolYear.Equals(compareTo.SchoolYear))
+            if (!(this as Entities.Common.TPDM.IEvaluationObjectiveRating).SchoolYear.Equals(compareTo.SchoolYear))
                 return false;
 
-            // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).SourceSystemDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluationObjectiveRating).SourceSystemDescriptor.Equals(compareTo.SourceSystemDescriptor))
-                return false;
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).TermDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluationObjectiveRating).TermDescriptor.Equals(compareTo.TermDescriptor))
+            if (!(this as Entities.Common.TPDM.IEvaluationObjectiveRating).SourceSystemDescriptor.Equals(compareTo.SourceSystemDescriptor))
                 return false;
-            #pragma warning disable 472
+
+
+            // Unified Type Property
+            if (!(this as Entities.Common.TPDM.IEvaluationObjectiveRating).TermDescriptor.Equals(compareTo.TermDescriptor))
+                return false;
+
 
             return true;
         }
@@ -14386,57 +14212,48 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationObjectiveRating.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).EducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).EducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).EducationOrganizationId.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationDate != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationDate.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationDate.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationObjectiveTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationObjectiveTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationObjectiveTitle.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationPeriodDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationPeriodDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationPeriodDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).EvaluationTitle.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).PerformanceEvaluationTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).PerformanceEvaluationTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).PerformanceEvaluationTitle.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).PerformanceEvaluationTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).PerformanceEvaluationTypeDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).PerformanceEvaluationTypeDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).PersonId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).PersonId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).PersonId.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).SchoolYear != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).SchoolYear.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).SchoolYear.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).SourceSystemDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).SourceSystemDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).SourceSystemDescriptor.GetHashCode();
+
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjectiveRating).TermDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).TermDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRating).TermDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -14929,7 +14746,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationObjectiveRating.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluationObjectiveRatingResult;
 
             if (ReferenceEquals(this, compareTo))
@@ -14944,15 +14760,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationObjectiveRating.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjectiveRatingResult).Rating == null
-                || !(this as Entities.Common.TPDM.IEvaluationObjectiveRatingResult).Rating.Equals(compareTo.Rating))
+             if ((this as Entities.Common.TPDM.IEvaluationObjectiveRatingResult).Rating.Equals(compareTo.Rating))
                 return false;
 
+
             // Standard Property
-            if ((this as Entities.Common.TPDM.IEvaluationObjectiveRatingResult).RatingResultTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationObjectiveRatingResult).RatingResultTitle.Equals(compareTo.RatingResultTitle))
+             if ((this as Entities.Common.TPDM.IEvaluationObjectiveRatingResult).RatingResultTitle.Equals(compareTo.RatingResultTitle))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -14965,7 +14780,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationObjectiveRating.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -14974,15 +14788,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationObjectiveRating.TPDM
                     hash = hash * 23 + _evaluationObjectiveRating.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjectiveRatingResult).Rating != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRatingResult).Rating.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRatingResult).Rating.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IEvaluationObjectiveRatingResult).RatingResultTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRatingResult).RatingResultTitle.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationObjectiveRatingResult).RatingResultTitle.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -15181,7 +14994,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationPeriodDescriptor.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluationPeriodDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -15192,10 +15004,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationPeriodDescriptor.TPDM
 
 
             // Derived Property
-            if ((this as Entities.Common.TPDM.IEvaluationPeriodDescriptor).EvaluationPeriodDescriptorId == null
-                || !(this as Entities.Common.TPDM.IEvaluationPeriodDescriptor).EvaluationPeriodDescriptorId.Equals(compareTo.EvaluationPeriodDescriptorId))
+            if (!(this as Entities.Common.TPDM.IEvaluationPeriodDescriptor).EvaluationPeriodDescriptorId.Equals(compareTo.EvaluationPeriodDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -15208,17 +15019,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationPeriodDescriptor.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.TPDM.IEvaluationPeriodDescriptor).EvaluationPeriodDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationPeriodDescriptor).EvaluationPeriodDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationPeriodDescriptor).EvaluationPeriodDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -15902,7 +15711,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRating.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluationRating;
 
             if (ReferenceEquals(this, compareTo))
@@ -15913,55 +15721,54 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRating.TPDM
 
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationRating).EducationOrganizationId == null
-                || !(this as Entities.Common.TPDM.IEvaluationRating).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
+            if (!(this as Entities.Common.TPDM.IEvaluationRating).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
                 return false;
+
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IEvaluationRating).EvaluationDate == null
-                || !(this as Entities.Common.TPDM.IEvaluationRating).EvaluationDate.Equals(compareTo.EvaluationDate))
+             if ((this as Entities.Common.TPDM.IEvaluationRating).EvaluationDate.Equals(compareTo.EvaluationDate))
                 return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluationRating).EvaluationPeriodDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluationRating).EvaluationPeriodDescriptor.Equals(compareTo.EvaluationPeriodDescriptor))
+            if (!(this as Entities.Common.TPDM.IEvaluationRating).EvaluationPeriodDescriptor.Equals(compareTo.EvaluationPeriodDescriptor))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationRating).EvaluationTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationRating).EvaluationTitle.Equals(compareTo.EvaluationTitle))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationRating).PerformanceEvaluationTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationRating).PerformanceEvaluationTitle.Equals(compareTo.PerformanceEvaluationTitle))
+            if (!(this as Entities.Common.TPDM.IEvaluationRating).EvaluationTitle.Equals(compareTo.EvaluationTitle))
                 return false;
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.TPDM.IEvaluationRating).PerformanceEvaluationTitle.Equals(compareTo.PerformanceEvaluationTitle))
+                return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluationRating).PerformanceEvaluationTypeDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluationRating).PerformanceEvaluationTypeDescriptor.Equals(compareTo.PerformanceEvaluationTypeDescriptor))
+            if (!(this as Entities.Common.TPDM.IEvaluationRating).PerformanceEvaluationTypeDescriptor.Equals(compareTo.PerformanceEvaluationTypeDescriptor))
                 return false;
+
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationRating).PersonId == null
-                || !(this as Entities.Common.TPDM.IEvaluationRating).PersonId.Equals(compareTo.PersonId))
+            if (!(this as Entities.Common.TPDM.IEvaluationRating).PersonId.Equals(compareTo.PersonId))
                 return false;
+
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IEvaluationRating).SchoolYear == null
-                || !(this as Entities.Common.TPDM.IEvaluationRating).SchoolYear.Equals(compareTo.SchoolYear))
+            if (!(this as Entities.Common.TPDM.IEvaluationRating).SchoolYear.Equals(compareTo.SchoolYear))
                 return false;
 
-            // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluationRating).SourceSystemDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluationRating).SourceSystemDescriptor.Equals(compareTo.SourceSystemDescriptor))
-                return false;
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IEvaluationRating).TermDescriptor == null
-                ||!(this as Entities.Common.TPDM.IEvaluationRating).TermDescriptor.Equals(compareTo.TermDescriptor))
+            if (!(this as Entities.Common.TPDM.IEvaluationRating).SourceSystemDescriptor.Equals(compareTo.SourceSystemDescriptor))
                 return false;
-            #pragma warning disable 472
+
+
+            // Unified Type Property
+            if (!(this as Entities.Common.TPDM.IEvaluationRating).TermDescriptor.Equals(compareTo.TermDescriptor))
+                return false;
+
 
             return true;
         }
@@ -15974,53 +15781,46 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRating.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationRating).EducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).EducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).EducationOrganizationId.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IEvaluationRating).EvaluationDate != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).EvaluationDate.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).EvaluationDate.GetHashCode();
+
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluationRating).EvaluationPeriodDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).EvaluationPeriodDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).EvaluationPeriodDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationRating).EvaluationTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).EvaluationTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).EvaluationTitle.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationRating).PerformanceEvaluationTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).PerformanceEvaluationTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).PerformanceEvaluationTitle.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluationRating).PerformanceEvaluationTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).PerformanceEvaluationTypeDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).PerformanceEvaluationTypeDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationRating).PersonId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).PersonId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).PersonId.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IEvaluationRating).SchoolYear != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).SchoolYear.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).SchoolYear.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluationRating).SourceSystemDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).SourceSystemDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).SourceSystemDescriptor.GetHashCode();
+
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IEvaluationRating).TermDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).TermDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRating).TermDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -16670,7 +16470,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRating.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluationRatingResult;
 
             if (ReferenceEquals(this, compareTo))
@@ -16685,15 +16484,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRating.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IEvaluationRatingResult).Rating == null
-                || !(this as Entities.Common.TPDM.IEvaluationRatingResult).Rating.Equals(compareTo.Rating))
+             if ((this as Entities.Common.TPDM.IEvaluationRatingResult).Rating.Equals(compareTo.Rating))
                 return false;
 
+
             // Standard Property
-            if ((this as Entities.Common.TPDM.IEvaluationRatingResult).RatingResultTitle == null
-                || !(this as Entities.Common.TPDM.IEvaluationRatingResult).RatingResultTitle.Equals(compareTo.RatingResultTitle))
+             if ((this as Entities.Common.TPDM.IEvaluationRatingResult).RatingResultTitle.Equals(compareTo.RatingResultTitle))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -16706,7 +16504,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRating.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -16715,15 +16512,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRating.TPDM
                     hash = hash * 23 + _evaluationRating.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IEvaluationRatingResult).Rating != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRatingResult).Rating.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRatingResult).Rating.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IEvaluationRatingResult).RatingResultTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRatingResult).RatingResultTitle.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRatingResult).RatingResultTitle.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -16962,7 +16758,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRating.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluationRatingReviewer;
 
             if (ReferenceEquals(this, compareTo))
@@ -16977,15 +16772,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRating.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IEvaluationRatingReviewer).FirstName == null
-                || !(this as Entities.Common.TPDM.IEvaluationRatingReviewer).FirstName.Equals(compareTo.FirstName))
+             if ((this as Entities.Common.TPDM.IEvaluationRatingReviewer).FirstName.Equals(compareTo.FirstName))
                 return false;
 
+
             // Standard Property
-            if ((this as Entities.Common.TPDM.IEvaluationRatingReviewer).LastSurname == null
-                || !(this as Entities.Common.TPDM.IEvaluationRatingReviewer).LastSurname.Equals(compareTo.LastSurname))
+             if ((this as Entities.Common.TPDM.IEvaluationRatingReviewer).LastSurname.Equals(compareTo.LastSurname))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -16998,7 +16792,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRating.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -17007,15 +16800,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRating.TPDM
                     hash = hash * 23 + _evaluationRating.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IEvaluationRatingReviewer).FirstName != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRatingReviewer).FirstName.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRatingReviewer).FirstName.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IEvaluationRatingReviewer).LastSurname != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRatingReviewer).LastSurname.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRatingReviewer).LastSurname.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -17278,7 +17070,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRating.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluationRatingReviewerReceivedTraining;
 
             if (ReferenceEquals(this, compareTo))
@@ -17291,7 +17082,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRating.TPDM
             if (_evaluationRatingReviewer == null || !_evaluationRatingReviewer.Equals(compareTo.EvaluationRatingReviewer))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -17304,7 +17094,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRating.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -17313,7 +17102,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRating.TPDM
                     hash = hash * 23 + _evaluationRatingReviewer.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -17520,7 +17308,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRatingLevelDescriptor.T
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluationRatingLevelDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -17531,10 +17318,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRatingLevelDescriptor.T
 
 
             // Derived Property
-            if ((this as Entities.Common.TPDM.IEvaluationRatingLevelDescriptor).EvaluationRatingLevelDescriptorId == null
-                || !(this as Entities.Common.TPDM.IEvaluationRatingLevelDescriptor).EvaluationRatingLevelDescriptorId.Equals(compareTo.EvaluationRatingLevelDescriptorId))
+            if (!(this as Entities.Common.TPDM.IEvaluationRatingLevelDescriptor).EvaluationRatingLevelDescriptorId.Equals(compareTo.EvaluationRatingLevelDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -17547,17 +17333,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRatingLevelDescriptor.T
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.TPDM.IEvaluationRatingLevelDescriptor).EvaluationRatingLevelDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRatingLevelDescriptor).EvaluationRatingLevelDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRatingLevelDescriptor).EvaluationRatingLevelDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -17808,7 +17592,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRatingStatusDescriptor.
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluationRatingStatusDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -17819,10 +17602,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRatingStatusDescriptor.
 
 
             // Derived Property
-            if ((this as Entities.Common.TPDM.IEvaluationRatingStatusDescriptor).EvaluationRatingStatusDescriptorId == null
-                || !(this as Entities.Common.TPDM.IEvaluationRatingStatusDescriptor).EvaluationRatingStatusDescriptorId.Equals(compareTo.EvaluationRatingStatusDescriptorId))
+            if (!(this as Entities.Common.TPDM.IEvaluationRatingStatusDescriptor).EvaluationRatingStatusDescriptorId.Equals(compareTo.EvaluationRatingStatusDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -17835,17 +17617,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationRatingStatusDescriptor.
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.TPDM.IEvaluationRatingStatusDescriptor).EvaluationRatingStatusDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRatingStatusDescriptor).EvaluationRatingStatusDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationRatingStatusDescriptor).EvaluationRatingStatusDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -18096,7 +17876,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationTypeDescriptor.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IEvaluationTypeDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -18107,10 +17886,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationTypeDescriptor.TPDM
 
 
             // Derived Property
-            if ((this as Entities.Common.TPDM.IEvaluationTypeDescriptor).EvaluationTypeDescriptorId == null
-                || !(this as Entities.Common.TPDM.IEvaluationTypeDescriptor).EvaluationTypeDescriptorId.Equals(compareTo.EvaluationTypeDescriptorId))
+            if (!(this as Entities.Common.TPDM.IEvaluationTypeDescriptor).EvaluationTypeDescriptorId.Equals(compareTo.EvaluationTypeDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -18123,17 +17901,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EvaluationTypeDescriptor.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.TPDM.IEvaluationTypeDescriptor).EvaluationTypeDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationTypeDescriptor).EvaluationTypeDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IEvaluationTypeDescriptor).EvaluationTypeDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -18531,7 +18307,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.FinancialAid.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IFinancialAid;
 
             if (ReferenceEquals(this, compareTo))
@@ -18542,20 +18317,19 @@ namespace EdFi.Ods.Api.Common.Models.Resources.FinancialAid.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IFinancialAid).AidTypeDescriptor == null
-                || !(this as Entities.Common.TPDM.IFinancialAid).AidTypeDescriptor.Equals(compareTo.AidTypeDescriptor))
+             if ((this as Entities.Common.TPDM.IFinancialAid).AidTypeDescriptor.Equals(compareTo.AidTypeDescriptor))
                 return false;
+
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IFinancialAid).BeginDate == null
-                || !(this as Entities.Common.TPDM.IFinancialAid).BeginDate.Equals(compareTo.BeginDate))
+             if ((this as Entities.Common.TPDM.IFinancialAid).BeginDate.Equals(compareTo.BeginDate))
                 return false;
 
+
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IFinancialAid).StudentUniqueId == null
-                || !(this as Entities.Common.TPDM.IFinancialAid).StudentUniqueId.Equals(compareTo.StudentUniqueId))
+            if (!(this as Entities.Common.TPDM.IFinancialAid).StudentUniqueId.Equals(compareTo.StudentUniqueId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -18568,25 +18342,22 @@ namespace EdFi.Ods.Api.Common.Models.Resources.FinancialAid.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IFinancialAid).AidTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IFinancialAid).AidTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IFinancialAid).AidTypeDescriptor.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IFinancialAid).BeginDate != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IFinancialAid).BeginDate.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IFinancialAid).BeginDate.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IFinancialAid).StudentUniqueId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IFinancialAid).StudentUniqueId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IFinancialAid).StudentUniqueId.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -18827,7 +18598,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.GenderDescriptor.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IGenderDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -18838,10 +18608,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.GenderDescriptor.TPDM
 
 
             // Derived Property
-            if ((this as Entities.Common.TPDM.IGenderDescriptor).GenderDescriptorId == null
-                || !(this as Entities.Common.TPDM.IGenderDescriptor).GenderDescriptorId.Equals(compareTo.GenderDescriptorId))
+            if (!(this as Entities.Common.TPDM.IGenderDescriptor).GenderDescriptorId.Equals(compareTo.GenderDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -18854,17 +18623,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.GenderDescriptor.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.TPDM.IGenderDescriptor).GenderDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IGenderDescriptor).GenderDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IGenderDescriptor).GenderDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -19115,7 +18882,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.ObjectiveRatingLevelDescriptor.TP
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IObjectiveRatingLevelDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -19126,10 +18892,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.ObjectiveRatingLevelDescriptor.TP
 
 
             // Derived Property
-            if ((this as Entities.Common.TPDM.IObjectiveRatingLevelDescriptor).ObjectiveRatingLevelDescriptorId == null
-                || !(this as Entities.Common.TPDM.IObjectiveRatingLevelDescriptor).ObjectiveRatingLevelDescriptorId.Equals(compareTo.ObjectiveRatingLevelDescriptorId))
+            if (!(this as Entities.Common.TPDM.IObjectiveRatingLevelDescriptor).ObjectiveRatingLevelDescriptorId.Equals(compareTo.ObjectiveRatingLevelDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -19142,17 +18907,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.ObjectiveRatingLevelDescriptor.TP
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.TPDM.IObjectiveRatingLevelDescriptor).ObjectiveRatingLevelDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IObjectiveRatingLevelDescriptor).ObjectiveRatingLevelDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IObjectiveRatingLevelDescriptor).ObjectiveRatingLevelDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -19635,7 +19398,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluation.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IPerformanceEvaluation;
 
             if (ReferenceEquals(this, compareTo))
@@ -19646,35 +19408,34 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluation.TPDM
 
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluation).EducationOrganizationId == null
-                || !(this as Entities.Common.TPDM.IPerformanceEvaluation).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
+            if (!(this as Entities.Common.TPDM.IPerformanceEvaluation).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
                 return false;
 
-            // Standard Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluation).EvaluationPeriodDescriptor == null
-                || !(this as Entities.Common.TPDM.IPerformanceEvaluation).EvaluationPeriodDescriptor.Equals(compareTo.EvaluationPeriodDescriptor))
-                return false;
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluation).PerformanceEvaluationTitle == null
-                || !(this as Entities.Common.TPDM.IPerformanceEvaluation).PerformanceEvaluationTitle.Equals(compareTo.PerformanceEvaluationTitle))
+             if ((this as Entities.Common.TPDM.IPerformanceEvaluation).EvaluationPeriodDescriptor.Equals(compareTo.EvaluationPeriodDescriptor))
                 return false;
 
+
             // Standard Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluation).PerformanceEvaluationTypeDescriptor == null
-                || !(this as Entities.Common.TPDM.IPerformanceEvaluation).PerformanceEvaluationTypeDescriptor.Equals(compareTo.PerformanceEvaluationTypeDescriptor))
+             if ((this as Entities.Common.TPDM.IPerformanceEvaluation).PerformanceEvaluationTitle.Equals(compareTo.PerformanceEvaluationTitle))
                 return false;
+
+
+            // Standard Property
+             if ((this as Entities.Common.TPDM.IPerformanceEvaluation).PerformanceEvaluationTypeDescriptor.Equals(compareTo.PerformanceEvaluationTypeDescriptor))
+                return false;
+
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluation).SchoolYear == null
-                || !(this as Entities.Common.TPDM.IPerformanceEvaluation).SchoolYear.Equals(compareTo.SchoolYear))
+            if (!(this as Entities.Common.TPDM.IPerformanceEvaluation).SchoolYear.Equals(compareTo.SchoolYear))
                 return false;
 
+
             // Standard Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluation).TermDescriptor == null
-                || !(this as Entities.Common.TPDM.IPerformanceEvaluation).TermDescriptor.Equals(compareTo.TermDescriptor))
+             if ((this as Entities.Common.TPDM.IPerformanceEvaluation).TermDescriptor.Equals(compareTo.TermDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -19687,37 +19448,33 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluation.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluation).EducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluation).EducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluation).EducationOrganizationId.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluation).EvaluationPeriodDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluation).EvaluationPeriodDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluation).EvaluationPeriodDescriptor.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluation).PerformanceEvaluationTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluation).PerformanceEvaluationTitle.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluation).PerformanceEvaluationTitle.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluation).PerformanceEvaluationTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluation).PerformanceEvaluationTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluation).PerformanceEvaluationTypeDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluation).SchoolYear != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluation).SchoolYear.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluation).SchoolYear.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluation).TermDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluation).TermDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluation).TermDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -20057,7 +19814,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluation.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IPerformanceEvaluationGradeLevel;
 
             if (ReferenceEquals(this, compareTo))
@@ -20072,10 +19828,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluation.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluationGradeLevel).GradeLevelDescriptor == null
-                || !(this as Entities.Common.TPDM.IPerformanceEvaluationGradeLevel).GradeLevelDescriptor.Equals(compareTo.GradeLevelDescriptor))
+             if ((this as Entities.Common.TPDM.IPerformanceEvaluationGradeLevel).GradeLevelDescriptor.Equals(compareTo.GradeLevelDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -20088,7 +19843,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluation.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -20097,11 +19851,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluation.TPDM
                     hash = hash * 23 + _performanceEvaluation.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluationGradeLevel).GradeLevelDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationGradeLevel).GradeLevelDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationGradeLevel).GradeLevelDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -20292,7 +20045,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluation.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IPerformanceEvaluationRatingLevel;
 
             if (ReferenceEquals(this, compareTo))
@@ -20307,10 +20059,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluation.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluationRatingLevel).EvaluationRatingLevelDescriptor == null
-                || !(this as Entities.Common.TPDM.IPerformanceEvaluationRatingLevel).EvaluationRatingLevelDescriptor.Equals(compareTo.EvaluationRatingLevelDescriptor))
+             if ((this as Entities.Common.TPDM.IPerformanceEvaluationRatingLevel).EvaluationRatingLevelDescriptor.Equals(compareTo.EvaluationRatingLevelDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -20323,7 +20074,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluation.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -20332,11 +20082,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluation.TPDM
                     hash = hash * 23 + _performanceEvaluation.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluationRatingLevel).EvaluationRatingLevelDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRatingLevel).EvaluationRatingLevelDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRatingLevel).EvaluationRatingLevelDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -20887,7 +20636,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationRating.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IPerformanceEvaluationRating;
 
             if (ReferenceEquals(this, compareTo))
@@ -20898,45 +20646,44 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationRating.TPDM
 
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluationRating).EducationOrganizationId == null
-                || !(this as Entities.Common.TPDM.IPerformanceEvaluationRating).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
+            if (!(this as Entities.Common.TPDM.IPerformanceEvaluationRating).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
                 return false;
 
+
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluationRating).EvaluationPeriodDescriptor == null
-                ||!(this as Entities.Common.TPDM.IPerformanceEvaluationRating).EvaluationPeriodDescriptor.Equals(compareTo.EvaluationPeriodDescriptor))
+            if (!(this as Entities.Common.TPDM.IPerformanceEvaluationRating).EvaluationPeriodDescriptor.Equals(compareTo.EvaluationPeriodDescriptor))
                 return false;
+
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluationRating).PerformanceEvaluationTitle == null
-                || !(this as Entities.Common.TPDM.IPerformanceEvaluationRating).PerformanceEvaluationTitle.Equals(compareTo.PerformanceEvaluationTitle))
+            if (!(this as Entities.Common.TPDM.IPerformanceEvaluationRating).PerformanceEvaluationTitle.Equals(compareTo.PerformanceEvaluationTitle))
                 return false;
 
+
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluationRating).PerformanceEvaluationTypeDescriptor == null
-                ||!(this as Entities.Common.TPDM.IPerformanceEvaluationRating).PerformanceEvaluationTypeDescriptor.Equals(compareTo.PerformanceEvaluationTypeDescriptor))
+            if (!(this as Entities.Common.TPDM.IPerformanceEvaluationRating).PerformanceEvaluationTypeDescriptor.Equals(compareTo.PerformanceEvaluationTypeDescriptor))
                 return false;
+
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluationRating).PersonId == null
-                || !(this as Entities.Common.TPDM.IPerformanceEvaluationRating).PersonId.Equals(compareTo.PersonId))
+            if (!(this as Entities.Common.TPDM.IPerformanceEvaluationRating).PersonId.Equals(compareTo.PersonId))
                 return false;
+
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluationRating).SchoolYear == null
-                || !(this as Entities.Common.TPDM.IPerformanceEvaluationRating).SchoolYear.Equals(compareTo.SchoolYear))
+            if (!(this as Entities.Common.TPDM.IPerformanceEvaluationRating).SchoolYear.Equals(compareTo.SchoolYear))
                 return false;
 
-            // Unified Type Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluationRating).SourceSystemDescriptor == null
-                ||!(this as Entities.Common.TPDM.IPerformanceEvaluationRating).SourceSystemDescriptor.Equals(compareTo.SourceSystemDescriptor))
-                return false;
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluationRating).TermDescriptor == null
-                ||!(this as Entities.Common.TPDM.IPerformanceEvaluationRating).TermDescriptor.Equals(compareTo.TermDescriptor))
+            if (!(this as Entities.Common.TPDM.IPerformanceEvaluationRating).SourceSystemDescriptor.Equals(compareTo.SourceSystemDescriptor))
                 return false;
-            #pragma warning disable 472
+
+
+            // Unified Type Property
+            if (!(this as Entities.Common.TPDM.IPerformanceEvaluationRating).TermDescriptor.Equals(compareTo.TermDescriptor))
+                return false;
+
 
             return true;
         }
@@ -20949,45 +20696,39 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationRating.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluationRating).EducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRating).EducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRating).EducationOrganizationId.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluationRating).EvaluationPeriodDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRating).EvaluationPeriodDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRating).EvaluationPeriodDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluationRating).PerformanceEvaluationTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRating).PerformanceEvaluationTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRating).PerformanceEvaluationTitle.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluationRating).PerformanceEvaluationTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRating).PerformanceEvaluationTypeDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRating).PerformanceEvaluationTypeDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluationRating).PersonId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRating).PersonId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRating).PersonId.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluationRating).SchoolYear != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRating).SchoolYear.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRating).SchoolYear.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluationRating).SourceSystemDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRating).SourceSystemDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRating).SourceSystemDescriptor.GetHashCode();
+
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluationRating).TermDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRating).TermDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRating).TermDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -21389,7 +21130,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationRating.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IPerformanceEvaluationRatingResult;
 
             if (ReferenceEquals(this, compareTo))
@@ -21404,15 +21144,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationRating.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluationRatingResult).Rating == null
-                || !(this as Entities.Common.TPDM.IPerformanceEvaluationRatingResult).Rating.Equals(compareTo.Rating))
+             if ((this as Entities.Common.TPDM.IPerformanceEvaluationRatingResult).Rating.Equals(compareTo.Rating))
                 return false;
 
+
             // Standard Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluationRatingResult).RatingResultTitle == null
-                || !(this as Entities.Common.TPDM.IPerformanceEvaluationRatingResult).RatingResultTitle.Equals(compareTo.RatingResultTitle))
+             if ((this as Entities.Common.TPDM.IPerformanceEvaluationRatingResult).RatingResultTitle.Equals(compareTo.RatingResultTitle))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -21425,7 +21164,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationRating.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -21434,15 +21172,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationRating.TPDM
                     hash = hash * 23 + _performanceEvaluationRating.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluationRatingResult).Rating != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRatingResult).Rating.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRatingResult).Rating.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluationRatingResult).RatingResultTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRatingResult).RatingResultTitle.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRatingResult).RatingResultTitle.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -21681,7 +21418,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationRating.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IPerformanceEvaluationRatingReviewer;
 
             if (ReferenceEquals(this, compareTo))
@@ -21696,15 +21432,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationRating.TPDM
 
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluationRatingReviewer).FirstName == null
-                || !(this as Entities.Common.TPDM.IPerformanceEvaluationRatingReviewer).FirstName.Equals(compareTo.FirstName))
+             if ((this as Entities.Common.TPDM.IPerformanceEvaluationRatingReviewer).FirstName.Equals(compareTo.FirstName))
                 return false;
 
+
             // Standard Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluationRatingReviewer).LastSurname == null
-                || !(this as Entities.Common.TPDM.IPerformanceEvaluationRatingReviewer).LastSurname.Equals(compareTo.LastSurname))
+             if ((this as Entities.Common.TPDM.IPerformanceEvaluationRatingReviewer).LastSurname.Equals(compareTo.LastSurname))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -21717,7 +21452,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationRating.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -21726,15 +21460,14 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationRating.TPDM
                     hash = hash * 23 + _performanceEvaluationRating.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluationRatingReviewer).FirstName != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRatingReviewer).FirstName.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRatingReviewer).FirstName.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluationRatingReviewer).LastSurname != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRatingReviewer).LastSurname.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRatingReviewer).LastSurname.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -21997,7 +21730,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationRating.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IPerformanceEvaluationRatingReviewerReceivedTraining;
 
             if (ReferenceEquals(this, compareTo))
@@ -22010,7 +21742,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationRating.TPDM
             if (_performanceEvaluationRatingReviewer == null || !_performanceEvaluationRatingReviewer.Equals(compareTo.PerformanceEvaluationRatingReviewer))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -22023,7 +21754,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationRating.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -22032,7 +21762,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationRating.TPDM
                     hash = hash * 23 + _performanceEvaluationRatingReviewer.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -22239,7 +21968,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationRatingLevelD
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IPerformanceEvaluationRatingLevelDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -22250,10 +21978,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationRatingLevelD
 
 
             // Derived Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluationRatingLevelDescriptor).PerformanceEvaluationRatingLevelDescriptorId == null
-                || !(this as Entities.Common.TPDM.IPerformanceEvaluationRatingLevelDescriptor).PerformanceEvaluationRatingLevelDescriptorId.Equals(compareTo.PerformanceEvaluationRatingLevelDescriptorId))
+            if (!(this as Entities.Common.TPDM.IPerformanceEvaluationRatingLevelDescriptor).PerformanceEvaluationRatingLevelDescriptorId.Equals(compareTo.PerformanceEvaluationRatingLevelDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -22266,17 +21993,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationRatingLevelD
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluationRatingLevelDescriptor).PerformanceEvaluationRatingLevelDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRatingLevelDescriptor).PerformanceEvaluationRatingLevelDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationRatingLevelDescriptor).PerformanceEvaluationRatingLevelDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -22527,7 +22252,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationTypeDescript
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IPerformanceEvaluationTypeDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -22538,10 +22262,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationTypeDescript
 
 
             // Derived Property
-            if ((this as Entities.Common.TPDM.IPerformanceEvaluationTypeDescriptor).PerformanceEvaluationTypeDescriptorId == null
-                || !(this as Entities.Common.TPDM.IPerformanceEvaluationTypeDescriptor).PerformanceEvaluationTypeDescriptorId.Equals(compareTo.PerformanceEvaluationTypeDescriptorId))
+            if (!(this as Entities.Common.TPDM.IPerformanceEvaluationTypeDescriptor).PerformanceEvaluationTypeDescriptorId.Equals(compareTo.PerformanceEvaluationTypeDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -22554,17 +22277,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.PerformanceEvaluationTypeDescript
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.TPDM.IPerformanceEvaluationTypeDescriptor).PerformanceEvaluationTypeDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationTypeDescriptor).PerformanceEvaluationTypeDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IPerformanceEvaluationTypeDescriptor).PerformanceEvaluationTypeDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -23164,7 +22885,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.RubricDimension.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IRubricDimension;
 
             if (ReferenceEquals(this, compareTo))
@@ -23175,55 +22895,54 @@ namespace EdFi.Ods.Api.Common.Models.Resources.RubricDimension.TPDM
 
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IRubricDimension).EducationOrganizationId == null
-                || !(this as Entities.Common.TPDM.IRubricDimension).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
+            if (!(this as Entities.Common.TPDM.IRubricDimension).EducationOrganizationId.Equals(compareTo.EducationOrganizationId))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.TPDM.IRubricDimension).EvaluationElementTitle == null
-                || !(this as Entities.Common.TPDM.IRubricDimension).EvaluationElementTitle.Equals(compareTo.EvaluationElementTitle))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IRubricDimension).EvaluationObjectiveTitle == null
-                || !(this as Entities.Common.TPDM.IRubricDimension).EvaluationObjectiveTitle.Equals(compareTo.EvaluationObjectiveTitle))
+            if (!(this as Entities.Common.TPDM.IRubricDimension).EvaluationElementTitle.Equals(compareTo.EvaluationElementTitle))
                 return false;
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.TPDM.IRubricDimension).EvaluationObjectiveTitle.Equals(compareTo.EvaluationObjectiveTitle))
+                return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IRubricDimension).EvaluationPeriodDescriptor == null
-                ||!(this as Entities.Common.TPDM.IRubricDimension).EvaluationPeriodDescriptor.Equals(compareTo.EvaluationPeriodDescriptor))
+            if (!(this as Entities.Common.TPDM.IRubricDimension).EvaluationPeriodDescriptor.Equals(compareTo.EvaluationPeriodDescriptor))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.TPDM.IRubricDimension).EvaluationTitle == null
-                || !(this as Entities.Common.TPDM.IRubricDimension).EvaluationTitle.Equals(compareTo.EvaluationTitle))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IRubricDimension).PerformanceEvaluationTitle == null
-                || !(this as Entities.Common.TPDM.IRubricDimension).PerformanceEvaluationTitle.Equals(compareTo.PerformanceEvaluationTitle))
+            if (!(this as Entities.Common.TPDM.IRubricDimension).EvaluationTitle.Equals(compareTo.EvaluationTitle))
                 return false;
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.TPDM.IRubricDimension).PerformanceEvaluationTitle.Equals(compareTo.PerformanceEvaluationTitle))
+                return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IRubricDimension).PerformanceEvaluationTypeDescriptor == null
-                ||!(this as Entities.Common.TPDM.IRubricDimension).PerformanceEvaluationTypeDescriptor.Equals(compareTo.PerformanceEvaluationTypeDescriptor))
+            if (!(this as Entities.Common.TPDM.IRubricDimension).PerformanceEvaluationTypeDescriptor.Equals(compareTo.PerformanceEvaluationTypeDescriptor))
                 return false;
+
 
             // Standard Property
-            if ((this as Entities.Common.TPDM.IRubricDimension).RubricRating == null
-                || !(this as Entities.Common.TPDM.IRubricDimension).RubricRating.Equals(compareTo.RubricRating))
+             if ((this as Entities.Common.TPDM.IRubricDimension).RubricRating.Equals(compareTo.RubricRating))
                 return false;
+
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.IRubricDimension).SchoolYear == null
-                || !(this as Entities.Common.TPDM.IRubricDimension).SchoolYear.Equals(compareTo.SchoolYear))
+            if (!(this as Entities.Common.TPDM.IRubricDimension).SchoolYear.Equals(compareTo.SchoolYear))
                 return false;
 
+
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.IRubricDimension).TermDescriptor == null
-                ||!(this as Entities.Common.TPDM.IRubricDimension).TermDescriptor.Equals(compareTo.TermDescriptor))
+            if (!(this as Entities.Common.TPDM.IRubricDimension).TermDescriptor.Equals(compareTo.TermDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -23236,53 +22955,45 @@ namespace EdFi.Ods.Api.Common.Models.Resources.RubricDimension.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IRubricDimension).EducationOrganizationId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).EducationOrganizationId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).EducationOrganizationId.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IRubricDimension).EvaluationElementTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).EvaluationElementTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).EvaluationElementTitle.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IRubricDimension).EvaluationObjectiveTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).EvaluationObjectiveTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).EvaluationObjectiveTitle.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IRubricDimension).EvaluationPeriodDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).EvaluationPeriodDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).EvaluationPeriodDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IRubricDimension).EvaluationTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).EvaluationTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).EvaluationTitle.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IRubricDimension).PerformanceEvaluationTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).PerformanceEvaluationTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).PerformanceEvaluationTitle.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IRubricDimension).PerformanceEvaluationTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).PerformanceEvaluationTypeDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).PerformanceEvaluationTypeDescriptor.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.TPDM.IRubricDimension).RubricRating != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).RubricRating.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).RubricRating.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.IRubricDimension).SchoolYear != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).SchoolYear.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).SchoolYear.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.IRubricDimension).TermDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).TermDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IRubricDimension).TermDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -23515,7 +23226,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.RubricRatingLevelDescriptor.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.IRubricRatingLevelDescriptor;
 
             if (ReferenceEquals(this, compareTo))
@@ -23526,10 +23236,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.RubricRatingLevelDescriptor.TPDM
 
 
             // Derived Property
-            if ((this as Entities.Common.TPDM.IRubricRatingLevelDescriptor).RubricRatingLevelDescriptorId == null
-                || !(this as Entities.Common.TPDM.IRubricRatingLevelDescriptor).RubricRatingLevelDescriptorId.Equals(compareTo.RubricRatingLevelDescriptorId))
+            if (!(this as Entities.Common.TPDM.IRubricRatingLevelDescriptor).RubricRatingLevelDescriptorId.Equals(compareTo.RubricRatingLevelDescriptorId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -23542,17 +23251,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.RubricRatingLevelDescriptor.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.TPDM.IRubricRatingLevelDescriptor).RubricRatingLevelDescriptorId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.IRubricRatingLevelDescriptor).RubricRatingLevelDescriptorId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.IRubricRatingLevelDescriptor).RubricRatingLevelDescriptorId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -23834,7 +23541,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Extensions.TPDM
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ISchoolExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -23847,7 +23553,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Extensions.TPDM
             if (_school == null || !_school.Equals(compareTo.School))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -23860,7 +23565,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Extensions.TPDM
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -23869,7 +23573,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Extensions.TPDM
                     hash = hash * 23 + _school.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -24126,7 +23829,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SurveyResponse.EdFi.Extensions.TP
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ISurveyResponseExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -24139,7 +23841,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SurveyResponse.EdFi.Extensions.TP
             if (_surveyResponse == null || !_surveyResponse.Equals(compareTo.SurveyResponse))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -24152,7 +23853,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SurveyResponse.EdFi.Extensions.TP
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -24161,7 +23861,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SurveyResponse.EdFi.Extensions.TP
                     hash = hash * 23 + _surveyResponse.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -24685,7 +24384,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SurveyResponsePersonTargetAssocia
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation;
 
             if (ReferenceEquals(this, compareTo))
@@ -24696,30 +24394,29 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SurveyResponsePersonTargetAssocia
 
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).Namespace == null
-                || !(this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).Namespace.Equals(compareTo.Namespace))
+            if (!(this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).Namespace.Equals(compareTo.Namespace))
                 return false;
 
+
             // Referenced Property
-            if ((this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).PersonId == null
-                || !(this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).PersonId.Equals(compareTo.PersonId))
+            if (!(this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).PersonId.Equals(compareTo.PersonId))
                 return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).SourceSystemDescriptor == null
-                ||!(this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).SourceSystemDescriptor.Equals(compareTo.SourceSystemDescriptor))
+            if (!(this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).SourceSystemDescriptor.Equals(compareTo.SourceSystemDescriptor))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).SurveyIdentifier == null
-                || !(this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).SurveyIdentifier.Equals(compareTo.SurveyIdentifier))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).SurveyResponseIdentifier == null
-                || !(this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).SurveyResponseIdentifier.Equals(compareTo.SurveyResponseIdentifier))
+            if (!(this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).SurveyIdentifier.Equals(compareTo.SurveyIdentifier))
                 return false;
-            #pragma warning disable 472
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).SurveyResponseIdentifier.Equals(compareTo.SurveyResponseIdentifier))
+                return false;
+
 
             return true;
         }
@@ -24732,33 +24429,27 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SurveyResponsePersonTargetAssocia
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).Namespace != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).Namespace.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).Namespace.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).PersonId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).PersonId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).PersonId.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).SourceSystemDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).SourceSystemDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).SourceSystemDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).SurveyIdentifier != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).SurveyIdentifier.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).SurveyIdentifier.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).SurveyResponseIdentifier != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).SurveyResponseIdentifier.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ISurveyResponsePersonTargetAssociation).SurveyResponseIdentifier.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -25276,7 +24967,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SurveySectionResponsePersonTarget
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation;
 
             if (ReferenceEquals(this, compareTo))
@@ -25287,35 +24977,34 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SurveySectionResponsePersonTarget
 
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).Namespace == null
-                || !(this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).Namespace.Equals(compareTo.Namespace))
+            if (!(this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).Namespace.Equals(compareTo.Namespace))
                 return false;
 
+
             // Referenced Property
-            if ((this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).PersonId == null
-                || !(this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).PersonId.Equals(compareTo.PersonId))
+            if (!(this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).PersonId.Equals(compareTo.PersonId))
                 return false;
+
 
             // Unified Type Property
-            if ((this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SourceSystemDescriptor == null
-                ||!(this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SourceSystemDescriptor.Equals(compareTo.SourceSystemDescriptor))
+            if (!(this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SourceSystemDescriptor.Equals(compareTo.SourceSystemDescriptor))
                 return false;
 
-            // Referenced Property
-            if ((this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SurveyIdentifier == null
-                || !(this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SurveyIdentifier.Equals(compareTo.SurveyIdentifier))
-                return false;
 
             // Referenced Property
-            if ((this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SurveyResponseIdentifier == null
-                || !(this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SurveyResponseIdentifier.Equals(compareTo.SurveyResponseIdentifier))
+            if (!(this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SurveyIdentifier.Equals(compareTo.SurveyIdentifier))
                 return false;
 
+
             // Referenced Property
-            if ((this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SurveySectionTitle == null
-                || !(this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SurveySectionTitle.Equals(compareTo.SurveySectionTitle))
+            if (!(this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SurveyResponseIdentifier.Equals(compareTo.SurveyResponseIdentifier))
                 return false;
-            #pragma warning disable 472
+
+
+            // Referenced Property
+            if (!(this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SurveySectionTitle.Equals(compareTo.SurveySectionTitle))
+                return false;
+
 
             return true;
         }
@@ -25328,37 +25017,30 @@ namespace EdFi.Ods.Api.Common.Models.Resources.SurveySectionResponsePersonTarget
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).Namespace != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).Namespace.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).Namespace.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).PersonId != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).PersonId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).PersonId.GetHashCode();
 
                 //Unified Type Property
-                if ((this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SourceSystemDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SourceSystemDescriptor.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SourceSystemDescriptor.GetHashCode();
+
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SurveyIdentifier != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SurveyIdentifier.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SurveyIdentifier.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SurveyResponseIdentifier != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SurveyResponseIdentifier.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SurveyResponseIdentifier.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SurveySectionTitle != null)
-                    hash = hash * 23 + (this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SurveySectionTitle.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.TPDM.ISurveySectionResponsePersonTargetAssociation).SurveySectionTitle.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Profiles.Sample_Resources_Resources.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Profiles.Sample_Resources_Resources.generated.approved.cs
@@ -182,7 +182,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationCategory;
 
             if (ReferenceEquals(this, compareTo))
@@ -197,10 +196,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor.Equals(compareTo.EducationOrganizationCategoryDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor.Equals(compareTo.EducationOrganizationCategoryDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -213,7 +211,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -222,11 +219,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -420,7 +416,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationIdentificationCode;
 
             if (ReferenceEquals(this, compareTo))
@@ -435,10 +430,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor.Equals(compareTo.EducationOrganizationIdentificationSystemDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor.Equals(compareTo.EducationOrganizationIdentificationSystemDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -451,7 +445,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -460,11 +453,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -670,7 +662,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationIndicator;
 
             if (ReferenceEquals(this, compareTo))
@@ -685,10 +676,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor.Equals(compareTo.IndicatorDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor.Equals(compareTo.IndicatorDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -701,7 +691,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -710,11 +699,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -998,7 +986,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod;
 
             if (ReferenceEquals(this, compareTo))
@@ -1013,10 +1000,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate.Equals(compareTo.BeginDate))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate.Equals(compareTo.BeginDate))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -1029,7 +1015,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -1038,11 +1023,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganizationIndicator.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -1244,7 +1228,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone;
 
             if (ReferenceEquals(this, compareTo))
@@ -1259,10 +1242,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor.Equals(compareTo.InstitutionTelephoneNumberTypeDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor.Equals(compareTo.InstitutionTelephoneNumberTypeDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -1275,7 +1257,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -1284,11 +1265,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -1490,7 +1470,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationInternationalAddress;
 
             if (ReferenceEquals(this, compareTo))
@@ -1505,10 +1484,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor.Equals(compareTo.AddressTypeDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor.Equals(compareTo.AddressTypeDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -1521,7 +1499,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -1530,11 +1507,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -1899,7 +1875,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.ISchool;
 
             if (ReferenceEquals(this, compareTo))
@@ -1910,10 +1885,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
 
 
             // Derived Property
-            if ((this as Entities.Common.EdFi.ISchool).SchoolId == null
-                || !(this as Entities.Common.EdFi.ISchool).SchoolId.Equals(compareTo.SchoolId))
+            if (!(this as Entities.Common.EdFi.ISchool).SchoolId.Equals(compareTo.SchoolId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -1926,17 +1900,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.EdFi.ISchool).SchoolId != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.ISchool).SchoolId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.EdFi.ISchool).SchoolId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -2541,7 +2513,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.ISchoolGradeLevel;
 
             if (ReferenceEquals(this, compareTo))
@@ -2556,10 +2527,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor == null
-                || !(this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor.Equals(compareTo.GradeLevelDescriptor))
+             if ((this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor.Equals(compareTo.GradeLevelDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -2572,7 +2542,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -2581,11 +2550,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _school.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -2777,7 +2745,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.ISchoolCTEProgram;
 
             if (ReferenceEquals(this, compareTo))
@@ -2790,7 +2757,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
             if (_schoolExtension == null || !_schoolExtension.Equals(compareTo.SchoolExtension))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -2803,7 +2769,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -2812,7 +2777,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _schoolExtension.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -3086,7 +3050,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.ISchoolDirectlyOwnedBus;
 
             if (ReferenceEquals(this, compareTo))
@@ -3101,10 +3064,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
 
 
             // Referenced Property
-            if ((this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId == null
-                || !(this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.Equals(compareTo.DirectlyOwnedBusId))
+            if (!(this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.Equals(compareTo.DirectlyOwnedBusId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -3117,7 +3079,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -3126,11 +3087,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _schoolExtension.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -3332,7 +3291,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.ISchoolExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -3345,7 +3303,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
             if (_school == null || !_school.Equals(compareTo.School))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -3358,7 +3315,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -3367,7 +3323,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _school.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -3668,7 +3623,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ISchoolExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -3681,7 +3635,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
             if (_school == null || !_school.Equals(compareTo.School))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -3694,7 +3647,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -3703,7 +3655,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _school.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -4054,7 +4005,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationAddress;
 
             if (ReferenceEquals(this, compareTo))
@@ -4069,30 +4019,29 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor.Equals(compareTo.AddressTypeDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor.Equals(compareTo.AddressTypeDescriptor))
                 return false;
 
-            // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).City == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).City.Equals(compareTo.City))
-                return false;
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode.Equals(compareTo.PostalCode))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).City.Equals(compareTo.City))
                 return false;
 
-            // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor.Equals(compareTo.StateAbbreviationDescriptor))
-                return false;
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName.Equals(compareTo.StreetNumberName))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode.Equals(compareTo.PostalCode))
                 return false;
-            #pragma warning disable 472
+
+
+            // Standard Property
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor.Equals(compareTo.StateAbbreviationDescriptor))
+                return false;
+
+
+            // Standard Property
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName.Equals(compareTo.StreetNumberName))
+                return false;
+
 
             return true;
         }
@@ -4105,7 +4054,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -4114,27 +4062,26 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).City != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).City.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).City.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -4458,7 +4405,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationAddressPeriod;
 
             if (ReferenceEquals(this, compareTo))
@@ -4473,10 +4419,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate.Equals(compareTo.BeginDate))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate.Equals(compareTo.BeginDate))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -4489,7 +4434,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -4498,11 +4442,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganizationAddress.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -4704,7 +4647,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationCategory;
 
             if (ReferenceEquals(this, compareTo))
@@ -4719,10 +4661,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor.Equals(compareTo.EducationOrganizationCategoryDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor.Equals(compareTo.EducationOrganizationCategoryDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -4735,7 +4676,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -4744,11 +4684,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -4942,7 +4881,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationIdentificationCode;
 
             if (ReferenceEquals(this, compareTo))
@@ -4957,10 +4895,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor.Equals(compareTo.EducationOrganizationIdentificationSystemDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor.Equals(compareTo.EducationOrganizationIdentificationSystemDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -4973,7 +4910,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -4982,11 +4918,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -5192,7 +5127,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationIndicator;
 
             if (ReferenceEquals(this, compareTo))
@@ -5207,10 +5141,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor.Equals(compareTo.IndicatorDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor.Equals(compareTo.IndicatorDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -5223,7 +5156,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -5232,11 +5164,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -5520,7 +5451,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod;
 
             if (ReferenceEquals(this, compareTo))
@@ -5535,10 +5465,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate.Equals(compareTo.BeginDate))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate.Equals(compareTo.BeginDate))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -5551,7 +5480,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -5560,11 +5488,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganizationIndicator.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -5766,7 +5693,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone;
 
             if (ReferenceEquals(this, compareTo))
@@ -5781,10 +5707,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor.Equals(compareTo.InstitutionTelephoneNumberTypeDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor.Equals(compareTo.InstitutionTelephoneNumberTypeDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -5797,7 +5722,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -5806,11 +5730,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -6143,7 +6066,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.ISchool;
 
             if (ReferenceEquals(this, compareTo))
@@ -6154,10 +6076,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
 
 
             // Derived Property
-            if ((this as Entities.Common.EdFi.ISchool).SchoolId == null
-                || !(this as Entities.Common.EdFi.ISchool).SchoolId.Equals(compareTo.SchoolId))
+            if (!(this as Entities.Common.EdFi.ISchool).SchoolId.Equals(compareTo.SchoolId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -6170,17 +6091,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.EdFi.ISchool).SchoolId != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.ISchool).SchoolId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.EdFi.ISchool).SchoolId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -6804,7 +6723,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.ISchoolCategory;
 
             if (ReferenceEquals(this, compareTo))
@@ -6819,10 +6737,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor == null
-                || !(this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor.Equals(compareTo.SchoolCategoryDescriptor))
+             if ((this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor.Equals(compareTo.SchoolCategoryDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -6835,7 +6752,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -6844,11 +6760,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _school.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -7040,7 +6955,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.ISchoolCTEProgram;
 
             if (ReferenceEquals(this, compareTo))
@@ -7053,7 +6967,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
             if (_schoolExtension == null || !_schoolExtension.Equals(compareTo.SchoolExtension))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -7066,7 +6979,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -7075,7 +6987,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _schoolExtension.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -7349,7 +7260,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.ISchoolDirectlyOwnedBus;
 
             if (ReferenceEquals(this, compareTo))
@@ -7364,10 +7274,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
 
 
             // Referenced Property
-            if ((this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId == null
-                || !(this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.Equals(compareTo.DirectlyOwnedBusId))
+            if (!(this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.Equals(compareTo.DirectlyOwnedBusId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -7380,7 +7289,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -7389,11 +7297,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _schoolExtension.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -7595,7 +7501,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.ISchoolExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -7608,7 +7513,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
             if (_school == null || !_school.Equals(compareTo.School))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -7621,7 +7525,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -7630,7 +7533,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _school.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -7931,7 +7833,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ISchoolExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -7944,7 +7845,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
             if (_school == null || !_school.Equals(compareTo.School))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -7957,7 +7857,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -7966,7 +7865,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _school.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -8317,7 +8215,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationAddress;
 
             if (ReferenceEquals(this, compareTo))
@@ -8332,30 +8229,29 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor.Equals(compareTo.AddressTypeDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor.Equals(compareTo.AddressTypeDescriptor))
                 return false;
 
-            // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).City == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).City.Equals(compareTo.City))
-                return false;
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode.Equals(compareTo.PostalCode))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).City.Equals(compareTo.City))
                 return false;
 
-            // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor.Equals(compareTo.StateAbbreviationDescriptor))
-                return false;
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName.Equals(compareTo.StreetNumberName))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode.Equals(compareTo.PostalCode))
                 return false;
-            #pragma warning disable 472
+
+
+            // Standard Property
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor.Equals(compareTo.StateAbbreviationDescriptor))
+                return false;
+
+
+            // Standard Property
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName.Equals(compareTo.StreetNumberName))
+                return false;
+
 
             return true;
         }
@@ -8368,7 +8264,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -8377,27 +8272,26 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).City != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).City.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).City.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -8721,7 +8615,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationAddressPeriod;
 
             if (ReferenceEquals(this, compareTo))
@@ -8736,10 +8629,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate.Equals(compareTo.BeginDate))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate.Equals(compareTo.BeginDate))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -8752,7 +8644,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -8761,11 +8652,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganizationAddress.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -9062,7 +8952,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.ISchool;
 
             if (ReferenceEquals(this, compareTo))
@@ -9073,10 +8962,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
 
 
             // Derived Property
-            if ((this as Entities.Common.EdFi.ISchool).SchoolId == null
-                || !(this as Entities.Common.EdFi.ISchool).SchoolId.Equals(compareTo.SchoolId))
+            if (!(this as Entities.Common.EdFi.ISchool).SchoolId.Equals(compareTo.SchoolId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -9089,17 +8977,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.EdFi.ISchool).SchoolId != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.ISchool).SchoolId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.EdFi.ISchool).SchoolId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -9604,7 +9490,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.ISchoolCategory;
 
             if (ReferenceEquals(this, compareTo))
@@ -9619,10 +9504,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor == null
-                || !(this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor.Equals(compareTo.SchoolCategoryDescriptor))
+             if ((this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor.Equals(compareTo.SchoolCategoryDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -9635,7 +9519,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -9644,11 +9527,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _school.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -9935,7 +9817,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationInternationalAddress;
 
             if (ReferenceEquals(this, compareTo))
@@ -9950,10 +9831,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor.Equals(compareTo.AddressTypeDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor.Equals(compareTo.AddressTypeDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -9966,7 +9846,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -9975,11 +9854,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -10307,7 +10185,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.ISchool;
 
             if (ReferenceEquals(this, compareTo))
@@ -10318,10 +10195,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
 
 
             // Derived Property
-            if ((this as Entities.Common.EdFi.ISchool).SchoolId == null
-                || !(this as Entities.Common.EdFi.ISchool).SchoolId.Equals(compareTo.SchoolId))
+            if (!(this as Entities.Common.EdFi.ISchool).SchoolId.Equals(compareTo.SchoolId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -10334,17 +10210,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.EdFi.ISchool).SchoolId != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.ISchool).SchoolId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.EdFi.ISchool).SchoolId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -10830,7 +10704,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.ISchoolGradeLevel;
 
             if (ReferenceEquals(this, compareTo))
@@ -10845,10 +10718,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor == null
-                || !(this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor.Equals(compareTo.GradeLevelDescriptor))
+             if ((this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor.Equals(compareTo.GradeLevelDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -10861,7 +10733,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -10870,11 +10741,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _school.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -11193,7 +11063,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationAddress;
 
             if (ReferenceEquals(this, compareTo))
@@ -11208,30 +11077,29 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor.Equals(compareTo.AddressTypeDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor.Equals(compareTo.AddressTypeDescriptor))
                 return false;
 
-            // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).City == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).City.Equals(compareTo.City))
-                return false;
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode.Equals(compareTo.PostalCode))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).City.Equals(compareTo.City))
                 return false;
 
-            // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor.Equals(compareTo.StateAbbreviationDescriptor))
-                return false;
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName.Equals(compareTo.StreetNumberName))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode.Equals(compareTo.PostalCode))
                 return false;
-            #pragma warning disable 472
+
+
+            // Standard Property
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor.Equals(compareTo.StateAbbreviationDescriptor))
+                return false;
+
+
+            // Standard Property
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName.Equals(compareTo.StreetNumberName))
+                return false;
+
 
             return true;
         }
@@ -11244,7 +11112,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -11253,27 +11120,26 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).City != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).City.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).City.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -11597,7 +11463,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationAddressPeriod;
 
             if (ReferenceEquals(this, compareTo))
@@ -11612,10 +11477,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate.Equals(compareTo.BeginDate))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate.Equals(compareTo.BeginDate))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -11628,7 +11492,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -11637,11 +11500,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganizationAddress.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -11843,7 +11705,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationCategory;
 
             if (ReferenceEquals(this, compareTo))
@@ -11858,10 +11719,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor.Equals(compareTo.EducationOrganizationCategoryDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor.Equals(compareTo.EducationOrganizationCategoryDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -11874,7 +11734,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -11883,11 +11742,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -12081,7 +11939,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationIdentificationCode;
 
             if (ReferenceEquals(this, compareTo))
@@ -12096,10 +11953,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor.Equals(compareTo.EducationOrganizationIdentificationSystemDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor.Equals(compareTo.EducationOrganizationIdentificationSystemDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -12112,7 +11968,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -12121,11 +11976,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -12331,7 +12185,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationIndicator;
 
             if (ReferenceEquals(this, compareTo))
@@ -12346,10 +12199,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor.Equals(compareTo.IndicatorDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor.Equals(compareTo.IndicatorDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -12362,7 +12214,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -12371,11 +12222,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -12659,7 +12509,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod;
 
             if (ReferenceEquals(this, compareTo))
@@ -12674,10 +12523,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate.Equals(compareTo.BeginDate))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate.Equals(compareTo.BeginDate))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -12690,7 +12538,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -12699,11 +12546,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganizationIndicator.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -12905,7 +12751,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone;
 
             if (ReferenceEquals(this, compareTo))
@@ -12920,10 +12765,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor.Equals(compareTo.InstitutionTelephoneNumberTypeDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor.Equals(compareTo.InstitutionTelephoneNumberTypeDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -12936,7 +12780,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -12945,11 +12788,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -13151,7 +12993,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationInternationalAddress;
 
             if (ReferenceEquals(this, compareTo))
@@ -13166,10 +13007,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor.Equals(compareTo.AddressTypeDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor.Equals(compareTo.AddressTypeDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -13182,7 +13022,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -13191,11 +13030,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -13594,7 +13432,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.ISchool;
 
             if (ReferenceEquals(this, compareTo))
@@ -13605,10 +13442,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
 
 
             // Derived Property
-            if ((this as Entities.Common.EdFi.ISchool).SchoolId == null
-                || !(this as Entities.Common.EdFi.ISchool).SchoolId.Equals(compareTo.SchoolId))
+            if (!(this as Entities.Common.EdFi.ISchool).SchoolId.Equals(compareTo.SchoolId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -13621,17 +13457,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.EdFi.ISchool).SchoolId != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.ISchool).SchoolId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.EdFi.ISchool).SchoolId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -14317,7 +14151,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.ISchoolCategory;
 
             if (ReferenceEquals(this, compareTo))
@@ -14332,10 +14165,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor == null
-                || !(this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor.Equals(compareTo.SchoolCategoryDescriptor))
+             if ((this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor.Equals(compareTo.SchoolCategoryDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -14348,7 +14180,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -14357,11 +14188,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _school.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -14555,7 +14385,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.ISchoolGradeLevel;
 
             if (ReferenceEquals(this, compareTo))
@@ -14570,10 +14399,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor == null
-                || !(this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor.Equals(compareTo.GradeLevelDescriptor))
+             if ((this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor.Equals(compareTo.GradeLevelDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -14586,7 +14414,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -14595,11 +14422,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _school.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -14791,7 +14617,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.ISchoolCTEProgram;
 
             if (ReferenceEquals(this, compareTo))
@@ -14804,7 +14629,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
             if (_schoolExtension == null || !_schoolExtension.Equals(compareTo.SchoolExtension))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -14817,7 +14641,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -14826,7 +14649,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _schoolExtension.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -15100,7 +14922,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.ISchoolDirectlyOwnedBus;
 
             if (ReferenceEquals(this, compareTo))
@@ -15115,10 +14936,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
 
 
             // Referenced Property
-            if ((this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId == null
-                || !(this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.Equals(compareTo.DirectlyOwnedBusId))
+            if (!(this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.Equals(compareTo.DirectlyOwnedBusId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -15131,7 +14951,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -15140,11 +14959,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _schoolExtension.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -15346,7 +15163,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.ISchoolExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -15359,7 +15175,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
             if (_school == null || !_school.Equals(compareTo.School))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -15372,7 +15187,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -15381,7 +15195,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _school.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -15682,7 +15495,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ISchoolExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -15695,7 +15507,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
             if (_school == null || !_school.Equals(compareTo.School))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -15708,7 +15519,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -15717,7 +15527,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _school.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -16068,7 +15877,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationAddress;
 
             if (ReferenceEquals(this, compareTo))
@@ -16083,30 +15891,29 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor.Equals(compareTo.AddressTypeDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor.Equals(compareTo.AddressTypeDescriptor))
                 return false;
 
-            // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).City == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).City.Equals(compareTo.City))
-                return false;
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode.Equals(compareTo.PostalCode))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).City.Equals(compareTo.City))
                 return false;
 
-            // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor.Equals(compareTo.StateAbbreviationDescriptor))
-                return false;
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName.Equals(compareTo.StreetNumberName))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode.Equals(compareTo.PostalCode))
                 return false;
-            #pragma warning disable 472
+
+
+            // Standard Property
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor.Equals(compareTo.StateAbbreviationDescriptor))
+                return false;
+
+
+            // Standard Property
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName.Equals(compareTo.StreetNumberName))
+                return false;
+
 
             return true;
         }
@@ -16119,7 +15926,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -16128,27 +15934,26 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).AddressTypeDescriptor.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).City != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).City.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).City.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).PostalCode.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).StateAbbreviationDescriptor.GetHashCode();
+
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddress).StreetNumberName.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -16472,7 +16277,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationAddressPeriod;
 
             if (ReferenceEquals(this, compareTo))
@@ -16487,10 +16291,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate.Equals(compareTo.BeginDate))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate.Equals(compareTo.BeginDate))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -16503,7 +16306,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -16512,11 +16314,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganizationAddress.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationAddressPeriod).BeginDate.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -16718,7 +16519,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationCategory;
 
             if (ReferenceEquals(this, compareTo))
@@ -16733,10 +16533,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor.Equals(compareTo.EducationOrganizationCategoryDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor.Equals(compareTo.EducationOrganizationCategoryDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -16749,7 +16548,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -16758,11 +16556,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationCategory).EducationOrganizationCategoryDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -16956,7 +16753,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationIdentificationCode;
 
             if (ReferenceEquals(this, compareTo))
@@ -16971,10 +16767,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor.Equals(compareTo.EducationOrganizationIdentificationSystemDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor.Equals(compareTo.EducationOrganizationIdentificationSystemDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -16987,7 +16782,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -16996,11 +16790,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIdentificationCode).EducationOrganizationIdentificationSystemDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -17206,7 +16999,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationIndicator;
 
             if (ReferenceEquals(this, compareTo))
@@ -17221,10 +17013,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor.Equals(compareTo.IndicatorDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor.Equals(compareTo.IndicatorDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -17237,7 +17028,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -17246,11 +17036,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIndicator).IndicatorDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -17534,7 +17323,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod;
 
             if (ReferenceEquals(this, compareTo))
@@ -17549,10 +17337,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate.Equals(compareTo.BeginDate))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate.Equals(compareTo.BeginDate))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -17565,7 +17352,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -17574,11 +17360,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganizationIndicator.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationIndicatorPeriod).BeginDate.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -17780,7 +17565,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone;
 
             if (ReferenceEquals(this, compareTo))
@@ -17795,10 +17579,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor.Equals(compareTo.InstitutionTelephoneNumberTypeDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor.Equals(compareTo.InstitutionTelephoneNumberTypeDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -17811,7 +17594,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -17820,11 +17602,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationInstitutionTelephone).InstitutionTelephoneNumberTypeDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -18026,7 +17807,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.IEducationOrganizationInternationalAddress;
 
             if (ReferenceEquals(this, compareTo))
@@ -18041,10 +17821,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor == null
-                || !(this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor.Equals(compareTo.AddressTypeDescriptor))
+             if ((this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor.Equals(compareTo.AddressTypeDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -18057,7 +17836,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -18066,11 +17844,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.EducationOrganization.EdFi.Test_P
                     hash = hash * 23 + _educationOrganization.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.IEducationOrganizationInternationalAddress).AddressTypeDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -18469,7 +18246,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.ISchool;
 
             if (ReferenceEquals(this, compareTo))
@@ -18480,10 +18256,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
 
 
             // Derived Property
-            if ((this as Entities.Common.EdFi.ISchool).SchoolId == null
-                || !(this as Entities.Common.EdFi.ISchool).SchoolId.Equals(compareTo.SchoolId))
+            if (!(this as Entities.Common.EdFi.ISchool).SchoolId.Equals(compareTo.SchoolId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -18496,17 +18271,15 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
 
                 //Derived Property
-                if ((this as Entities.Common.EdFi.ISchool).SchoolId != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.ISchool).SchoolId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.EdFi.ISchool).SchoolId.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -19192,7 +18965,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.ISchoolCategory;
 
             if (ReferenceEquals(this, compareTo))
@@ -19207,10 +18979,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor == null
-                || !(this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor.Equals(compareTo.SchoolCategoryDescriptor))
+             if ((this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor.Equals(compareTo.SchoolCategoryDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -19223,7 +18994,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -19232,11 +19002,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _school.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.ISchoolCategory).SchoolCategoryDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -19430,7 +19199,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.EdFi.ISchoolGradeLevel;
 
             if (ReferenceEquals(this, compareTo))
@@ -19445,10 +19213,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
 
 
             // Standard Property
-            if ((this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor == null
-                || !(this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor.Equals(compareTo.GradeLevelDescriptor))
+             if ((this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor.Equals(compareTo.GradeLevelDescriptor))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -19461,7 +19228,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -19470,11 +19236,10 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _school.GetHashCode();
 
                 // Standard Property
-                if ((this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor != null)
-                    hash = hash * 23 + (this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor.GetHashCode();
+                 hash = hash * 23 + (this as Entities.Common.EdFi.ISchoolGradeLevel).GradeLevelDescriptor.GetHashCode();
+
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -19666,7 +19431,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.ISchoolCTEProgram;
 
             if (ReferenceEquals(this, compareTo))
@@ -19679,7 +19443,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
             if (_schoolExtension == null || !_schoolExtension.Equals(compareTo.SchoolExtension))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -19692,7 +19455,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -19701,7 +19463,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _schoolExtension.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -19975,7 +19736,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.ISchoolDirectlyOwnedBus;
 
             if (ReferenceEquals(this, compareTo))
@@ -19990,10 +19750,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
 
 
             // Referenced Property
-            if ((this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId == null
-                || !(this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.Equals(compareTo.DirectlyOwnedBusId))
+            if (!(this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.Equals(compareTo.DirectlyOwnedBusId))
                 return false;
-            #pragma warning disable 472
+
 
             return true;
         }
@@ -20006,7 +19765,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -20015,11 +19773,9 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _schoolExtension.GetHashCode();
 
                 //Referenced Property
-                if ((this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId != null)
-                    hash = hash * 23 + (this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.GetHashCode();
+                hash = hash * 23 + (this as Entities.Common.Sample.ISchoolDirectlyOwnedBus).DirectlyOwnedBusId.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -20221,7 +19977,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.Sample.ISchoolExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -20234,7 +19989,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
             if (_school == null || !_school.Equals(compareTo.School))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -20247,7 +20001,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -20256,7 +20009,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _school.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 
@@ -20557,7 +20309,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override bool Equals(object obj)
         {
-            #pragma warning disable 472
             var compareTo = obj as Entities.Common.TPDM.ISchoolExtension;
 
             if (ReferenceEquals(this, compareTo))
@@ -20570,7 +20321,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
             if (_school == null || !_school.Equals(compareTo.School))
                 return false;
 
-            #pragma warning disable 472
 
             return true;
         }
@@ -20583,7 +20333,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
         /// </returns>
         public override int GetHashCode()
         {
-            #pragma warning disable 472
             unchecked
             {
                 int hash = 17;
@@ -20592,7 +20341,6 @@ namespace EdFi.Ods.Api.Common.Models.Resources.School.EdFi.Test_Profile_Resource
                     hash = hash * 23 + _school.GetHashCode();
                 return hash;
             }
-            #pragma warning restore 472
         }
         // -------------------------------------------------------------
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Profiles.Test_Controllers_Controllers.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Profiles.Test_Controllers_Controllers.generated.approved.cs
@@ -2120,61 +2120,6 @@ namespace EdFi.Ods.Api.Services.Controllers.Students.EdFi.Test_Profile_Student_a
     }
 }
 
-namespace EdFi.Ods.Api.Services.Controllers.Students.EdFi.Test_Profile_StudentOnly2_Resource_IncludeAll
-{
-    [ApiExplorerSettings(IgnoreApi = true)]
-    [ExcludeFromCodeCoverage]
-    [ApiController]
-    [Authorize]
-    [ProfileContentType("application/vnd.ed-fi.student.test-profile-studentonly2-resource-includeall")]
-    [Route("ed-fi/students")]
-    public partial class StudentsController : DataManagementControllerBase<
-        Api.Common.Models.Resources.Student.EdFi.Test_Profile_StudentOnly2_Resource_IncludeAll_Readable.Student,
-        Api.Common.Models.Resources.Student.EdFi.Test_Profile_StudentOnly2_Resource_IncludeAll_Writable.Student,
-        Entities.Common.EdFi.IStudent,
-        Entities.NHibernate.StudentAggregate.EdFi.Student,
-        Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly2_Resource_IncludeAll.StudentPut,
-        Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly2_Resource_IncludeAll.StudentPost,
-        Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly2_Resource_IncludeAll.StudentDelete,
-        Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly2_Resource_IncludeAll.StudentGetByExample>
-    {
-        public StudentsController(IPipelineFactory pipelineFactory, ISchoolYearContextProvider schoolYearContextProvider, IRESTErrorProvider restErrorProvider, IDefaultPageSizeLimitProvider defaultPageSizeLimitProvider, ApiSettings apiSettings)
-            : base(pipelineFactory, schoolYearContextProvider, restErrorProvider, defaultPageSizeLimitProvider, apiSettings)
-        {
-        }
-
-        protected override void MapAll(Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly2_Resource_IncludeAll.StudentGetByExample request, Entities.Common.EdFi.IStudent specification)
-        {
-            // Copy all existing values
-            specification.SuspendReferenceAssignmentCheck();
-            specification.BirthCity = request.BirthCity;
-            specification.BirthCountryDescriptor = request.BirthCountryDescriptor;
-            specification.BirthDate = request.BirthDate;
-            specification.BirthInternationalProvince = request.BirthInternationalProvince;
-            specification.BirthSexDescriptor = request.BirthSexDescriptor;
-            specification.BirthStateAbbreviationDescriptor = request.BirthStateAbbreviationDescriptor;
-            specification.CitizenshipStatusDescriptor = request.CitizenshipStatusDescriptor;
-            specification.DateEnteredUS = request.DateEnteredUS;
-            specification.FirstName = request.FirstName;
-            specification.GenerationCodeSuffix = request.GenerationCodeSuffix;
-            specification.Id = request.Id;
-            specification.LastSurname = request.LastSurname;
-            specification.MaidenName = request.MaidenName;
-            specification.MiddleName = request.MiddleName;
-            specification.MultipleBirthStatus = request.MultipleBirthStatus;
-            specification.PersonalTitlePrefix = request.PersonalTitlePrefix;
-            specification.PersonId = request.PersonId;
-            specification.SourceSystemDescriptor = request.SourceSystemDescriptor;
-            specification.StudentUniqueId = request.StudentUniqueId;
-        }
-
-        protected override string GetReadContentType()
-        {
-            return "application/vnd.ed-fi.student.test-profile-studentonly2-resource-includeall.readable+json";
-        }
-    }
-}
-
 namespace EdFi.Ods.Api.Services.Controllers.Students.EdFi.Test_Profile_StudentOnly_Resource_IncludeAll
 {
     [ApiExplorerSettings(IgnoreApi = true)]
@@ -2226,6 +2171,61 @@ namespace EdFi.Ods.Api.Services.Controllers.Students.EdFi.Test_Profile_StudentOn
         protected override string GetReadContentType()
         {
             return "application/vnd.ed-fi.student.test-profile-studentonly-resource-includeall.readable+json";
+        }
+    }
+}
+
+namespace EdFi.Ods.Api.Services.Controllers.Students.EdFi.Test_Profile_StudentOnly2_Resource_IncludeAll
+{
+    [ApiExplorerSettings(IgnoreApi = true)]
+    [ExcludeFromCodeCoverage]
+    [ApiController]
+    [Authorize]
+    [ProfileContentType("application/vnd.ed-fi.student.test-profile-studentonly2-resource-includeall")]
+    [Route("ed-fi/students")]
+    public partial class StudentsController : DataManagementControllerBase<
+        Api.Common.Models.Resources.Student.EdFi.Test_Profile_StudentOnly2_Resource_IncludeAll_Readable.Student,
+        Api.Common.Models.Resources.Student.EdFi.Test_Profile_StudentOnly2_Resource_IncludeAll_Writable.Student,
+        Entities.Common.EdFi.IStudent,
+        Entities.NHibernate.StudentAggregate.EdFi.Student,
+        Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly2_Resource_IncludeAll.StudentPut,
+        Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly2_Resource_IncludeAll.StudentPost,
+        Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly2_Resource_IncludeAll.StudentDelete,
+        Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly2_Resource_IncludeAll.StudentGetByExample>
+    {
+        public StudentsController(IPipelineFactory pipelineFactory, ISchoolYearContextProvider schoolYearContextProvider, IRESTErrorProvider restErrorProvider, IDefaultPageSizeLimitProvider defaultPageSizeLimitProvider, ApiSettings apiSettings)
+            : base(pipelineFactory, schoolYearContextProvider, restErrorProvider, defaultPageSizeLimitProvider, apiSettings)
+        {
+        }
+
+        protected override void MapAll(Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly2_Resource_IncludeAll.StudentGetByExample request, Entities.Common.EdFi.IStudent specification)
+        {
+            // Copy all existing values
+            specification.SuspendReferenceAssignmentCheck();
+            specification.BirthCity = request.BirthCity;
+            specification.BirthCountryDescriptor = request.BirthCountryDescriptor;
+            specification.BirthDate = request.BirthDate;
+            specification.BirthInternationalProvince = request.BirthInternationalProvince;
+            specification.BirthSexDescriptor = request.BirthSexDescriptor;
+            specification.BirthStateAbbreviationDescriptor = request.BirthStateAbbreviationDescriptor;
+            specification.CitizenshipStatusDescriptor = request.CitizenshipStatusDescriptor;
+            specification.DateEnteredUS = request.DateEnteredUS;
+            specification.FirstName = request.FirstName;
+            specification.GenerationCodeSuffix = request.GenerationCodeSuffix;
+            specification.Id = request.Id;
+            specification.LastSurname = request.LastSurname;
+            specification.MaidenName = request.MaidenName;
+            specification.MiddleName = request.MiddleName;
+            specification.MultipleBirthStatus = request.MultipleBirthStatus;
+            specification.PersonalTitlePrefix = request.PersonalTitlePrefix;
+            specification.PersonId = request.PersonId;
+            specification.SourceSystemDescriptor = request.SourceSystemDescriptor;
+            specification.StudentUniqueId = request.StudentUniqueId;
+        }
+
+        protected override string GetReadContentType()
+        {
+            return "application/vnd.ed-fi.student.test-profile-studentonly2-resource-includeall.readable+json";
         }
     }
 }

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Profiles.Test_Controllers_Controllers.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Profiles.Test_Controllers_Controllers.generated.approved.cs
@@ -2120,61 +2120,6 @@ namespace EdFi.Ods.Api.Services.Controllers.Students.EdFi.Test_Profile_Student_a
     }
 }
 
-namespace EdFi.Ods.Api.Services.Controllers.Students.EdFi.Test_Profile_StudentOnly_Resource_IncludeAll
-{
-    [ApiExplorerSettings(IgnoreApi = true)]
-    [ExcludeFromCodeCoverage]
-    [ApiController]
-    [Authorize]
-    [ProfileContentType("application/vnd.ed-fi.student.test-profile-studentonly-resource-includeall")]
-    [Route("ed-fi/students")]
-    public partial class StudentsController : DataManagementControllerBase<
-        Api.Common.Models.Resources.Student.EdFi.Test_Profile_StudentOnly_Resource_IncludeAll_Readable.Student,
-        Api.Common.Models.Resources.Student.EdFi.Test_Profile_StudentOnly_Resource_IncludeAll_Writable.Student,
-        Entities.Common.EdFi.IStudent,
-        Entities.NHibernate.StudentAggregate.EdFi.Student,
-        Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly_Resource_IncludeAll.StudentPut,
-        Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly_Resource_IncludeAll.StudentPost,
-        Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly_Resource_IncludeAll.StudentDelete,
-        Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly_Resource_IncludeAll.StudentGetByExample>
-    {
-        public StudentsController(IPipelineFactory pipelineFactory, ISchoolYearContextProvider schoolYearContextProvider, IRESTErrorProvider restErrorProvider, IDefaultPageSizeLimitProvider defaultPageSizeLimitProvider, ApiSettings apiSettings)
-            : base(pipelineFactory, schoolYearContextProvider, restErrorProvider, defaultPageSizeLimitProvider, apiSettings)
-        {
-        }
-
-        protected override void MapAll(Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly_Resource_IncludeAll.StudentGetByExample request, Entities.Common.EdFi.IStudent specification)
-        {
-            // Copy all existing values
-            specification.SuspendReferenceAssignmentCheck();
-            specification.BirthCity = request.BirthCity;
-            specification.BirthCountryDescriptor = request.BirthCountryDescriptor;
-            specification.BirthDate = request.BirthDate;
-            specification.BirthInternationalProvince = request.BirthInternationalProvince;
-            specification.BirthSexDescriptor = request.BirthSexDescriptor;
-            specification.BirthStateAbbreviationDescriptor = request.BirthStateAbbreviationDescriptor;
-            specification.CitizenshipStatusDescriptor = request.CitizenshipStatusDescriptor;
-            specification.DateEnteredUS = request.DateEnteredUS;
-            specification.FirstName = request.FirstName;
-            specification.GenerationCodeSuffix = request.GenerationCodeSuffix;
-            specification.Id = request.Id;
-            specification.LastSurname = request.LastSurname;
-            specification.MaidenName = request.MaidenName;
-            specification.MiddleName = request.MiddleName;
-            specification.MultipleBirthStatus = request.MultipleBirthStatus;
-            specification.PersonalTitlePrefix = request.PersonalTitlePrefix;
-            specification.PersonId = request.PersonId;
-            specification.SourceSystemDescriptor = request.SourceSystemDescriptor;
-            specification.StudentUniqueId = request.StudentUniqueId;
-        }
-
-        protected override string GetReadContentType()
-        {
-            return "application/vnd.ed-fi.student.test-profile-studentonly-resource-includeall.readable+json";
-        }
-    }
-}
-
 namespace EdFi.Ods.Api.Services.Controllers.Students.EdFi.Test_Profile_StudentOnly2_Resource_IncludeAll
 {
     [ApiExplorerSettings(IgnoreApi = true)]
@@ -2226,6 +2171,61 @@ namespace EdFi.Ods.Api.Services.Controllers.Students.EdFi.Test_Profile_StudentOn
         protected override string GetReadContentType()
         {
             return "application/vnd.ed-fi.student.test-profile-studentonly2-resource-includeall.readable+json";
+        }
+    }
+}
+
+namespace EdFi.Ods.Api.Services.Controllers.Students.EdFi.Test_Profile_StudentOnly_Resource_IncludeAll
+{
+    [ApiExplorerSettings(IgnoreApi = true)]
+    [ExcludeFromCodeCoverage]
+    [ApiController]
+    [Authorize]
+    [ProfileContentType("application/vnd.ed-fi.student.test-profile-studentonly-resource-includeall")]
+    [Route("ed-fi/students")]
+    public partial class StudentsController : DataManagementControllerBase<
+        Api.Common.Models.Resources.Student.EdFi.Test_Profile_StudentOnly_Resource_IncludeAll_Readable.Student,
+        Api.Common.Models.Resources.Student.EdFi.Test_Profile_StudentOnly_Resource_IncludeAll_Writable.Student,
+        Entities.Common.EdFi.IStudent,
+        Entities.NHibernate.StudentAggregate.EdFi.Student,
+        Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly_Resource_IncludeAll.StudentPut,
+        Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly_Resource_IncludeAll.StudentPost,
+        Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly_Resource_IncludeAll.StudentDelete,
+        Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly_Resource_IncludeAll.StudentGetByExample>
+    {
+        public StudentsController(IPipelineFactory pipelineFactory, ISchoolYearContextProvider schoolYearContextProvider, IRESTErrorProvider restErrorProvider, IDefaultPageSizeLimitProvider defaultPageSizeLimitProvider, ApiSettings apiSettings)
+            : base(pipelineFactory, schoolYearContextProvider, restErrorProvider, defaultPageSizeLimitProvider, apiSettings)
+        {
+        }
+
+        protected override void MapAll(Api.Common.Models.Requests.Students.EdFi.Test_Profile_StudentOnly_Resource_IncludeAll.StudentGetByExample request, Entities.Common.EdFi.IStudent specification)
+        {
+            // Copy all existing values
+            specification.SuspendReferenceAssignmentCheck();
+            specification.BirthCity = request.BirthCity;
+            specification.BirthCountryDescriptor = request.BirthCountryDescriptor;
+            specification.BirthDate = request.BirthDate;
+            specification.BirthInternationalProvince = request.BirthInternationalProvince;
+            specification.BirthSexDescriptor = request.BirthSexDescriptor;
+            specification.BirthStateAbbreviationDescriptor = request.BirthStateAbbreviationDescriptor;
+            specification.CitizenshipStatusDescriptor = request.CitizenshipStatusDescriptor;
+            specification.DateEnteredUS = request.DateEnteredUS;
+            specification.FirstName = request.FirstName;
+            specification.GenerationCodeSuffix = request.GenerationCodeSuffix;
+            specification.Id = request.Id;
+            specification.LastSurname = request.LastSurname;
+            specification.MaidenName = request.MaidenName;
+            specification.MiddleName = request.MiddleName;
+            specification.MultipleBirthStatus = request.MultipleBirthStatus;
+            specification.PersonalTitlePrefix = request.PersonalTitlePrefix;
+            specification.PersonId = request.PersonId;
+            specification.SourceSystemDescriptor = request.SourceSystemDescriptor;
+            specification.StudentUniqueId = request.StudentUniqueId;
+        }
+
+        protected override string GetReadContentType()
+        {
+            return "application/vnd.ed-fi.student.test-profile-studentonly-resource-includeall.readable+json";
         }
     }
 }

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Generators/Controllers.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Generators/Controllers.cs
@@ -386,7 +386,7 @@ namespace EdFi.Ods.CodeGen.Generators
                                     Writable = pct.Writable,
                                     ProfileName = prm.ProfileName
                                 }))
-                    .OrderBy(spd => spd.ProfileName, StringComparer.InvariantCultureIgnoreCase)
+                    .OrderBy(spd => spd.ProfileName, StringComparer.OrdinalIgnoreCase)
                     .ThenBy(x => x.ResolvedResource.Name);
             }
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Generators/Controllers.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Generators/Controllers.cs
@@ -386,7 +386,7 @@ namespace EdFi.Ods.CodeGen.Generators
                                     Writable = pct.Writable,
                                     ProfileName = prm.ProfileName
                                 }))
-                    .OrderBy(spd => spd.ProfileName.ToLower())
+                    .OrderBy(spd => spd.ProfileName, StringComparer.InvariantCultureIgnoreCase)
                     .ThenBy(x => x.ResolvedResource.Name);
             }
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Mustache/ResourceClaimMetadata.mustache
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Mustache/ResourceClaimMetadata.mustache
@@ -61,6 +61,9 @@ VALUES ('Relationships with Students only', 'RelationshipsWithStudentsOnly', @ap
 INSERT INTO [dbo].[AuthorizationStrategies] ([DisplayName], [AuthorizationStrategyName], [Application_ApplicationId])
 VALUES ('Relationships with Students only (through StudentEducationOrganizationAssociation)', 'RelationshipsWithStudentsOnlyThroughEdOrgAssociation', @applicationId);
 
+INSERT INTO [dbo].[AuthorizationStrategies] ([DisplayName], [AuthorizationStrategyName], [Application_ApplicationId])
+VALUES ('Ownership Based', 'OwnershipBased', @applicationId);
+
 /* --------------------------------- */
 
 /* --------------------------------- */
@@ -148,21 +151,20 @@ VALUES (N'{{DisplayName}}', N'{{ResourceName}}', N'http://ed-fi.org/ods/identity
 {{/Aggregates}}
 /* --------------------------------- */
 
-/* --------------------------------- */
-/*     ClaimSetResourceClaims        */
-/* --------------------------------- */
+/* ---------------------------------------------------  */
+/*     ClaimSetResourceClaimActions        */
+/* ---------------------------------------------------- */
 
 /* SIS Vendors Claims */
 
 SELECT @ClaimSetId = (SELECT ClaimSetId FROM [dbo].[ClaimSets] WHERE [ClaimSetName] = 'SIS Vendor');
 
-INSERT INTO [dbo].[ClaimSetResourceClaims]
-    ([Action_ActionId]
-    ,[ClaimSet_ClaimSetId]
-    ,[ResourceClaim_ResourceClaimId]
-    ,[AuthorizationStrategyOverride_AuthorizationStrategyId]
+INSERT INTO [dbo].[ClaimSetResourceClaimActions]
+    ([ActionId]
+    ,[ClaimSetId]
+    ,[ResourceClaimId]
     ,[ValidationRuleSetNameOverride])
-SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null, null
+SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null
 FROM [dbo].[ResourceClaims]
 CROSS APPLY
    (SELECT ActionId
@@ -170,12 +172,26 @@ CROSS APPLY
     WHERE ActionName IN ('Read')) AS ac
 WHERE ResourceName IN ('types', 'systemDescriptors', 'educationOrganizations')
 UNION
-SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null, null
+SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null
 FROM [dbo].[ResourceClaims]
 CROSS APPLY
     (SELECT ActionId
     FROM [dbo].[Actions]
-    WHERE ActionName IN ('Create','Read','Update','Delete')) AS ac
+    WHERE ActionName IN ('Read','Update','Delete')) AS ac
+WHERE ResourceName IN ('people'
+    , 'relationshipBasedData'
+    , 'assessmentMetadata'
+    , 'managedDescriptors'
+    , 'primaryRelationships'
+    , 'educationStandards'
+    , 'educationContent')
+UNION
+SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null
+FROM [dbo].[ResourceClaims]
+CROSS APPLY
+    (SELECT ActionId
+    FROM [dbo].[Actions]
+    WHERE ActionName IN ('Create')) AS ac
 WHERE ResourceName IN ('people'
     , 'relationshipBasedData'
     , 'assessmentMetadata'
@@ -188,13 +204,12 @@ WHERE ResourceName IN ('people'
 
 SELECT @ClaimSetId = (SELECT ClaimSetId FROM [dbo].[ClaimSets] WHERE [ClaimSetName] = 'Ed-Fi Sandbox');
 
-INSERT INTO [dbo].[ClaimSetResourceClaims]
-    ([Action_ActionId]
-    ,[ClaimSet_ClaimSetId]
-    ,[ResourceClaim_ResourceClaimId]
-    ,[AuthorizationStrategyOverride_AuthorizationStrategyId]
+INSERT INTO [dbo].[ClaimSetResourceClaimActions]
+    ([ActionId]
+    ,[ClaimSetId]
+    ,[ResourceClaimId]
     ,[ValidationRuleSetNameOverride])
-SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null, null
+SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null
 FROM [dbo].[ResourceClaims]
 CROSS APPLY
     (SELECT ActionId
@@ -202,7 +217,7 @@ CROSS APPLY
     WHERE ActionName IN ('Read')) AS ac
 WHERE ResourceName IN ('types', 'identity')
 UNION
-SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null, null
+SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null
 FROM [dbo].[ResourceClaims]
 CROSS APPLY
     (SELECT ActionId
@@ -210,26 +225,32 @@ CROSS APPLY
     WHERE ActionName IN ('Create', 'Update')) AS ac
 WHERE ResourceName IN ('identity')
 UNION
-SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null, null  FROM [dbo].[ResourceClaims]
+SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null  FROM [dbo].[ResourceClaims]
 CROSS APPLY
     (SELECT ActionId
     FROM [dbo].[Actions]
-    WHERE ActionName IN ('Create','Read','Update','Delete')) AS ac
+    WHERE ActionName IN ('Read','Update','Delete')) AS ac
+WHERE ResourceName IN ('systemDescriptors', 'educationOrganizations', 'people', 'relationshipBasedData',
+    'assessmentMetadata', 'managedDescriptors', 'primaryRelationships', 'educationStandards',
+    'educationContent', 'surveyDomain')
+UNION
+SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null  FROM [dbo].[ResourceClaims]
+CROSS APPLY
+    (SELECT ActionId
+    FROM [dbo].[Actions]
+    WHERE ActionName IN ('Create')) AS ac
 WHERE ResourceName IN ('systemDescriptors', 'educationOrganizations', 'people', 'relationshipBasedData',
     'assessmentMetadata', 'managedDescriptors', 'primaryRelationships', 'educationStandards',
     'educationContent', 'surveyDomain');
 
 /* EdFi Sandbox Claims with Overrides */
 
-SELECT @AuthorizationStrategyId  = (SELECT AuthorizationStrategyId FROM [dbo].[AuthorizationStrategies] WHERE AuthorizationStrategyName = 'NoFurtherAuthorizationRequired');
-
-INSERT INTO [dbo].[ClaimSetResourceClaims]
-    ([Action_ActionId]
-    ,[ClaimSet_ClaimSetId]
-    ,[ResourceClaim_ResourceClaimId]
-    ,[AuthorizationStrategyOverride_AuthorizationStrategyId]
+INSERT INTO [dbo].[ClaimSetResourceClaimActions]
+    ([ActionId]
+    ,[ClaimSetId]
+    ,[ResourceClaimId]
     ,[ValidationRuleSetNameOverride])
-SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, @AuthorizationStrategyId, null
+SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null
 FROM [dbo].[ResourceClaims]
 CROSS APPLY
     (SELECT ActionId
@@ -241,13 +262,12 @@ WHERE ResourceName IN ('communityProviderLicense');
 
 SELECT @ClaimSetId = (SELECT ClaimSetId FROM [dbo].[ClaimSets] WHERE [ClaimSetName] = 'Roster Vendor');
 
-INSERT INTO [dbo].[ClaimSetResourceClaims]
-    ([Action_ActionId]
-    ,[ClaimSet_ClaimSetId]
-    ,[ResourceClaim_ResourceClaimId]
-    ,[AuthorizationStrategyOverride_AuthorizationStrategyId]
+INSERT INTO [dbo].[ClaimSetResourceClaimActions]
+    ([ActionId]
+    ,[ClaimSetId]
+    ,[ResourceClaimId]
     ,[ValidationRuleSetNameOverride])
-SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null, null
+SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null
 FROM [dbo].[ResourceClaims]
 CROSS APPLY
     (SELECT ActionId
@@ -261,13 +281,12 @@ WHERE ResourceName IN ('educationOrganizations', 'section', 'student', 'staff', 
 
 SELECT @ClaimSetId = (SELECT ClaimSetId FROM [dbo].[ClaimSets] WHERE [ClaimSetName] = 'Assessment Vendor');
 
-INSERT INTO [dbo].[ClaimSetResourceClaims]
-    ([Action_ActionId]
-    ,[ClaimSet_ClaimSetId]
-    ,[ResourceClaim_ResourceClaimId]
-    ,[AuthorizationStrategyOverride_AuthorizationStrategyId]
+INSERT INTO [dbo].[ClaimSetResourceClaimActions]
+    ([ActionId]
+    ,[ClaimSetId]
+    ,[ResourceClaimId]
     ,[ValidationRuleSetNameOverride])
-SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null, null
+SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null
 FROM [dbo].[ResourceClaims]
 CROSS APPLY
     (SELECT ActionId
@@ -275,7 +294,7 @@ CROSS APPLY
     WHERE ActionName IN ('Create','Read','Update','Delete')) AS ac
 WHERE ResourceName IN ('assessmentMetadata')
 UNION
-SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null, null
+SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null
 FROM [dbo].[ResourceClaims]
 CROSS APPLY
     (SELECT ActionId
@@ -285,13 +304,12 @@ WHERE ResourceName IN ('learningObjective', 'learningStandard', 'student');
 
 /* Assessment Read Resource Claims */
 SET @ClaimSetId = (SELECT ClaimSetId FROM [dbo].[ClaimSets] WHERE [ClaimSetName] = 'Assessment Read');
-INSERT INTO [dbo].[ClaimSetResourceClaims]
-    ([Action_ActionId]
-    ,[ClaimSet_ClaimSetId]
-    ,[ResourceClaim_ResourceClaimId]
-    ,[AuthorizationStrategyOverride_AuthorizationStrategyId]
+INSERT INTO [dbo].[ClaimSetResourceClaimActions]
+    ([ActionId]
+    ,[ClaimSetId]
+    ,[ResourceClaimId]
     ,[ValidationRuleSetNameOverride])
-SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null, null
+SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null
 FROM [dbo].[ResourceClaims]
 CROSS APPLY
     (SELECT ActionId
@@ -302,21 +320,318 @@ WHERE ResourceName IN ('assessmentMetadata', 'learningObjective', 'learningStand
 /* Bootstrap Descriptors and EdOrgs Claims */
 
 SELECT @ClaimSetId = (SELECT ClaimSetId FROM [dbo].[ClaimSets] WHERE [ClaimSetName] = 'Bootstrap Descriptors and EdOrgs');
-SELECT @AuthorizationStrategyId = (SELECT AuthorizationStrategyId FROM [dbo].[AuthorizationStrategies] WHERE AuthorizationStrategyName = 'NoFurtherAuthorizationRequired');
 
-INSERT INTO [dbo].[ClaimSetResourceClaims]
-    ([Action_ActionId]
-    ,[ClaimSet_ClaimSetId]
-    ,[ResourceClaim_ResourceClaimId]
-    ,[AuthorizationStrategyOverride_AuthorizationStrategyId]
+INSERT INTO [dbo].[ClaimSetResourceClaimActions]
+    ([ActionId]
+    ,[ClaimSetId]
+    ,[ResourceClaimId]
     ,[ValidationRuleSetNameOverride])
-SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, @AuthorizationStrategyId, null
+SELECT ac.ActionId, @ClaimSetId, ResourceClaimId, null
 FROM [dbo].[ResourceClaims]
 CROSS APPLY
     (SELECT ActionId
     FROM [dbo].[Actions]
     WHERE ActionName IN ('Create')) AS ac
 WHERE ResourceName IN (
+    'systemDescriptors',
+    'managedDescriptors',
+    'educationOrganizations',
+    -- from Interchange-Standards.xml
+    'learningObjective',
+    'learningStandard',
+    'learningStandardEquivalenceAssociation',
+    -- from Interchange-EducationOrganization.xml
+    'accountabilityRating',
+    'classPeriod',
+    'communityProviderLicense',
+    'course',
+    'educationOrganizationPeerAssociation',
+    'feederSchoolAssociation',
+    'location',
+    'program'
+);
+
+/* --------------------------------- */
+/* ResourceClaimActions */
+/* --------------------------------- */
+
+/* NoFurtherAuthorizationRequired */
+
+INSERT INTO [dbo].[ResourceClaimActions]
+    ([ActionId]
+    ,[ResourceClaimId]
+    ,[ValidationRuleSetName])
+SELECT ac.ActionId, ResourceClaimId, null
+FROM [dbo].[ResourceClaims]
+CROSS APPLY
+    (SELECT ActionId
+    FROM [dbo].[Actions]
+    WHERE ActionName IN ('Read')) AS ac
+WHERE ResourceName IN ('types', 'systemDescriptors', 'educationOrganizations', 'course', 'managedDescriptors', 'identity', 'credential', 'person' )
+UNION
+SELECT ac.ActionId, ResourceClaimId, null
+FROM [dbo].[ResourceClaims]
+CROSS APPLY
+    (SELECT ActionId
+    FROM [dbo].[Actions]
+    WHERE ActionName IN ('Create')) AS ac
+WHERE ResourceName IN ('educationOrganizations', 'credential', 'people', 'identity', 'person')
+UNION
+SELECT ac.ActionId, ResourceClaimId, null
+FROM [dbo].[ResourceClaims]
+CROSS APPLY
+    (SELECT ActionId
+    FROM [dbo].[Actions]
+    WHERE ActionName IN ('Update')) AS ac
+WHERE ResourceName IN ('educationOrganizations', 'identity', 'credential', 'person' )
+UNION
+SELECT ac.ActionId, ResourceClaimId, null FROM [dbo].[ResourceClaims]
+CROSS APPLY
+    (SELECT ActionId
+    FROM [dbo].[Actions]
+    WHERE ActionName IN ('Delete')) AS ac
+WHERE ResourceName IN ('educationOrganizations', 'people', 'credential', 'person');
+
+/* NamespaceBased */
+
+INSERT INTO [dbo].[ResourceClaimActions]
+    ([ActionId]
+    ,[ResourceClaimId]
+    ,[ValidationRuleSetName])
+SELECT ac.ActionId, ResourceClaimId, null
+FROM [dbo].[ResourceClaims]
+CROSS APPLY
+    (SELECT ActionId
+    FROM [dbo].[Actions]
+    WHERE ActionName IN ('Read')) AS ac
+WHERE ResourceName IN ('assessmentMetadata', 'educationStandards', 'educationContent', 'surveyDomain' )
+UNION
+SELECT ac.ActionId, ResourceClaimId, null
+FROM [dbo].[ResourceClaims]
+CROSS APPLY
+    (SELECT ActionId
+    FROM [dbo].[Actions]
+    WHERE ActionName IN ('Create', 'Update', 'Delete')) AS ac
+WHERE ResourceName IN ('systemDescriptors', 'managedDescriptors', 'assessmentMetadata', 'educationStandards', 'educationContent', 'surveyDomain');
+
+/* RelationshipsWithEdOrgsAndPeople */
+
+INSERT INTO [dbo].[ResourceClaimActions]
+    ([ActionId]
+    ,[ResourceClaimId]
+    ,[ValidationRuleSetName])
+SELECT ac.ActionId, ResourceClaimId, null
+FROM [dbo].[ResourceClaims]
+CROSS APPLY
+    (SELECT ActionId
+    FROM [dbo].[Actions]
+    WHERE ActionName IN ('Read', 'Update')) AS ac
+WHERE ResourceName IN ('primaryRelationships', 'studentParentAssociation', 'people', 'relationshipBasedData')
+UNION
+SELECT ac.ActionId, ResourceClaimId, null
+FROM [dbo].[ResourceClaims]
+CROSS APPLY
+    (SELECT ActionId
+    FROM [dbo].[Actions]
+    WHERE ActionName IN ('Create')) AS ac
+WHERE ResourceName IN ('relationshipBasedData')
+UNION
+SELECT ac.ActionId, ResourceClaimId, null
+FROM [dbo].[ResourceClaims]
+CROSS APPLY
+    (SELECT ActionId
+    FROM [dbo].[Actions]
+    WHERE ActionName IN ('Delete')) AS ac
+WHERE ResourceName IN ('relationshipBasedData', 'studentParentAssociation', 'primaryRelationships');
+
+/* RelationshipsWithStudentsOnly */
+
+INSERT INTO [dbo].[ResourceClaimActions]
+    ([ActionId]
+    ,[ResourceClaimId]
+    ,[ValidationRuleSetName])
+SELECT ac.ActionId, ResourceClaimId, null
+FROM [dbo].[ResourceClaims]
+CROSS APPLY
+    (SELECT ActionId
+    FROM [dbo].[Actions]
+    WHERE ActionName IN ('Create')) AS ac
+WHERE ResourceName IN ('studentParentAssociation');
+
+/* RelationshipsWithEdOrgsOnly */
+
+INSERT INTO [dbo].[ResourceClaimActions]
+    ([ActionId]
+    ,[ResourceClaimId]
+    ,[ValidationRuleSetName])
+SELECT ac.ActionId, ResourceClaimId, null
+FROM [dbo].[ResourceClaims]
+CROSS APPLY
+    (SELECT ActionId
+    FROM [dbo].[Actions]
+    WHERE ActionName IN ('Create')) AS ac
+WHERE ResourceName IN ('primaryRelationships')
+
+/* --------------------------------- */
+
+/* ------------------------------------------- */
+/* ResourceClaimActionAuthorizationStrategies */
+/* --------------------------------------------- */
+
+/* NoFurtherAuthorizationRequired */
+
+SELECT @AuthorizationStrategyId  = (SELECT AuthorizationStrategyId FROM [dbo].[AuthorizationStrategies] WHERE AuthorizationStrategyName = 'NoFurtherAuthorizationRequired');
+
+INSERT INTO [dbo].[ResourceClaimActionAuthorizationStrategies]
+    ([ResourceClaimActionId]
+    ,[AuthorizationStrategyId])
+
+
+SELECT RCAA.ResourceClaimActionId,@AuthorizationStrategyId FROM  [dbo].[ResourceClaimActions] RCAA
+    INNER JOIN [dbo].[ResourceClaims] RC ON  RC.ResourceClaimId =RCAA.ResourceClaimId
+    INNER JOIN [dbo].[Actions] A on A.ActionId = RCAA.ActionId
+    WHERE A.ActionName IN ('Read')
+    AND RC.ResourceName IN ('types', 'systemDescriptors', 'educationOrganizations', 'course', 'managedDescriptors', 'identity', 'credential', 'person')
+
+UNION
+
+SELECT RCAA.ResourceClaimActionId,@AuthorizationStrategyId FROM  [dbo].[ResourceClaimActions] RCAA
+    INNER JOIN [dbo].[ResourceClaims] RC ON  RC.ResourceClaimId =RCAA.ResourceClaimId
+    INNER JOIN [dbo].[Actions] A on A.ActionId = RCAA.ActionId
+    WHERE A.ActionName IN ('Create')
+    AND RC.ResourceName IN ('educationOrganizations', 'credential', 'people', 'identity', 'person')
+
+UNION
+
+SELECT RCAA.ResourceClaimActionId,@AuthorizationStrategyId FROM  [dbo].[ResourceClaimActions] RCAA
+    INNER JOIN [dbo].[ResourceClaims] RC ON  RC.ResourceClaimId =RCAA.ResourceClaimId
+    INNER JOIN [dbo].[Actions] A on A.ActionId = RCAA.ActionId
+    WHERE A.ActionName IN ('Update')
+    AND RC.ResourceName IN ('educationOrganizations', 'identity', 'credential', 'person' )
+
+UNION
+
+SELECT RCAA.ResourceClaimActionId,@AuthorizationStrategyId FROM  [dbo].[ResourceClaimActions] RCAA
+    INNER JOIN [dbo].[ResourceClaims] RC ON  RC.ResourceClaimId =RCAA.ResourceClaimId
+    INNER JOIN [dbo].[Actions] A on A.ActionId = RCAA.ActionId
+    WHERE A.ActionName IN ('Delete')
+    AND RC.ResourceName IN ('educationOrganizations', 'people', 'credential', 'person');
+
+
+/* NamespaceBased */
+
+SELECT @AuthorizationStrategyId  = (SELECT AuthorizationStrategyId FROM [dbo].[AuthorizationStrategies] WHERE AuthorizationStrategyName = 'NamespaceBased');
+
+INSERT INTO [dbo].[ResourceClaimActionAuthorizationStrategies]
+    ([ResourceClaimActionId]
+    ,[AuthorizationStrategyId])
+
+SELECT RCAA.ResourceClaimActionId,@AuthorizationStrategyId FROM  [dbo].[ResourceClaimActions] RCAA
+    INNER JOIN [dbo].[ResourceClaims] RC ON  RC.ResourceClaimId =RCAA.ResourceClaimId
+    INNER JOIN [dbo].[Actions] A on A.ActionId = RCAA.ActionId
+    WHERE A.ActionName IN ('Read')
+    AND RC.ResourceName IN ('assessmentMetadata', 'educationStandards', 'educationContent', 'surveyDomain' )
+
+UNION
+
+SELECT RCAA.ResourceClaimActionId,@AuthorizationStrategyId FROM  [dbo].[ResourceClaimActions] RCAA
+    INNER JOIN [dbo].[ResourceClaims] RC ON  RC.ResourceClaimId =RCAA.ResourceClaimId
+    INNER JOIN [dbo].[Actions] A on A.ActionId = RCAA.ActionId
+    WHERE A.ActionName IN ('Create', 'Update', 'Delete')
+    AND RC.ResourceName IN ('systemDescriptors', 'managedDescriptors', 'assessmentMetadata', 'educationStandards', 'educationContent', 'surveyDomain')
+
+
+/* RelationshipsWithEdOrgsAndPeople */
+
+SELECT @AuthorizationStrategyId  = (SELECT AuthorizationStrategyId FROM [dbo].[AuthorizationStrategies] WHERE AuthorizationStrategyName = 'RelationshipsWithEdOrgsAndPeople');
+
+INSERT INTO [dbo].[ResourceClaimActionAuthorizationStrategies]
+    ([ResourceClaimActionId]
+    ,[AuthorizationStrategyId])
+
+SELECT RCAA.ResourceClaimActionId,@AuthorizationStrategyId FROM  [dbo].[ResourceClaimActions] RCAA
+    INNER JOIN [dbo].[ResourceClaims] RC ON  RC.ResourceClaimId =RCAA.ResourceClaimId
+    INNER JOIN [dbo].[Actions] A on A.ActionId = RCAA.ActionId
+    WHERE A.ActionName IN ('Read', 'Update')
+    AND RC.ResourceName IN ('primaryRelationships', 'studentParentAssociation', 'people', 'relationshipBasedData')
+UNION
+SELECT RCAA.ResourceClaimActionId,@AuthorizationStrategyId FROM  [dbo].[ResourceClaimActions] RCAA
+    INNER JOIN [dbo].[ResourceClaims] RC ON  RC.ResourceClaimId =RCAA.ResourceClaimId
+    INNER JOIN [dbo].[Actions] A on A.ActionId = RCAA.ActionId
+    WHERE A.ActionName IN ('Create')
+    AND RC.ResourceName IN ('relationshipBasedData')
+UNION
+SELECT RCAA.ResourceClaimActionId,@AuthorizationStrategyId FROM  [dbo].[ResourceClaimActions] RCAA
+    INNER JOIN [dbo].[ResourceClaims] RC ON  RC.ResourceClaimId =RCAA.ResourceClaimId
+    INNER JOIN [dbo].[Actions] A on A.ActionId = RCAA.ActionId
+    WHERE A.ActionName IN ('Delete')
+    AND RC.ResourceName IN ('relationshipBasedData', 'studentParentAssociation', 'primaryRelationships')
+
+
+
+/* RelationshipsWithStudentsOnly */
+
+SELECT @AuthorizationStrategyId  = (SELECT AuthorizationStrategyId FROM [dbo].[AuthorizationStrategies] WHERE AuthorizationStrategyName = 'RelationshipsWithStudentsOnly');
+
+INSERT INTO [dbo].[ResourceClaimActionAuthorizationStrategies]
+    ([ResourceClaimActionId]
+    ,[AuthorizationStrategyId])
+SELECT RCAA.ResourceClaimActionId,@AuthorizationStrategyId FROM  [dbo].[ResourceClaimActions] RCAA
+    INNER JOIN [dbo].[ResourceClaims] RC ON  RC.ResourceClaimId =RCAA.ResourceClaimId
+    INNER JOIN [dbo].[Actions] A on A.ActionId = RCAA.ActionId
+    WHERE A.ActionName IN ('Create')
+    AND RC.ResourceName IN ('studentParentAssociation')
+
+/* RelationshipsWithEdOrgsOnly */
+
+SET @AuthorizationStrategyId  = (SELECT AuthorizationStrategyId FROM [dbo].[AuthorizationStrategies] WHERE AuthorizationStrategyName = 'RelationshipsWithEdOrgsOnly');
+
+INSERT INTO [dbo].[ResourceClaimActionAuthorizationStrategies]
+    ([ResourceClaimActionId]
+    ,[AuthorizationStrategyId])
+SELECT RCAA.ResourceClaimActionId,@AuthorizationStrategyId FROM  [dbo].[ResourceClaimActions] RCAA
+    INNER JOIN [dbo].[ResourceClaims] RC ON  RC.ResourceClaimId =RCAA.ResourceClaimId
+    INNER JOIN [dbo].[Actions] A on A.ActionId = RCAA.ActionId
+    WHERE A.ActionName IN ('Create')
+    AND RC.ResourceName IN ('primaryRelationships')
+
+
+/* -------------------------------------------------------------- */
+/*     ClaimSetResourceClaimActionAuthorizationStrategyOverrides  */
+/* -------------------------------------------------------------- */
+
+/* Bootstrap Descriptors and EdOrgs Claims */
+
+SELECT @AuthorizationStrategyId = (SELECT AuthorizationStrategyId FROM [dbo].[AuthorizationStrategies] WHERE AuthorizationStrategyName = 'NoFurtherAuthorizationRequired');
+SELECT @ClaimSetId = (SELECT ClaimSetId FROM [dbo].[ClaimSets] WHERE [ClaimSetName] = 'Ed-Fi Sandbox');
+
+INSERT INTO [dbo].[ClaimSetResourceClaimActionAuthorizationStrategyOverrides]
+    ([ClaimSetResourceClaimActionId]
+    ,[AuthorizationStrategyId])
+
+
+SELECT CSRCAA.ClaimSetResourceClaimActionId,@AuthorizationStrategyId FROM  [dbo].[ClaimSetResourceClaimActions] CSRCAA
+    INNER JOIN [dbo].[ResourceClaims] RC ON  RC.ResourceClaimId =CSRCAA.ResourceClaimId
+    INNER JOIN [dbo].[Actions] A on A.ActionId = CSRCAA.ActionId
+    INNER JOIN [dbo].[ClaimSets] CS on CS.ClaimSetId = CSRCAA.ClaimSetId
+    WHERE  CS.ClaimSetId =@ClaimSetId
+    AND A.ActionName IN ('Create','Read','Update','Delete')
+    AND RC.ResourceName IN ('communityProviderLicense')
+
+
+SELECT @ClaimSetId = (SELECT ClaimSetId FROM [dbo].[ClaimSets] WHERE [ClaimSetName] = 'Bootstrap Descriptors and EdOrgs');
+
+INSERT INTO [dbo].[ClaimSetResourceClaimActionAuthorizationStrategyOverrides]
+    ([ClaimSetResourceClaimActionId]
+    ,[AuthorizationStrategyId])
+
+SELECT CSRCAA.ClaimSetResourceClaimActionId,@AuthorizationStrategyId FROM  [dbo].[ClaimSetResourceClaimActions] CSRCAA
+    INNER JOIN [dbo].[ResourceClaims] RC ON  RC.ResourceClaimId =CSRCAA.ResourceClaimId
+    INNER JOIN [dbo].[Actions] A on A.ActionId = CSRCAA.ActionId
+    INNER JOIN [dbo].[ClaimSets] CS on CS.ClaimSetId = CSRCAA.ClaimSetId
+    WHERE  CS.ClaimSetId =@ClaimSetId
+    AND A.ActionName IN ('Create')
+    AND RC.ResourceName IN (
     'systemDescriptors',
     'managedDescriptors',
     'educationOrganizations',
@@ -342,143 +657,4 @@ WHERE ResourceName IN (
     'program',
     'school',
     'stateEducationAgency'
-);
-
-/* --------------------------------- */
-/* ResourceClaimAuthorizationMeatada */
-/* --------------------------------- */
-
-/* NoFurtherAuthorizationRequired */
-
-SELECT @AuthorizationStrategyId  = (SELECT AuthorizationStrategyId FROM [dbo].[AuthorizationStrategies] WHERE AuthorizationStrategyName = 'NoFurtherAuthorizationRequired');
-
-INSERT INTO [dbo].[ResourceClaimAuthorizationMetadatas]
-    ([Action_ActionId]
-    ,[AuthorizationStrategy_AuthorizationStrategyId]
-    ,[ResourceClaim_ResourceClaimId]
-    ,[ValidationRuleSetName])
-SELECT ac.ActionId, @AuthorizationStrategyId, ResourceClaimId, null
-FROM [dbo].[ResourceClaims]
-CROSS APPLY
-    (SELECT ActionId
-    FROM [dbo].[Actions]
-    WHERE ActionName IN ('Read')) AS ac
-WHERE ResourceName IN ('types', 'systemDescriptors', 'educationOrganizations', 'course', 'managedDescriptors', 'identity', 'credential', 'person' )
-UNION
-SELECT ac.ActionId, @AuthorizationStrategyId, ResourceClaimId, null
-FROM [dbo].[ResourceClaims]
-CROSS APPLY
-    (SELECT ActionId
-    FROM [dbo].[Actions]
-    WHERE ActionName IN ('Create')) AS ac
-WHERE ResourceName IN ('educationOrganizations', 'credential', 'people', 'identity', 'person')
-UNION
-SELECT ac.ActionId, @AuthorizationStrategyId, ResourceClaimId, null
-FROM [dbo].[ResourceClaims]
-CROSS APPLY
-    (SELECT ActionId
-    FROM [dbo].[Actions]
-    WHERE ActionName IN ('Update')) AS ac
-WHERE ResourceName IN ('educationOrganizations', 'identity', 'credential', 'person' )
-UNION
-SELECT ac.ActionId, @AuthorizationStrategyId, ResourceClaimId, null FROM [dbo].[ResourceClaims]
-CROSS APPLY
-    (SELECT ActionId
-    FROM [dbo].[Actions]
-    WHERE ActionName IN ('Delete')) AS ac
-WHERE ResourceName IN ('educationOrganizations', 'people', 'credential', 'person');
-
-/* NamespaceBased */
-
-SELECT @AuthorizationStrategyId  = (SELECT AuthorizationStrategyId FROM [dbo].[AuthorizationStrategies] WHERE AuthorizationStrategyName = 'NamespaceBased');
-
-INSERT INTO [dbo].[ResourceClaimAuthorizationMetadatas]
-    ([Action_ActionId]
-    ,[AuthorizationStrategy_AuthorizationStrategyId]
-    ,[ResourceClaim_ResourceClaimId]
-    ,[ValidationRuleSetName])
-SELECT ac.ActionId, @AuthorizationStrategyId, ResourceClaimId, null
-FROM [dbo].[ResourceClaims]
-CROSS APPLY
-    (SELECT ActionId
-    FROM [dbo].[Actions]
-    WHERE ActionName IN ('Read')) AS ac
-WHERE ResourceName IN ('assessmentMetadata', 'educationStandards', 'educationContent', 'surveyDomain' )
-UNION
-SELECT ac.ActionId, @AuthorizationStrategyId, ResourceClaimId, null
-FROM [dbo].[ResourceClaims]
-CROSS APPLY
-    (SELECT ActionId
-    FROM [dbo].[Actions]
-    WHERE ActionName IN ('Create', 'Update', 'Delete')) AS ac
-WHERE ResourceName IN ('systemDescriptors', 'managedDescriptors', 'assessmentMetadata', 'educationStandards', 'educationContent', 'surveyDomain');
-
-/* RelationshipsWithEdOrgsAndPeople */
-
-SELECT @AuthorizationStrategyId  = (SELECT AuthorizationStrategyId FROM [dbo].[AuthorizationStrategies] WHERE AuthorizationStrategyName = 'RelationshipsWithEdOrgsAndPeople');
-
-INSERT INTO [dbo].[ResourceClaimAuthorizationMetadatas]
-    ([Action_ActionId]
-    ,[AuthorizationStrategy_AuthorizationStrategyId]
-    ,[ResourceClaim_ResourceClaimId]
-    ,[ValidationRuleSetName])
-SELECT ac.ActionId, @AuthorizationStrategyId, ResourceClaimId, null
-FROM [dbo].[ResourceClaims]
-CROSS APPLY
-    (SELECT ActionId
-    FROM [dbo].[Actions]
-    WHERE ActionName IN ('Read', 'Update')) AS ac
-WHERE ResourceName IN ('primaryRelationships', 'studentParentAssociation', 'people', 'relationshipBasedData')
-UNION
-SELECT ac.ActionId, @AuthorizationStrategyId, ResourceClaimId, null
-FROM [dbo].[ResourceClaims]
-CROSS APPLY
-    (SELECT ActionId
-    FROM [dbo].[Actions]
-    WHERE ActionName IN ('Create')) AS ac
-WHERE ResourceName IN ('relationshipBasedData')
-UNION
-SELECT ac.ActionId, @AuthorizationStrategyId, ResourceClaimId, null
-FROM [dbo].[ResourceClaims]
-CROSS APPLY
-    (SELECT ActionId
-    FROM [dbo].[Actions]
-    WHERE ActionName IN ('Delete')) AS ac
-WHERE ResourceName IN ('relationshipBasedData', 'studentParentAssociation', 'primaryRelationships');
-
-/* RelationshipsWithStudentsOnly */
-
-SELECT @AuthorizationStrategyId  = (SELECT AuthorizationStrategyId FROM [dbo].[AuthorizationStrategies] WHERE AuthorizationStrategyName = 'RelationshipsWithStudentsOnly');
-
-INSERT INTO [dbo].[ResourceClaimAuthorizationMetadatas]
-    ([Action_ActionId]
-    ,[AuthorizationStrategy_AuthorizationStrategyId]
-    ,[ResourceClaim_ResourceClaimId]
-    ,[ValidationRuleSetName])
-SELECT ac.ActionId, @AuthorizationStrategyId, ResourceClaimId, null
-FROM [dbo].[ResourceClaims]
-CROSS APPLY
-    (SELECT ActionId
-    FROM [dbo].[Actions]
-    WHERE ActionName IN ('Create')) AS ac
-WHERE ResourceName IN ('studentParentAssociation');
-
-/* RelationshipsWithEdOrgsOnly */
-
-SET @AuthorizationStrategyId  = (SELECT AuthorizationStrategyId FROM [dbo].[AuthorizationStrategies] WHERE AuthorizationStrategyName = 'RelationshipsWithEdOrgsOnly');
-
-INSERT INTO [dbo].[ResourceClaimAuthorizationMetadatas]
-    ([Action_ActionId]
-    ,[AuthorizationStrategy_AuthorizationStrategyId]
-    ,[ResourceClaim_ResourceClaimId]
-    ,[ValidationRuleSetName])
-SELECT ac.ActionId, @AuthorizationStrategyId, ResourceClaimId, null
-FROM [dbo].[ResourceClaims]
-CROSS APPLY
-    (SELECT ActionId
-    FROM [dbo].[Actions]
-    WHERE ActionName IN ('Create')) AS ac
-WHERE ResourceName IN ('primaryRelationships')
-
-/* --------------------------------- */
-
+)

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Mustache/ResourceClaimMetadata.pgsql.mustache
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Mustache/ResourceClaimMetadata.pgsql.mustache
@@ -43,13 +43,16 @@ begin
     insert into dbo.AuthorizationStrategies (DisplayName, AuthorizationStrategyName, Application_ApplicationId)
     values ('Relationships with Students only (through StudentEducationOrganizationAssociation)', 'RelationshipsWithStudentsOnlyThroughEdOrgAssociation', application_id);
 
+    insert into dbo.AuthorizationStrategies (DisplayName, AuthorizationStrategyName, Application_ApplicationId)
+    values ('Ownership Based', 'OwnershipBased', application_id);
+
 end $$;
 
 /* --------------------------------- */
 /*           Claimsets               */
 /* --------------------------------- */
 do $$
-    declare application_id INT;
+    declare application_id int;
 begin
     select ApplicationId into application_id from dbo.Applications where ApplicationName = 'Ed-Fi ODS API';
 
@@ -155,9 +158,9 @@ begin
 {{/Aggregates}}
 end $$;
 
-/* --------------------------------- */
-/*     ClaimSetResourceClaims        */
-/* --------------------------------- */
+/* ------------------------------------------------- */
+/*     ClaimSetResourceClaimActions    */
+/* ------------------------------------------------ */
 do $$
     declare claim_set_id int;
     declare authorization_strategy_id int;
@@ -166,13 +169,12 @@ begin
     /* SIS Vendors Claims */
     select ClaimSetId into claim_set_id from dbo.ClaimSets where ClaimSetName = 'SIS Vendor';
 
-    insert into dbo.ClaimSetResourceClaims
-        (Action_ActionId
-        ,ClaimSet_ClaimSetId
-        ,ResourceClaim_ResourceClaimId
-        ,AuthorizationStrategyOverride_AuthorizationStrategyId
+    insert into dbo.ClaimSetResourceClaimActions
+        (ActionId
+        ,ClaimSetId
+        ,ResourceClaimId
         ,ValidationRuleSetNameOverride)
-    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int), cast(null as int)
+    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
        (select ActionId
@@ -180,30 +182,43 @@ begin
         where ActionName IN ('Read')) as ac on true
     where ResourceName IN ('types', 'systemDescriptors', 'educationOrganizations')
     union
-    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int), cast(null as int)
+    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
         from dbo.Actions
-        where ActionName IN ('Create','Read','Update','Delete')) as ac on true
+        where ActionName IN ('Read','Update','Delete')) as ac on true
     where ResourceName IN ('people'
         , 'relationshipBasedData'
         , 'assessmentMetadata'
         , 'managedDescriptors'
         , 'primaryRelationships'
         , 'educationStandards'
-        , 'educationContent');
+        , 'educationContent')
+    union
+    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int)
+    from dbo.ResourceClaims
+    inner join lateral
+        (select ActionId
+        from dbo.Actions
+        where ActionName IN ('Create')) as ac on true
+    where ResourceName IN ('people'
+    , 'relationshipBasedData'
+    , 'assessmentMetadata'
+    , 'managedDescriptors'
+    , 'primaryRelationships'
+    , 'educationStandards'
+    , 'educationContent');
 
     /* EdFi Sandbox Claims */
     select ClaimSetId INTO claim_set_id from dbo.ClaimSets where ClaimSetName = 'Ed-Fi Sandbox';
 
-    insert into dbo.ClaimSetResourceClaims
-        (Action_ActionId
-        ,ClaimSet_ClaimSetId
-        ,ResourceClaim_ResourceClaimId
-        ,AuthorizationStrategyOverride_AuthorizationStrategyId
+    insert into dbo.ClaimSetResourceClaimActions
+        (ActionId
+        ,ClaimSetId
+        ,ResourceClaimId
         ,ValidationRuleSetNameOverride)
-    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int), cast(null as int)
+    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
@@ -211,7 +226,7 @@ begin
         where ActionName IN ('Read')) as ac on true
     where ResourceName IN ('types', 'identity')
     union
-    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int), cast(null as int)
+    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
@@ -219,28 +234,34 @@ begin
         where ActionName IN ('Create', 'Update')) as ac on true
     where ResourceName IN ('identity')
     union
-    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int), cast(null as int)
+    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
         from dbo.Actions
-        where ActionName IN ('Create','Read','Update','Delete')) as ac on true
+        where ActionName IN ('Read','Update','Delete')) as ac on true
     where ResourceName IN ('systemDescriptors', 'educationOrganizations', 'people', 'relationshipBasedData',
         'assessmentMetadata', 'managedDescriptors', 'primaryRelationships', 'educationStandards',
-        'educationContent', 'surveyDomain');
+        'educationContent', 'surveyDomain')
+     union
+    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int)
+    from dbo.ResourceClaims
+    inner join lateral
+        (select ActionId
+        from dbo.Actions
+        where ActionName IN ('Create')) as ac on true
+    where ResourceName IN ('systemDescriptors','educationOrganizations','people', 'relationshipBasedData',
+    'assessmentMetadata', 'managedDescriptors',  'primaryRelationships', 'educationStandards',
+    'educationContent', 'surveyDomain');
 
     /* EdFi Sandbox Claims with Overrides */
-    select AuthorizationStrategyId INTO authorization_strategy_id
-    from dbo.AuthorizationStrategies
-    where AuthorizationStrategyName = 'NoFurtherAuthorizationRequired';
 
-    insert into dbo.ClaimSetResourceClaims
-        (Action_ActionId
-        ,ClaimSet_ClaimSetId
-        ,ResourceClaim_ResourceClaimId
-        ,AuthorizationStrategyOverride_AuthorizationStrategyId
+     insert into dbo.ClaimSetResourceClaimActions
+        (ActionId
+        ,ClaimSetId
+        ,ResourceClaimId
         ,ValidationRuleSetNameOverride)
-    select ac.ActionId, claim_set_id, ResourceClaimId, authorization_strategy_id, cast (null as int)
+    select ac.ActionId, claim_set_id, ResourceClaimId, cast (null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
@@ -251,13 +272,12 @@ begin
     /* Roster Vendor Claims */
     select ClaimSetId into claim_set_id from dbo.ClaimSets where ClaimSetName = 'Roster Vendor';
 
-    insert into dbo.ClaimSetResourceClaims
-        (Action_ActionId
-        ,ClaimSet_ClaimSetId
-        ,ResourceClaim_ResourceClaimId
-        ,AuthorizationStrategyOverride_AuthorizationStrategyId
+    insert into dbo.ClaimSetResourceClaimActions
+        (ActionId
+        ,ClaimSetId
+        ,ResourceClaimId
         ,ValidationRuleSetNameOverride)
-    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int), cast(null as int)
+    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
@@ -270,13 +290,12 @@ begin
     /* Assessment Vendor Claims */
     select ClaimSetId into claim_set_id from dbo.ClaimSets where ClaimSetName = 'Assessment Vendor';
 
-    insert into dbo.ClaimSetResourceClaims
-        (Action_ActionId
-        ,ClaimSet_ClaimSetId
-        ,ResourceClaim_ResourceClaimId
-        ,AuthorizationStrategyOverride_AuthorizationStrategyId
+    insert into dbo.ClaimSetResourceClaimActions
+        (ActionId
+        ,ClaimSetId
+        ,ResourceClaimId
         ,ValidationRuleSetNameOverride)
-    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int), cast(null as int)
+    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
@@ -284,7 +303,7 @@ begin
         where ActionName IN ('Create','Read','Update','Delete')) as ac on true
     where ResourceName IN ('assessmentMetadata')
     union
-    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int), cast(null as int)
+    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
@@ -295,13 +314,12 @@ begin
     /* Assessment Read Resource Claims */
     select ClaimSetId into claim_set_id from dbo.ClaimSets where ClaimSetName = 'Assessment Read';
 
-    insert into dbo.ClaimSetResourceClaims
-        (Action_ActionId
-        ,ClaimSet_ClaimSetId
-        ,ResourceClaim_ResourceClaimId
-        ,AuthorizationStrategyOverride_AuthorizationStrategyId
+ insert into dbo.ClaimSetResourceClaimActions
+        (ActionId
+        ,ClaimSetId
+        ,ResourceClaimId
         ,ValidationRuleSetNameOverride)
-    select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int), cast(null as int)
+ select ac.ActionId, claim_set_id, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
@@ -312,68 +330,52 @@ begin
     /* Bootstrap Descriptors and EdOrgs Claims */
 
     select ClaimSetId INTO claim_set_id from dbo.ClaimSets where ClaimSetName = 'Bootstrap Descriptors and EdOrgs';
-    select AuthorizationStrategyId INTO authorization_strategy_id
-    from dbo.AuthorizationStrategies
-    where AuthorizationStrategyName = 'NoFurtherAuthorizationRequired';
-
-    insert into dbo.ClaimSetResourceClaims
-        (Action_ActionId
-        ,ClaimSet_ClaimSetId
-        ,ResourceClaim_ResourceClaimId
-        ,AuthorizationStrategyOverride_AuthorizationStrategyId
+    insert into dbo.ClaimSetResourceClaimActions
+        (ActionId
+        ,ClaimSetId
+        ,ResourceClaimId
         ,ValidationRuleSetNameOverride)
-    select ac.ActionId, claim_set_id, ResourceClaimId, authorization_strategy_id, cast (null as int)
+    select ac.ActionId, claim_set_id, ResourceClaimId, cast (null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
         from dbo.Actions
         where ActionName IN ('Create')) as ac on true
     where ResourceName IN (
-        'systemDescriptors',
-        'managedDescriptors',
-        'educationOrganizations',
-        -- from Interchange-Standards.xml
-        'learningObjective',
-        'learningStandard',
-        'learningStandardEquivalenceAssociation',
-        -- from Interchange-EducationOrganization.xml
-        'accountabilityRating',
-        'classPeriod',
-        'communityOrganization',
-        'communityProvider',
-        'communityProviderLicense',
-        'course',
-        'educationOrganizationNetwork',
-        'educationOrganizationNetworkAssociation',
-        'educationOrganizationPeerAssociation',
-        'educationServiceCenter',
-        'feederSchoolAssociation',
-        'localEducationAgency',
-        'location',
-        'postSecondaryInstitution',
-        'program',
-        'school',
-        'stateEducationAgency'
+    'systemDescriptors',
+    'managedDescriptors',
+    'educationOrganizations',
+    -- from Interchange-Standards.xml
+    'learningObjective',
+    'learningStandard',
+    'learningStandardEquivalenceAssociation',
+    -- from Interchange-EducationOrganization.xml
+    'accountabilityRating',
+    'classPeriod',
+    'communityProviderLicense',
+    'course',
+    'educationOrganizationPeerAssociation',
+    'feederSchoolAssociation',
+    'location',
+    'program'
     );
 
 end $$;
 
 /* --------------------------------- */
-/* ResourceClaimAuthorizationMeatada */
+/* ResourceClaimActions */
 /* --------------------------------- */
 do $$
     declare authorization_strategy_id int;
 begin
 
     /* NoFurtherAuthorizationRequired */
-    select AuthorizationStrategyId INTO authorization_strategy_id from dbo.AuthorizationStrategies where AuthorizationStrategyName = 'NoFurtherAuthorizationRequired';
 
-    insert into dbo.ResourceClaimAuthorizationMetadatas
-        (Action_ActionId
-        ,AuthorizationStrategy_AuthorizationStrategyId
-        ,ResourceClaim_ResourceClaimId
+    insert into dbo.ResourceClaimActions
+        (ActionId
+        ,ResourceClaimId
         ,ValidationRuleSetName)
-    select ac.ActionId, authorization_strategy_id, ResourceClaimId, cast(null as int)
+    select ac.ActionId, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
@@ -381,7 +383,7 @@ begin
         where ActionName IN ('Read')) as ac on true
     where ResourceName IN ('types', 'systemDescriptors', 'educationOrganizations', 'course', 'managedDescriptors', 'identity', 'credential', 'person' )
     union
-    select ac.ActionId, authorization_strategy_id, ResourceClaimId, cast(null as int)
+    select ac.ActionId, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
@@ -389,7 +391,7 @@ begin
         where ActionName IN ('Create')) as ac on true
     where ResourceName IN ('educationOrganizations', 'credential', 'people', 'identity', 'person')
     union
-    select ac.ActionId, authorization_strategy_id, ResourceClaimId, cast(null as int)
+    select ac.ActionId, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
@@ -397,7 +399,7 @@ begin
         where ActionName IN ('Update')) as ac on true
     where ResourceName IN ('educationOrganizations', 'identity', 'credential', 'person' )
     union
-    select ac.ActionId, authorization_strategy_id, ResourceClaimId, cast(null as int) from dbo.ResourceClaims
+    select ac.ActionId, ResourceClaimId, cast(null as int) from dbo.ResourceClaims
     inner join lateral
         (select ActionId
         from dbo.Actions
@@ -405,14 +407,12 @@ begin
     where ResourceName IN ('educationOrganizations', 'people', 'credential', 'person');
 
     /* NamespaceBased */
-    select AuthorizationStrategyId INTO authorization_strategy_id from dbo.AuthorizationStrategies where AuthorizationStrategyName = 'NamespaceBased';
 
-    insert into dbo.ResourceClaimAuthorizationMetadatas
-        (Action_ActionId
-        ,AuthorizationStrategy_AuthorizationStrategyId
-        ,ResourceClaim_ResourceClaimId
+    insert into dbo.ResourceClaimActions
+        (ActionId
+        ,ResourceClaimId
         ,ValidationRuleSetName)
-    select ac.ActionId, authorization_strategy_id, ResourceClaimId, cast(null as int)
+    select ac.ActionId, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
@@ -420,7 +420,7 @@ begin
         where ActionName IN ('Read')) as ac on true
     where ResourceName IN ('assessmentMetadata', 'educationStandards', 'educationContent', 'surveyDomain' )
     union
-    select ac.ActionId, authorization_strategy_id, ResourceClaimId, cast(null as int)
+    select ac.ActionId, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
@@ -429,14 +429,12 @@ begin
     where ResourceName IN ('systemDescriptors', 'managedDescriptors', 'assessmentMetadata', 'educationStandards', 'educationContent', 'surveyDomain');
 
     /* RelationshipsWithEdOrgsAndPeople */
-    select AuthorizationStrategyId INTO authorization_strategy_id from dbo.AuthorizationStrategies where AuthorizationStrategyName = 'RelationshipsWithEdOrgsAndPeople';
 
-    insert into dbo.ResourceClaimAuthorizationMetadatas
-        (Action_ActionId
-        ,AuthorizationStrategy_AuthorizationStrategyId
-        ,ResourceClaim_ResourceClaimId
+    insert into dbo.ResourceClaimActions
+        (ActionId
+        ,ResourceClaimId
         ,ValidationRuleSetName)
-    select ac.ActionId, authorization_strategy_id, ResourceClaimId, cast(null as int)
+    select ac.ActionId, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
@@ -444,7 +442,7 @@ begin
         where ActionName IN ('Read', 'Update')) as ac on true
     where ResourceName IN ('primaryRelationships', 'studentParentAssociation', 'people', 'relationshipBasedData')
     union
-    select ac.ActionId, authorization_strategy_id, ResourceClaimId, cast(null as int)
+    select ac.ActionId, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
@@ -452,7 +450,7 @@ begin
         where ActionName IN ('Create')) as ac on true
     where ResourceName IN ('relationshipBasedData')
     union
-    select ac.ActionId, authorization_strategy_id, ResourceClaimId, cast(null as int)
+    select ac.ActionId, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
@@ -461,14 +459,12 @@ begin
     where ResourceName IN ('relationshipBasedData', 'studentParentAssociation', 'primaryRelationships');
 
     /* RelationshipsWithStudentsOnly */
-    select AuthorizationStrategyId INTO authorization_strategy_id from dbo.AuthorizationStrategies where AuthorizationStrategyName = 'RelationshipsWithStudentsOnly';
 
-    insert into dbo.ResourceClaimAuthorizationMetadatas
-        (Action_ActionId
-        ,AuthorizationStrategy_AuthorizationStrategyId
-        ,ResourceClaim_ResourceClaimId
+    insert into dbo.ResourceClaimActions
+        (ActionId
+        ,ResourceClaimId
         ,ValidationRuleSetName)
-    select ac.ActionId, authorization_strategy_id, ResourceClaimId, cast(null as int)
+    select ac.ActionId, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
@@ -477,14 +473,12 @@ begin
     where ResourceName IN ('studentParentAssociation');
 
     /* RelationshipsWithEdOrgsOnly */
-    select AuthorizationStrategyId INTO authorization_strategy_id from dbo.AuthorizationStrategies where AuthorizationStrategyName = 'RelationshipsWithEdOrgsOnly';
 
-    insert into dbo.ResourceClaimAuthorizationMetadatas
-        (Action_ActionId
-        ,AuthorizationStrategy_AuthorizationStrategyId
-        ,ResourceClaim_ResourceClaimId
+    insert into dbo.ResourceClaimActions
+        (ActionId
+        ,ResourceClaimId
         ,ValidationRuleSetName)
-    select ac.ActionId, authorization_strategy_id, ResourceClaimId, cast(null as int)
+    select ac.ActionId, ResourceClaimId, cast(null as int)
     from dbo.ResourceClaims
     inner join lateral
         (select ActionId
@@ -492,6 +486,207 @@ begin
         where ActionName IN ('Create')) as ac on true
     where ResourceName IN ('primaryRelationships');
 
+end $$;
+
+/* ------------------------------------------ */
+/* ResourceClaimActionAuthorizationStrategies */
+/* ------------------------------------------ */
+
+/* NoFurtherAuthorizationRequired */
+
+do $$
+    declare authorization_strategy_id int;
+begin
+
+    select AuthorizationStrategyId into authorization_strategy_id
+    from dbo.AuthorizationStrategies
+    where AuthorizationStrategyName = 'NoFurtherAuthorizationRequired';
+
+    insert into dbo.ResourceClaimActionAuthorizationStrategies
+    (ResourceClaimActionId
+    ,AuthorizationStrategyId)
+
+    select RCAA.ResourceClaimActionId,authorization_strategy_id FROM  dbo.ResourceClaimActions RCAA
+    inner join dbo.ResourceClaims RC ON  RC.ResourceClaimId =RCAA.ResourceClaimId
+    inner join dbo.Actions A on A.ActionId = RCAA.ActionId
+    where A.ActionName IN ('Read')
+    and RC.ResourceName IN ('types', 'systemDescriptors', 'educationOrganizations', 'course', 'managedDescriptors', 'identity', 'credential', 'person')
+
+    union
+
+    select RCAA.ResourceClaimActionId,authorization_strategy_id FROM  dbo.ResourceClaimActions RCAA
+        inner join dbo.ResourceClaims RC ON  RC.ResourceClaimId =RCAA.ResourceClaimId
+        inner join dbo.Actions A on A.ActionId = RCAA.ActionId
+        where A.ActionName IN ('Create')
+        and RC.ResourceName IN ('educationOrganizations', 'credential', 'people', 'identity', 'person')
+
+    union
+
+    select RCAA.ResourceClaimActionId,authorization_strategy_id FROM  dbo.ResourceClaimActions RCAA
+        inner join dbo.ResourceClaims RC ON  RC.ResourceClaimId =RCAA.ResourceClaimId
+        inner join dbo.Actions A on A.ActionId = RCAA.ActionId
+        where A.ActionName IN ('Update')
+        and RC.ResourceName IN ('educationOrganizations', 'identity', 'credential', 'person' )
+
+    union
+
+    select RCAA.ResourceClaimActionId,authorization_strategy_id FROM  dbo.ResourceClaimActions RCAA
+        inner join dbo.ResourceClaims RC ON  RC.ResourceClaimId =RCAA.ResourceClaimId
+        inner join dbo.Actions A on A.ActionId = RCAA.ActionId
+        where A.ActionName IN ('Delete')
+        and RC.ResourceName IN ('educationOrganizations', 'people', 'credential', 'person');
+
+
+/* NamespaceBased */
+
+    select AuthorizationStrategyId into authorization_strategy_id
+    from dbo.AuthorizationStrategies
+    where AuthorizationStrategyName = 'NamespaceBased';
+
+    insert into dbo.ResourceClaimActionAuthorizationStrategies
+    (ResourceClaimActionId
+    ,AuthorizationStrategyId)
+
+    select RCAA.ResourceClaimActionId,authorization_strategy_id FROM  dbo.ResourceClaimActions RCAA
+    inner join dbo.ResourceClaims RC on  RC.ResourceClaimId =RCAA.ResourceClaimId
+    inner join dbo.Actions A on A.ActionId = RCAA.ActionId
+    where A.ActionName in ('Read')
+    and RC.ResourceName in ('assessmentMetadata', 'educationStandards', 'educationContent', 'surveyDomain' )
+    union
+    select RCAA.ResourceClaimActionId,authorization_strategy_id FROM  dbo.ResourceClaimActions RCAA
+    inner join dbo.ResourceClaims RC on  RC.ResourceClaimId =RCAA.ResourceClaimId
+    inner join dbo.Actions A on A.ActionId = RCAA.ActionId
+    where A.ActionName in ('Create', 'Update', 'Delete')
+    and RC.ResourceName in ('systemDescriptors', 'managedDescriptors', 'assessmentMetadata', 'educationStandards', 'educationContent', 'surveyDomain');
+
+
+
+
+/* RelationshipsWithEdOrgsAndPeople */
+
+    select AuthorizationStrategyId into authorization_strategy_id
+    from dbo.AuthorizationStrategies
+    where AuthorizationStrategyName = 'RelationshipsWithEdOrgsAndPeople';
+
+    insert into dbo.ResourceClaimActionAuthorizationStrategies
+    (ResourceClaimActionId
+    ,AuthorizationStrategyId)
+    select RCAA.ResourceClaimActionId,authorization_strategy_id FROM  dbo.ResourceClaimActions RCAA
+    inner join dbo.ResourceClaims RC on  RC.ResourceClaimId =RCAA.ResourceClaimId
+    inner join dbo.Actions A on A.ActionId = RCAA.ActionId
+    where A.ActionName in ('Read', 'Update')
+    and RC.ResourceName in ('primaryRelationships', 'studentParentAssociation', 'people', 'relationshipBasedData')
+	union
+	select RCAA.ResourceClaimActionId,authorization_strategy_id FROM  dbo.ResourceClaimActions RCAA
+    inner join dbo.ResourceClaims RC on  RC.ResourceClaimId =RCAA.ResourceClaimId
+    inner join dbo.Actions A on A.ActionId = RCAA.ActionId
+    where A.ActionName in ('Create')
+    and RC.ResourceName in ('relationshipBasedData')
+	union
+    select RCAA.ResourceClaimActionId,authorization_strategy_id FROM  dbo.ResourceClaimActions RCAA
+    inner join dbo.ResourceClaims RC on  RC.ResourceClaimId =RCAA.ResourceClaimId
+    inner join dbo.Actions A on A.ActionId = RCAA.ActionId
+    where A.ActionName in ('Delete')
+    and RC.ResourceName in ('relationshipBasedData', 'studentParentAssociation', 'primaryRelationships');
+
+
+/* RelationshipsWithStudentsOnly */
+
+select AuthorizationStrategyId into authorization_strategy_id
+from dbo.AuthorizationStrategies
+where AuthorizationStrategyName = 'RelationshipsWithStudentsOnly';
+
+insert into dbo.ResourceClaimActionAuthorizationStrategies
+    (ResourceClaimActionId
+    ,AuthorizationStrategyId)
+select RCAA.ResourceClaimActionId,authorization_strategy_id FROM  dbo.ResourceClaimActions RCAA
+    inner join dbo.ResourceClaims RC on  RC.ResourceClaimId =RCAA.ResourceClaimId
+    inner join dbo.Actions A on A.ActionId = RCAA.ActionId
+    where A.ActionName in ('Create')
+    and RC.ResourceName in ('studentParentAssociation');
+
+/* RelationshipsWithEdOrgsOnly */
+
+select AuthorizationStrategyId into authorization_strategy_id
+from dbo.AuthorizationStrategies
+where AuthorizationStrategyName = 'RelationshipsWithEdOrgsOnly';
+
+insert into dbo.ResourceClaimActionAuthorizationStrategies
+    (ResourceClaimActionId
+    ,AuthorizationStrategyId)
+select RCAA.ResourceClaimActionId,authorization_strategy_id FROM  dbo.ResourceClaimActions RCAA
+    inner join dbo.ResourceClaims RC on  RC.ResourceClaimId =RCAA.ResourceClaimId
+    inner join dbo.Actions A on A.ActionId = RCAA.ActionId
+    where A.ActionName in ('Create')
+    and RC.ResourceName in ('primaryRelationships');
+
+end $$;
+
+/* --------------------------------------------------------------- */
+/*     ClaimSetResourceClaimActionAuthorizationStrategyOverrides   */
+/* --------------------------------------------------------------- */
+
+/* Bootstrap Descriptors and EdOrgs Claims */
+
+do $$
+    declare claim_set_id int;
+    declare authorization_strategy_id int;
+begin
+
+select AuthorizationStrategyId into authorization_strategy_id
+from dbo.AuthorizationStrategies
+where AuthorizationStrategyName = 'NoFurtherAuthorizationRequired';
+
+select ClaimSetId INTO claim_set_id from dbo.ClaimSets where ClaimSetName = 'Ed-Fi Sandbox';
+
+insert into dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides
+    (ClaimSetResourceClaimActionId
+    ,AuthorizationStrategyId)
+select CSRCAA.ClaimSetResourceClaimActionId,authorization_strategy_id FROM  dbo.ClaimSetResourceClaimActions CSRCAA
+    inner join dbo.ResourceClaims RC on  RC.ResourceClaimId =CSRCAA.ResourceClaimId
+    inner join dbo.Actions A on A.ActionId = CSRCAA.ActionId
+    inner join dbo.ClaimSets CS on CS.ClaimSetId = CSRCAA.ClaimSetId
+    where CS.ClaimSetId = claim_set_id
+    and A.ActionName in ('Create','Read','Update','Delete')
+    and RC.ResourceName in ('communityProviderLicense');
+
+select ClaimSetId INTO claim_set_id from dbo.ClaimSets where ClaimSetName = 'Bootstrap Descriptors and EdOrgs';
+
+insert into dbo.ClaimSetResourceClaimActionAuthorizationStrategyOverrides
+    (ClaimSetResourceClaimActionId
+    ,AuthorizationStrategyId)
+select CSRCAA.ClaimSetResourceClaimActionId,authorization_strategy_id FROM  dbo.ClaimSetResourceClaimActions CSRCAA
+    inner join dbo.ResourceClaims RC on  RC.ResourceClaimId =CSRCAA.ResourceClaimId
+    inner join dbo.Actions A on A.ActionId = CSRCAA.ActionId
+    inner join dbo.ClaimSets CS on CS.ClaimSetId = CSRCAA.ClaimSetId
+    where CS.ClaimSetId = claim_set_id
+    and A.ActionName in ('Create')
+    and RC.ResourceName in (
+	'systemDescriptors',
+    'managedDescriptors',
+    'educationOrganizations',
+    -- from Interchange-Standards.xml
+    'learningObjective',
+    'learningStandard',
+    'learningStandardEquivalenceAssociation',
+    -- from Interchange-EducationOrganization.xml
+    'accountabilityRating',
+    'classPeriod',
+    'communityOrganization',
+    'communityProvider',
+    'communityProviderLicense',
+    'course',
+    'educationOrganizationNetwork',
+    'educationOrganizationNetworkAssociation',
+    'educationOrganizationPeerAssociation',
+    'educationServiceCenter',
+    'feederSchoolAssociation',
+    'localEducationAgency',
+    'location',
+    'postSecondaryInstitution',
+    'program',
+    'school',
+    'stateEducationAgency');
 end $$;
 
 commit;

--- a/Utilities/CodeGeneration/README.md
+++ b/Utilities/CodeGeneration/README.md
@@ -14,12 +14,12 @@ Ed-Fi ODS software developers and implementers.
 
 ## Prerequisites
 To build the application the following tools are needed:
-* .NET Core 3.1 SDK (https://dotnet.microsoft.com/download)
-* Visual Studio 2019 (https://visualstudio.microsoft.com/downloads/)
+* .NET 6 SDK (https://dotnet.microsoft.com/download)
+* Visual Studio 2022 (https://visualstudio.microsoft.com/downloads/)
 
 ## Testing the generated artifacts against the main solution
 * Run `initdev` on the main solution first
 * run `Rebuild-Solution` or `initdev -NoCodegen`
 
 ## Known issues
-* must use Visual Studio 2019+ netcore 3.1 is not compatible with Visual Studio 2017
+* must use Visual Studio 2022+ net6 is not compatible with Visual Studio 2019

--- a/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj
+++ b/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
@@ -21,8 +21,8 @@
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="aqua-graphcompare" Version="1.2.2" />
-      <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
-      <PackageReference Include="EdFi.Suite3.OdsApi.TestSdk" Version="5.3.243" />
+      <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
+      <PackageReference Include="EdFi.Suite3.OdsApi.TestSdk" Version="5.4.3" />
       <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
       <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
       <PackageReference Include="log4net" Version="2.0.13" />

--- a/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.3.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
     <PackageReference Include="log4net" Version="2.0.13" />

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
     <PackageReference Include="log4net" Version="2.0.13" />

--- a/Utilities/DataLoading/EdFi.XmlLookup.Console/EdFi.XmlLookup.Console.csproj
+++ b/Utilities/DataLoading/EdFi.XmlLookup.Console/EdFi.XmlLookup.Console.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />

--- a/tests/EdFi.Admin.DataAccess.UnitTests/EdFi.Admin.DataAccess.UnitTests.csproj
+++ b/tests/EdFi.Admin.DataAccess.UnitTests/EdFi.Admin.DataAccess.UnitTests.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />

--- a/tests/EdFi.Common.UnitTests/Inflection/InflectorTests.cs
+++ b/tests/EdFi.Common.UnitTests/Inflection/InflectorTests.cs
@@ -6,6 +6,7 @@
 using System.Linq;
 using EdFi.Common.Inflection;
 using NUnit.Framework;
+using Shouldly;
 
 namespace EdFi.Ods.Common.UnitTests.Inflection
 {
@@ -94,6 +95,53 @@ namespace EdFi.Ods.Common.UnitTests.Inflection
             Assert.IsTrue(result.Contains("BravoCharlie"));
             Assert.IsTrue(result.Contains("Charlie"));
             Assert.IsFalse(result.Contains(string.Empty));
+        }
+
+        [Test]
+        public void Words_are_inflected_to_singular_and_plural_forms_based_on_supplied_count_correctly()
+        {
+            "".ShouldSatisfyAllConditions(
+                // Singular form supplied
+                () => Inflector.Inflect("dog", 0).ShouldBe("dogs"),
+                () => Inflector.Inflect("dog", 1).ShouldBe("dog"),
+                () => Inflector.Inflect("dog", 2).ShouldBe("dogs"),
+                
+                // Plural form supplied
+                () => Inflector.Inflect("dogs", 0).ShouldBe("dogs"),
+                () => Inflector.Inflect("dogs", 1).ShouldBe("dog"),
+                () => Inflector.Inflect("dogs", 2).ShouldBe("dogs"),
+                
+                // Singular form supplied
+                () => Inflector.Inflect("doggy", 0).ShouldBe("doggies"),
+                () => Inflector.Inflect("doggy", 1).ShouldBe("doggy"),
+                () => Inflector.Inflect("doggy", 2).ShouldBe("doggies"),
+                
+                // Plural form supplied
+                () => Inflector.Inflect("doggies", 0).ShouldBe("doggies"),
+                () => Inflector.Inflect("doggies", 1).ShouldBe("doggy"),
+                () => Inflector.Inflect("doggies", 2).ShouldBe("doggies")
+            );
+        }
+        
+        [Test]
+        public void Words_are_inflected_using_overridden_singular_and_plural_forms_based_on_supplied_count_correctly()
+        {
+            "".ShouldSatisfyAllConditions(
+                // No overrides, showing default Inflection behavior
+                () => Inflector.Inflect("do", 0).ShouldBe("dos"),
+                () => Inflector.Inflect("do", 1).ShouldBe("do"),
+                () => Inflector.Inflect("do", 2).ShouldBe("dos"),
+                
+                // Overrides, showing Inflection using overrides
+                () => Inflector.Inflect("do", 0, "does", "do").ShouldBe("do"),
+                () => Inflector.Inflect("do", 1, "does", "do").ShouldBe("does"),
+                () => Inflector.Inflect("do", 2, "does", "do").ShouldBe("do"),
+                
+                // Overrides, showing Inflection using overrides (ignoring the supplied word completely)
+                () => Inflector.Inflect(null, 0, "does", "do").ShouldBe("do"),
+                () => Inflector.Inflect(null, 1, "does", "do").ShouldBe("does"),
+                () => Inflector.Inflect(null, 2, "does", "do").ShouldBe("do")
+            );
         }
     }
 }

--- a/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
+++ b/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
@@ -25,13 +25,13 @@
     <ProjectReference Include="..\EdFi.TestFixture\EdFi.TestFixture.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.3.43" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.3.43" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.2" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.2" />
     <PackageReference Include="NHibernate" Version="5.3.10" />
     <PackageReference Include="ApprovalTests" Version="5.7.1" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />

--- a/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/FakedAuthenticationProvider.cs
+++ b/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/FakedAuthenticationProvider.cs
@@ -31,7 +31,7 @@ namespace EdFi.Ods.WebApi.CompositeSpecFlowTests
             _identity = new Lazy<ClaimsIdentity>(
                 () => claimsIdentityProvider
                     .GetClaimsIdentity(
-                        _educationOrganizationIds.Value, ClaimSetName, _namespacePrefixes.Value, new List<string>()));
+                        _educationOrganizationIds.Value, ClaimSetName, _namespacePrefixes.Value, new List<string>(), new List<short?>()));
 
             _apiKeyContext = new Lazy<ApiKeyContext>(
                 () => new ApiKeyContext(

--- a/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
+++ b/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
@@ -13,14 +13,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.3.43" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.3.43" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.2" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.2" />
     <PackageReference Include="NHibernate" Version="5.3.10" />
     <PackageReference Include="ApprovalTests" Version="5.7.1" />
     <PackageReference Include="ApprovalUtilities" Version="5.7.1" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />

--- a/tests/EdFi.Ods.WebApi.IntegrationTests/FakedAuthenticationProvider.cs
+++ b/tests/EdFi.Ods.WebApi.IntegrationTests/FakedAuthenticationProvider.cs
@@ -31,7 +31,7 @@ namespace EdFi.Ods.WebApi.IntegrationTests
             _identity = new Lazy<ClaimsIdentity>(
                 () => claimsIdentityProvider
                     .GetClaimsIdentity(
-                        _educationOrganizationIds.Value, ClaimSetName, _namespacePrefixes.Value, new List<string>()));
+                        _educationOrganizationIds.Value, ClaimSetName, _namespacePrefixes.Value, new List<string>(), new List<short?>()));
 
             _apiKeyContext = new Lazy<ApiKeyContext>(
                 () => new ApiKeyContext(

--- a/tests/EdFi.Security.DataAccess.UnitTests/EdFi.Security.DataAccess.UnitTests.csproj
+++ b/tests/EdFi.Security.DataAccess.UnitTests/EdFi.Security.DataAccess.UnitTests.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFrameworkTesting.FakeItEasy" Version="1.3.0" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />

--- a/tests/EdFi.Security.DataAccess.UnitTests/StubSecurityContext.cs
+++ b/tests/EdFi.Security.DataAccess.UnitTests/StubSecurityContext.cs
@@ -27,9 +27,11 @@ namespace EdFi.Security.DataAccess.UnitTests
             securityContext.Actions = GetFakeDbSet<Action>().SetupData();
             securityContext.AuthorizationStrategies = GetFakeDbSet<AuthorizationStrategy>().SetupData();
             securityContext.ClaimSets = GetFakeDbSet<ClaimSet>().SetupData();
-            securityContext.ClaimSetResourceClaims = GetFakeDbSet<ClaimSetResourceClaim>().SetupData();
+            securityContext.ClaimSetResourceClaimActions = GetFakeDbSet<ClaimSetResourceClaimAction>().SetupData();
             securityContext.ResourceClaims = GetFakeDbSet<ResourceClaim>().SetupData();
-            securityContext.ResourceClaimAuthorizationMetadatas = GetFakeDbSet<ResourceClaimAuthorizationMetadata>().SetupData();
+            securityContext.ResourceClaimActions = GetFakeDbSet<ResourceClaimAction>().SetupData();
+            securityContext.ClaimSetResourceClaimActionAuthorizationStrategyOverrides = GetFakeDbSet<ClaimSetResourceClaimActionAuthorizationStrategyOverrides>().SetupData();
+            securityContext.ResourceClaimActionAuthorizationStrategies = GetFakeDbSet<ResourceClaimActionAuthorizationStrategies>().SetupData();
 
             return securityContext;
         }


### PR DESCRIPTION
After updating to .NET 6, some of the code gen tests were no longer passing. This updates the approved files to match how they should look after recent changes so they now pass.

The CodeGen readme was also updated to reference .NET 6 and VS2022 being required now.