### PR TITLE
ODS-5246 - Update SDKGen to target net6

### DIFF
--- a/Utilities/SdkGen/EdFi.SdkGen.Console/EdFi.SdkGen.Console.csproj
+++ b/Utilities/SdkGen/EdFi.SdkGen.Console/EdFi.SdkGen.Console.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 	<ItemGroup>
     <None Remove="readme.txt" />
@@ -13,8 +13,8 @@
   </ItemGroup>
 	<ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="log4net" Version="2.0.12" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="log4net" Version="2.0.13" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 	<ItemGroup>
     <None Update="EdFi.OdsApi.Sdk.nuspec">


### PR DESCRIPTION
Also updated nuget packages to match versions they were updated to in other projects. Latest log4net is now 2.0.14, but since other projects were updated to 2.0.13, it was updated only to that version.

No updates were needed to the implementation repo since all the relevant packages pull "latest"