### PR TITLE
ODS-5273 - Downgrade Nhibernate to previous version from before net6 upgrade

### DIFF
--- a/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
+++ b/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
-    <PackageReference Include="NHibernate" Version="5.3.10" />
+    <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="Npgsql" Version="4.1.5" />
     <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="Remotion.Linq" Version="2.2.0" />

--- a/Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj
+++ b/Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="FluentValidation" Version="8.6.3" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NHibernate" Version="5.3.10" />
+    <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="Npgsql" Version="4.1.5" />
     <PackageReference Include="Sandwych.QuickGraph.Core" Version="1.0.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
+++ b/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NHibernate" Version="5.3.10" />
+    <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Application/EdFi.Ods.Standard/EdFi.Ods.Standard.csproj
+++ b/Application/EdFi.Ods.Standard/EdFi.Ods.Standard.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NHibernate" Version="5.3.10" />
+    <PackageReference Include="NHibernate" Version="5.2.7" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.2" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.2" />
-    <PackageReference Include="NHibernate" Version="5.3.10" />
+    <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="Autofac.Extras.FakeItEasy" Version="7.0.0" />
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="CompareNETObjects" Version="4.74.0" />

--- a/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
+++ b/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.2" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.2" />
-    <PackageReference Include="NHibernate" Version="5.3.10" />
+    <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="ApprovalTests" Version="5.7.1" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="Dapper" Version="2.0.123" />

--- a/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
+++ b/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.2" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.2" />
-    <PackageReference Include="NHibernate" Version="5.3.10" />
+    <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="ApprovalTests" Version="5.7.1" />
     <PackageReference Include="ApprovalUtilities" Version="5.7.1" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />


### PR DESCRIPTION
Part of the .NET6 upgrade also updated the Nhibernate package, and once upgraded, there were TypeExceptions being thrown on a number of smoke tests and Repository tests. Downgrading back to the previous version fixes this. Another ticket will be opened to investigate what is needed to get the latest version of NHibernate working.

With ODS-5242 still being under review in PR #424  not all tests will be working on this branch, but if you apply its commits to this branch and do the same for the ODS-Implementation repo, you should see everything working.