### PR TITLE
ODS-5301 - Update composite test to use ClaimEdOrg filtering

### DIFF
--- a/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/CompositeResourcesCanBeDefinedThroughXmlFeature.CompositeIncludesLinkedCollectionWithProperties.approved.txt
+++ b/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/CompositeResourcesCanBeDefinedThroughXmlFeature.CompositeIncludesLinkedCollectionWithProperties.approved.txt
@@ -5,9 +5,9 @@ select
 from 
 	EdFi.Ods.Entities.NHibernate.QueryModels.StudentAggregate.EdFi.StudentQ comp_aaa
 where comp_aaa.Id = :Id AND (comp_aaa.StudentUSI IN (
-                            SELECT fltr_aad.StudentUSI 
-                            FROM EdFi.Ods.Entities.NHibernate.QueryModels.Views.auth_EducationOrganizationIdToStudentUSI fltr_aad 
-                            WHERE fltr_aad.SourceEducationOrganizationId IN (:LocalEducationAgencyId)))
+                    SELECT fltr_aad.StudentUSI 
+                    FROM EdFi.Ods.Entities.NHibernate.QueryModels.Views.auth_EducationOrganizationIdToStudentUSI fltr_aad 
+                    WHERE fltr_aad.SourceEducationOrganizationId IN (:ClaimEducationOrganizationIds)))
 order by comp_aaa.StudentUSI
 HQL:
 select 
@@ -24,12 +24,12 @@ from
 	join comp_aaa.StudentAcademicRecords comp_aab
 		left join comp_aab.TermDescriptor comp_aac 
 where comp_aaa.StudentUSI IN (:BaseEntityId) AND (comp_aab.EducationOrganizationId IN (
-                        SELECT fltr_aax.TargetEducationOrganizationId 
-                        FROM EdFi.Ods.Entities.NHibernate.QueryModels.Views.auth_EducationOrganizationIdToEducationOrganizationId fltr_aax 
-                        WHERE fltr_aax.SourceEducationOrganizationId IN (:LocalEducationAgencyId))) AND (comp_aab.StudentUSI IN (
-                            SELECT fltr_aad.StudentUSI 
-                            FROM EdFi.Ods.Entities.NHibernate.QueryModels.Views.auth_EducationOrganizationIdToStudentUSI fltr_aad 
-                            WHERE fltr_aad.SourceEducationOrganizationId IN (:LocalEducationAgencyId)))
+                    SELECT fltr_aah.TargetEducationOrganizationId 
+                    FROM EdFi.Ods.Entities.NHibernate.QueryModels.Views.auth_EducationOrganizationIdToEducationOrganizationId fltr_aah 
+                    WHERE fltr_aah.SourceEducationOrganizationId IN (:ClaimEducationOrganizationIds))) AND (comp_aab.StudentUSI IN (
+                    SELECT fltr_aad.StudentUSI 
+                    FROM EdFi.Ods.Entities.NHibernate.QueryModels.Views.auth_EducationOrganizationIdToStudentUSI fltr_aad 
+                    WHERE fltr_aad.SourceEducationOrganizationId IN (:ClaimEducationOrganizationIds)))
 order by comp_aaa.StudentUSI,
 	comp_aab.EducationOrganizationId,
 	comp_aab.SchoolYear,


### PR DESCRIPTION
This test was previously being ignored when changes to the auth filtering was made so it did not show up as failing until the PR that removed the ignore was merged. Now this test will filter the query using ClaimEdOrgIds instead of LEAId. The alias was also updated along with fixing the indention to match what is generated, which lines up with other approved files as well in how far the subquery is indented.