### PR TITLE
[ODS-5247] Update Npgsql and HealthChecks libraries

### DIFF
--- a/Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj
+++ b/Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="log4net" Version="2.0.13" />

--- a/Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj
+++ b/Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="log4net" Version="2.0.13" />
-    <PackageReference Include="Npgsql" Version="4.1.5" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
   </ItemGroup>
   <ItemGroup>
     <None Include="../../LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />

--- a/Application/EdFi.Common/EdFi.Common.csproj
+++ b/Application/EdFi.Common/EdFi.Common.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="log4net" Version="2.0.13" />
-    <PackageReference Include="Npgsql" Version="4.1.5" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
   </ItemGroup>
 </Project>

--- a/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
+++ b/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
@@ -21,9 +21,9 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.1" />
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.19" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.9" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.20" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.10" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />

--- a/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
+++ b/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
@@ -19,8 +19,8 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="3.1.1" />
-    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.1.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.1" />
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.19" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.9" />
@@ -37,7 +37,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="NHibernate" Version="5.2.7" />
-    <PackageReference Include="Npgsql" Version="4.1.5" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="Remotion.Linq" Version="2.2.0" />
     <PackageReference Include="Remotion.Linq.EagerFetching" Version="2.2.0" />

--- a/Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj
+++ b/Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NHibernate" Version="5.2.7" />
-    <PackageReference Include="Npgsql" Version="4.1.5" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="Sandwych.QuickGraph.Core" Version="1.0.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />

--- a/Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj
+++ b/Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj
@@ -16,7 +16,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
+++ b/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
@@ -17,9 +17,9 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="Autofac" Version="6.3.0" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.9" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.10" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />

--- a/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
+++ b/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
@@ -13,8 +13,8 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.19" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.20" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="Dapper" Version="2.0.123" />

--- a/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
+++ b/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
@@ -18,10 +18,10 @@
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="Npgsql" Version="4.1.5" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Npgsql" Version="4.1.5" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
@@ -17,13 +17,13 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.19" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.9" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.20" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.10" />
     <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="Autofac.Extras.FakeItEasy" Version="7.0.0" />
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="CompareNETObjects" Version="4.74.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFrameworkTesting.FakeItEasy" Version="1.3.0" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Npgsql" Version="4.1.5" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj
+++ b/Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
-    <PackageReference Include="Npgsql" Version="4.1.5" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />

--- a/Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj
+++ b/Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj
@@ -15,7 +15,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="Npgsql" Version="6.0.3" />

--- a/Application/EdFi.TestObjects/EdFi.TestObjects.csproj
+++ b/Application/EdFi.TestObjects/EdFi.TestObjects.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/Application/Test.Common/Test.Common.csproj
+++ b/Application/Test.Common/Test.Common.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.9" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.10" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj
+++ b/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
@@ -21,7 +21,7 @@
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="aqua-graphcompare" Version="1.2.2" />
-      <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
+      <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
       <PackageReference Include="EdFi.Suite3.OdsApi.TestSdk" Version="5.4.38" />
       <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
       <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />

--- a/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.3.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
     <PackageReference Include="log4net" Version="2.0.13" />

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
     <PackageReference Include="log4net" Version="2.0.13" />

--- a/Utilities/DataLoading/EdFi.XmlLookup.Console/EdFi.XmlLookup.Console.csproj
+++ b/Utilities/DataLoading/EdFi.XmlLookup.Console/EdFi.XmlLookup.Console.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />

--- a/tests/EdFi.Admin.DataAccess.UnitTests/EdFi.Admin.DataAccess.UnitTests.csproj
+++ b/tests/EdFi.Admin.DataAccess.UnitTests/EdFi.Admin.DataAccess.UnitTests.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />

--- a/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
+++ b/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
@@ -25,13 +25,13 @@
     <ProjectReference Include="..\EdFi.TestFixture\EdFi.TestFixture.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.19" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.9" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.20" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.10" />
     <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="ApprovalTests" Version="5.7.1" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />

--- a/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
+++ b/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
@@ -13,14 +13,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.19" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.9" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.20" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.10" />
     <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="ApprovalTests" Version="5.7.1" />
     <PackageReference Include="ApprovalUtilities" Version="5.7.1" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />

--- a/tests/EdFi.Security.DataAccess.UnitTests/EdFi.Security.DataAccess.UnitTests.csproj
+++ b/tests/EdFi.Security.DataAccess.UnitTests/EdFi.Security.DataAccess.UnitTests.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFrameworkTesting.FakeItEasy" Version="1.3.0" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />


### PR DESCRIPTION
Cannot write DateTime with Kind=UTC to PostgreSQL type 'timestamp without time zone', consider using 'timestamp with time zone'. Note that it's not possible to mix DateTimes with different Kinds in an array/range. See the Npgsql.EnableLegacyTimestampBehavior AppContext switch to enable legacy behavior.

I was getting above error after upgrading to Npgsql package to "6.0.3"  .Basically posgreSQl default to timestamp with time zone  now So I added additional code to make it work like before with  AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
And then it will use timestamp without time zone for ClientAccessToken class - Expiration property for example here
Reference Links
https://stackoverflow.com/questions/70643895/how-to-say-datetime-timestamp-without-time-zone-in-ef-core-6-0
https://github.com/npgsql/doc/blob/main/conceptual/Npgsql/types/datetime.md/
https://github.com/npgsql/efcore.pg/issues/2000

Note
One of the builds here is currently failing due to a previous merge causing builds to fail on main. Once that is addressed this PR will be updated.