### PR TITLE
ODS-5250 - Update DataLoading to NET6

### DIFF
--- a/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj
+++ b/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RestorePackages>true</RestorePackages>
     <Configurations>Debug;Release</Configurations>

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/JsonMetadataTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/JsonMetadataTests.cs
@@ -37,7 +37,7 @@ namespace EdFi.LoadTools.Test
         }
 
         [Test]
-        [Category("Run Manually")]
+        [Category("RunManually")]
         public void Should_display_all_Json_metadata()
         {
             var loader = new SwaggerMetadataRetriever(

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/MappingFactories/LookupToGetByExampleMetadataMappingFactoryTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/MappingFactories/LookupToGetByExampleMetadataMappingFactoryTests.cs
@@ -57,7 +57,7 @@ namespace EdFi.LoadTools.Test.MappingFactories
         }
 
         [Test]
-        [Category("Run Manually")]
+        [Category("RunManually")]
         public void Should_map_lookup_to_getByExample()
         {
             foreach (var m in _mappings.OrderBy(x => x.SourceName))

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/MappingFactories/LookupToIdentityMetadataMappingFactoryTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/MappingFactories/LookupToIdentityMetadataMappingFactoryTests.cs
@@ -35,7 +35,7 @@ namespace EdFi.LoadTools.Test.MappingFactories
         }
 
         [Test]
-        [Category("Run Manually")]
+        [Category("RunManually")]
         public void Should_map_lookup_to_identity()
         {
             foreach (var mapping in _mappings.OrderBy(x => x.SourceName))

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/MappingFactories/ResourceToIdentityMetadataMappingFactoryTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/MappingFactories/ResourceToIdentityMetadataMappingFactoryTests.cs
@@ -54,7 +54,7 @@ namespace EdFi.LoadTools.Test.MappingFactories
         }
 
         [Test]
-        [Category("Run Manually")]
+        [Category("RunManually")]
         public void Should_map_resource_to_identity()
         {
             foreach (var mapping in _mappings.OrderBy(x => x.SourceName))

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/MappingFactories/ResourceToResourceMetadataMappingFactoryTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/MappingFactories/ResourceToResourceMetadataMappingFactoryTests.cs
@@ -51,7 +51,7 @@ namespace EdFi.LoadTools.Test.MappingFactories
         }
 
         [Test]
-        [Category("Run Manually")]
+        [Category("RunManually")]
         public void Should_map_resource_to_resource()
         {
             foreach (var m in _mappings.OrderBy(x => x.SourceName))

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/OAuthTokenHandlerTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/OAuthTokenHandlerTests.cs
@@ -14,7 +14,7 @@ using NUnit.Framework;
 namespace EdFi.LoadTools.Test
 {
     /// <summary>
-    ///     These tests are meant to be run manually with a functioning API
+    ///     These tests are meant to be RunManually with a functioning API
     /// </summary>
     [TestFixture]
     public class OAuthTokenHandlerTests
@@ -31,7 +31,7 @@ namespace EdFi.LoadTools.Test
         }
 
         [Test]
-        [Category("Run Manually")]
+        [Category("RunManually")]
         public void ShouldSuccessfullyRetrieveBearerToken()
         {
             var config = new TestOAuthConfiguration

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/ReadMe.md
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/ReadMe.md
@@ -1,2 +1,2 @@
 ﻿*Testing Instructions
-The tests labeled as "Run Manually" require a running Ed-Fi ODS API with a known key and secret. Configuration for these tests may be changed in the app.config file of this project.
+The tests labeled as "RunManually" require a running Ed-Fi ODS API with a known key and secret. Configuration for these tests may be changed in the app.config file of this project.

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/ModelDependencySortTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/ModelDependencySortTests.cs
@@ -86,7 +86,7 @@ namespace EdFi.LoadTools.Test.SmokeTests
         }
 
         [Test]
-        [Category("Run Manually")]
+        [Category("RunManually")]
         public void Should_order_types_from_Sdk()
         {
             var cat = new SdkCategorizer(SdkLibraryFactory);
@@ -100,7 +100,7 @@ namespace EdFi.LoadTools.Test.SmokeTests
         }
 
         [Test]
-        [Category("Run Manually")]
+        [Category("RunManually")]
         public void Should_order_Apis_from_Sdk()
         {
             var cat = new SdkCategorizer(SdkLibraryFactory);

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SwaggerRetrieverTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SwaggerRetrieverTests.cs
@@ -28,7 +28,7 @@ namespace EdFi.LoadTools.Test
         }
 
         [Test]
-        [Category("Run Manually")]
+        [Category("RunManually")]
         public async Task Should_retrieve_swagger_information()
         {
             var retriever = new SwaggerRetriever(new TestApiMetadataConfiguration(_configuration));

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/XsdFileRetrieverTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/XsdFileRetrieverTests.cs
@@ -56,7 +56,12 @@ namespace EdFi.LoadTools.Test
                     new Dictionary<string, string>
                     {
                         {"name", "Ed-Fi"},
-                        {"version", "3.2.0-c"}
+                        {"version", "3.3.1-b"}
+                    },
+                    new Dictionary<string, string>
+                    {
+                        {"name", "TPDM"},
+                        {"version", "1.1.0"}
                     }
                 }
             };

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/XsdFileRetrieverTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/XsdFileRetrieverTests.cs
@@ -46,7 +46,7 @@ namespace EdFi.LoadTools.Test
         }
 
         [Test]
-        [Category("Run Manually")]
+        [Category("RunManually")]
         public async Task Should_get_xsd_metadata_information_and_download_files()
         {
             var odsVersionInformation = new OdsVersionInformation

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/XsdMetadataRetrievalTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/XsdMetadataRetrievalTests.cs
@@ -33,7 +33,7 @@ namespace EdFi.LoadTools.Test
             }
 
             [Test]
-            [Category("Run Manually")]
+            [Category("RunManually")]
             public void Should_display_all_Xml_metadata()
             {
                 Assert.IsTrue(_metadata.Any());

--- a/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RestorePackages>true</RestorePackages>
     <Configurations>Debug;Release</Configurations>

--- a/Utilities/DataLoading/EdFi.LoadTools/Engine/HashProvider.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/Engine/HashProvider.cs
@@ -13,7 +13,7 @@ namespace EdFi.LoadTools.Engine
     public class HashProvider : IHashProvider
     {
         private readonly ThreadLocal<HashAlgorithm> _algorithm =
-            new ThreadLocal<HashAlgorithm>(() => new SHA1CryptoServiceProvider());
+            new ThreadLocal<HashAlgorithm>(SHA1.Create);
 
         public int Bytes => _algorithm.Value.HashSize / 8;
 

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/BaseBuilder.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/BaseBuilder.cs
@@ -48,12 +48,12 @@ namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
             // if necessary in the future.
             const string alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
             var res = new StringBuilder(length);
-            using (var rng = new RNGCryptoServiceProvider())
+            using (var rng = RandomNumberGenerator.Create())
             {
                 int count = (int)Math.Ceiling(Math.Log(alphabet.Length, 2) / 8.0);
                 Debug.Assert(count <= sizeof(uint));
                 int offset = BitConverter.IsLittleEndian ? 0 : sizeof(uint) - count;
-                int max = (int)(Math.Pow(2, count*8) / alphabet.Length) * alphabet.Length;
+                int max = (int)(Math.Pow(2, count * 8) / alphabet.Length) * alphabet.Length;
                 byte[] uintBuffer = new byte[sizeof(uint)];
 
                 while (res.Length < length)
@@ -62,11 +62,10 @@ namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
                     uint num = BitConverter.ToUInt32(uintBuffer, 0);
                     if (num < max)
                     {
-                        res.Append(alphabet[(int) (num % alphabet.Length)]);
+                        res.Append(alphabet[(int)(num % alphabet.Length)]);
                     }
                 }
             }
-
             return res.ToString();
         }
 

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RestorePackages>true</RestorePackages>
     <Configurations>Debug;Release</Configurations>

--- a/Utilities/DataLoading/EdFi.XmlLookup.Console/EdFi.XmlLookup.Console.csproj
+++ b/Utilities/DataLoading/EdFi.XmlLookup.Console/EdFi.XmlLookup.Console.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EdFi.XmlLookup.Console</AssemblyName>
     <RootNamespace>EdFi.XmlLookup.Console</RootNamespace>
     <Copyright>Copyright © 2020 Ed-Fi Alliance, LLC and Contributors</Copyright>


### PR DESCRIPTION
In addition to updating it to NET6, the test cases that are for running manually had to be renamed to remove the space, since there is a current [bug](https://github.com/nunit/nunit3-vs-adapter/issues/876) in the NUnit Test Adapter causing filtering to not work on categories with spaces in them.

A related PR that has now been merged updated the Kotlin builds for the load tools [here](https://github.com/Ed-Fi-Alliance/Ed-Fi-TeamCity-Configs/pull/44) to update the build step to match the change from 'Run Manually' to 'RunManually'.

A successful build after that related PR was merged can be found [here](https://intedfitools1.msdf.org/buildConfiguration/OdsPlatform_OdsImplementationKotlin_EdFiLoadTools_BranchBuild/153248)