### PR TITLE
[ODS-5298] Improve Error Reporting for Bad Connection String

### DIFF
--- a/Application/EdFi.Admin.DataAccess/Contexts/UsersContext.cs
+++ b/Application/EdFi.Admin.DataAccess/Contexts/UsersContext.cs
@@ -19,7 +19,8 @@ namespace EdFi.Admin.DataAccess.Contexts
         protected UsersContext(string connectionString)
             : base(connectionString)
         {
-            Database.SetInitializer(new ValidateDatabase<UsersContext>());
+            Database.SetInitializer(new ValidateDatabase<SqlServerUsersContext>());
+            Database.SetInitializer(new ValidateDatabase<PostgresUsersContext>());
         }
         public const string UserTableName = "Users";
 

--- a/Application/EdFi.Admin.DataAccess/Utils/ValidateDatabase.cs
+++ b/Application/EdFi.Admin.DataAccess/Utils/ValidateDatabase.cs
@@ -22,12 +22,7 @@ namespace EdFi.Admin.DataAccess.Utils
             {
                 if (!context.Database.Exists())
                 {
-                    throw new ConfigurationErrorsException("Admin database does not exist.");
-                }
-
-                if (!context.Database.CompatibleWithModel(true))
-                {
-                    throw new InvalidOperationException($"The {context.Database.Connection.Database} database is not compatible with the entity model.");
+                    throw new ConfigurationErrorsException("Unable to open connection to the Admin database.");
                 }
             }
         }

--- a/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
+++ b/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
@@ -21,9 +21,9 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.1" />
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.20" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.21" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.11" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />

--- a/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
+++ b/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.1" />
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.21" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.12" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />

--- a/Application/EdFi.Ods.Api/Middleware/EdFiOAuthAuthenticationHandler.cs
+++ b/Application/EdFi.Ods.Api/Middleware/EdFiOAuthAuthenticationHandler.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Collections.Generic;
+using System.Configuration;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
@@ -58,6 +59,11 @@ namespace EdFi.Ods.Api.Middleware
                 {
                     return authenticationResult.AuthenticateResult;
                 }
+            }
+            catch(ConfigurationException)
+            {
+                // The Security repository couldn't open a connection to the Security database
+                throw;
             }
             catch
             {

--- a/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
+++ b/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="Autofac" Version="6.3.0" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.12" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.3.0" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />

--- a/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
+++ b/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="Autofac" Version="6.3.0" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.11" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.3.0" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />

--- a/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
+++ b/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
@@ -13,7 +13,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.20" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.21" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
@@ -17,8 +17,8 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.20" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.21" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.11" />
     <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="Autofac.Extras.FakeItEasy" Version="7.0.0" />
     <PackageReference Include="AutoMapper" Version="11.0.1" />

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.21" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.12" />
     <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="Autofac.Extras.FakeItEasy" Version="7.0.0" />
     <PackageReference Include="AutoMapper" Version="11.0.1" />

--- a/Application/EdFi.Security.DataAccess/Contexts/SecurityContext.cs
+++ b/Application/EdFi.Security.DataAccess/Contexts/SecurityContext.cs
@@ -14,7 +14,8 @@ namespace EdFi.Security.DataAccess.Contexts
         protected SecurityContext(string connectionString)
             : base(connectionString)
         {
-            Database.SetInitializer(new ValidateDatabase<SecurityContext>());
+            Database.SetInitializer(new ValidateDatabase<SqlServerSecurityContext>());
+            Database.SetInitializer(new ValidateDatabase<PostgresSecurityContext>());
         }
 
         public DbSet<Application> Applications { get; set; }

--- a/Application/EdFi.Security.DataAccess/Repositories/CachedSecurityRepository.cs
+++ b/Application/EdFi.Security.DataAccess/Repositories/CachedSecurityRepository.cs
@@ -88,7 +88,7 @@ namespace EdFi.Security.DataAccess.Repositories
 
                 try
                 {
-                    LoadSecurityConfigurationFromDatabase();
+                    Reset();
                     _lastCacheUpdate = SystemClock.Now();
                 }
                 finally

--- a/Application/EdFi.Security.DataAccess/Repositories/SecurityRepository.cs
+++ b/Application/EdFi.Security.DataAccess/Repositories/SecurityRepository.cs
@@ -24,7 +24,7 @@ namespace EdFi.Security.DataAccess.Repositories
 
             Initialize(
                 GetApplication,
-                GetAcctions,
+                GetActions,
                 GetClaimSets,
                 GetResourceClaims,
                 GetAuthorizationStrategies,
@@ -118,7 +118,7 @@ namespace EdFi.Security.DataAccess.Repositories
                 app => app.ApplicationName.Equals("Ed-Fi ODS API", StringComparison.InvariantCultureIgnoreCase));
         }
 
-        private List<Models.Action> GetAcctions()
+        private List<Models.Action> GetActions()
         {
             using var context = _securityContextFactory.CreateContext();
 

--- a/Application/EdFi.Security.DataAccess/Repositories/SecurityRepository.cs
+++ b/Application/EdFi.Security.DataAccess/Repositories/SecurityRepository.cs
@@ -20,7 +20,15 @@ namespace EdFi.Security.DataAccess.Repositories
         public SecurityRepository(ISecurityContextFactory securityContextFactory)
         {
             _securityContextFactory = Preconditions.ThrowIfNull(securityContextFactory, nameof(securityContextFactory));
-            LoadSecurityConfigurationFromDatabase();
+
+            Initialize(
+                GetApplication,
+                GetAcctions,
+                GetClaimSets,
+                GetResourceClaims,
+                GetAuthorizationStrategies,
+                GetClaimSetResourceClaimActions,
+                GetResourceClaimActionAuthorizations);
         }
 
         public void LoadRecordOwnershipData()
@@ -98,65 +106,90 @@ namespace EdFi.Security.DataAccess.Repositories
                 }
             }
 
-            LoadSecurityConfigurationFromDatabase();
+            Reset();
         }
 
-        protected void LoadSecurityConfigurationFromDatabase()
+        private Application GetApplication()
         {
-            using (var context = _securityContextFactory.CreateContext())
+            using var context = _securityContextFactory.CreateContext();
+
+            return context.Applications.First(
+                app => app.ApplicationName.Equals("Ed-Fi ODS API", StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        private List<Models.Action> GetAcctions()
+        {
+            using var context = _securityContextFactory.CreateContext();
+
+            return context.Actions.ToList();
+        }
+
+        private List<ClaimSet> GetClaimSets()
+        {
+            using var context = _securityContextFactory.CreateContext();
+
+            return context.ClaimSets.Include(cs => cs.Application).ToList();
+        }
+
+        private List<ResourceClaim> GetResourceClaims()
+        {
+            using var context = _securityContextFactory.CreateContext();
+
+            return context.ResourceClaims
+                .Include(rc => rc.Application)
+                .Include(rc => rc.ParentResourceClaim)
+                .Where(rc => rc.Application.ApplicationId.Equals(Application.Value.ApplicationId))
+                .ToList();
+        }
+
+        private List<AuthorizationStrategy> GetAuthorizationStrategies()
+        {
+            using var context = _securityContextFactory.CreateContext();
+
+            return context.AuthorizationStrategies
+                .Include(auth => auth.Application)
+                .Where(auth => auth.Application.ApplicationId.Equals(Application.Value.ApplicationId))
+                .ToList();
+        }
+
+        private List<ClaimSetResourceClaimAction> GetClaimSetResourceClaimActions()
+        {
+            using var context = _securityContextFactory.CreateContext();
+
+            return context.ClaimSetResourceClaimActions
+                .Include(csrc => csrc.Action)
+                .Include(csrc => csrc.ClaimSet)
+                .Include(csrc => csrc.ResourceClaim)
+                .Where(csrc => csrc.ResourceClaim.Application.ApplicationId.Equals(Application.Value.ApplicationId))
+                .ToList();
+        }
+
+        private List<ResourceClaimAction> GetResourceClaimActionAuthorizations()
+        {
+            using var context = _securityContextFactory.CreateContext();
+
+            var claimSetResourceClaimActionAuthorizationStrategyOverrides = context.ClaimSetResourceClaimActionAuthorizationStrategyOverrides
+                .Include(csrcas => csrcas.AuthorizationStrategy)
+                .Include(csrcas => csrcas.ClaimSetResourceClaimAction)
+                .ToList();
+
+            var resourceClaimActionAuthorizationStrategies = context.ResourceClaimActionAuthorizationStrategies
+                .Include(rcaas => rcaas.AuthorizationStrategy)
+                .Include(rcaas => rcaas.ResourceClaimAction)
+                .ToList();
+
+            var resourceClaimActionAuthorizations = context.ResourceClaimActions
+                .Include(rcas => rcas.Action)
+                .Include(rcas => rcas.ResourceClaim)
+                .Where(rcas => rcas.ResourceClaim.Application.ApplicationId.Equals(Application.Value.ApplicationId))
+                .ToList();
+
+            foreach (var a in resourceClaimActionAuthorizations)
             {
-                var application =
-                    context.Applications.First(
-                        app => app.ApplicationName.Equals("Ed-Fi ODS API", StringComparison.InvariantCultureIgnoreCase));
-
-                var actions = context.Actions.ToList();
-
-                var claimSets = context.ClaimSets.Include(cs => cs.Application)
-                                       .ToList();
-
-                var resourceClaims = context.ResourceClaims.Include(rc => rc.Application)
-                                            .Include(rc => rc.ParentResourceClaim)
-                                            .Where(rc => rc.Application.ApplicationId.Equals(application.ApplicationId))
-                                            .ToList();
-
-                var authorizationStrategies = context.AuthorizationStrategies.Include(auth => auth.Application)
-                                                     .Where(auth => auth.Application.ApplicationId.Equals(application.ApplicationId))
-                                                     .ToList();
-
-                var claimSetResourceClaimActions = context.ClaimSetResourceClaimActions.Include(csrc => csrc.Action)
-                                                    .Include(csrc => csrc.ClaimSet)
-                                                    .Include(csrc => csrc.ResourceClaim)
-                                                    .Where(csrc => csrc.ResourceClaim.Application.ApplicationId.Equals(application.ApplicationId))
-                                                    .ToList();
-
-                var claimSetResourceClaimActionAuthorizationStrategyOverrides = context.ClaimSetResourceClaimActionAuthorizationStrategyOverrides.Include(csrcas => csrcas.AuthorizationStrategy)
-                                                   .Include(csrcas => csrcas.ClaimSetResourceClaimAction)
-                                                   .ToList();
-
-                var resourceClaimActionAuthorizationStrategies = context.ResourceClaimActionAuthorizationStrategies.Include(rcaas => rcaas.AuthorizationStrategy)
-                                    .Include(rcaas => rcaas.ResourceClaimAction)
-                                    .ToList();
-
-                var resourceClaimActionAuthorizations =
-                    context.ResourceClaimActions.Include(rcas => rcas.Action)                           
-                           .Include(rcas => rcas.ResourceClaim)
-                           .Where(rcas => rcas.ResourceClaim.Application.ApplicationId.Equals(application.ApplicationId))
-                           .ToList();
-
-                foreach (var a in resourceClaimActionAuthorizations)
-                {
-                    a.AuthorizationStrategies = resourceClaimActionAuthorizationStrategies.Where(r => r.ResourceClaimAction.ResourceClaimActionId == a.ResourceClaimActionId).ToList();
-                }
-
-                Initialize(
-                    application,
-                    actions,
-                    claimSets,
-                    resourceClaims,
-                    authorizationStrategies,
-                    claimSetResourceClaimActions,
-                    resourceClaimActionAuthorizations);
+                a.AuthorizationStrategies = resourceClaimActionAuthorizationStrategies.Where(r => r.ResourceClaimAction.ResourceClaimActionId == a.ResourceClaimActionId).ToList();
             }
+
+            return resourceClaimActionAuthorizations;
         }
     }
 }

--- a/Application/EdFi.Security.DataAccess/Repositories/SecurityRepositoryBase.cs
+++ b/Application/EdFi.Security.DataAccess/Repositories/SecurityRepositoryBase.cs
@@ -47,7 +47,7 @@ namespace EdFi.Security.DataAccess.Repositories
         }
 
         /// <summary>
-        /// Causes all the 
+        /// Clears the cache, the database will be hit lazily.
         /// </summary>
         protected void Reset()
         {

--- a/Application/EdFi.Security.DataAccess/Repositories/SecurityRepositoryBase.cs
+++ b/Application/EdFi.Security.DataAccess/Repositories/SecurityRepositoryBase.cs
@@ -7,42 +7,57 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using EdFi.Security.DataAccess.Models;
+using EdFi.Security.DataAccess.Utils;
 using Action = EdFi.Security.DataAccess.Models.Action;
 
 namespace EdFi.Security.DataAccess.Repositories
 {
     public abstract class SecurityRepositoryBase
     {
-        protected Application Application { get; private set; }
+        protected ResettableLazy<Application> Application { get; private set; }
 
-        protected List<Action> Actions { get; private set; }
+        protected ResettableLazy<List<Action>> Actions { get; private set; }
 
-        protected List<ClaimSet> ClaimSets { get; private set; }
+        protected ResettableLazy<List<ClaimSet>> ClaimSets { get; private set; }
 
-        protected List<ResourceClaim> ResourceClaims { get; private set; }
+        protected ResettableLazy<List<ResourceClaim>> ResourceClaims { get; private set; }
 
-        protected List<AuthorizationStrategy> AuthorizationStrategies { get; private set; }
+        protected ResettableLazy<List<AuthorizationStrategy>> AuthorizationStrategies { get; private set; }
 
-        protected List<ClaimSetResourceClaimAction> ClaimSetResourceClaimActions { get; private set; }
+        protected ResettableLazy<List<ClaimSetResourceClaimAction>> ClaimSetResourceClaimActions { get; private set; }
 
-        protected List<ResourceClaimAction> ResourceClaimActions { get; private set; }
+        protected ResettableLazy<List<ResourceClaimAction>> ResourceClaimActions { get; private set; }
 
         protected void Initialize(
-            Application application,
-            List<Action> actions,
-            List<ClaimSet> claimSets,
-            List<ResourceClaim> resourceClaims,
-            List<AuthorizationStrategy> authorizationStrategies,
-            List<ClaimSetResourceClaimAction> claimSetResourceClaimActions,
-            List<ResourceClaimAction> resourceClaimActions)
+            Func<Application> application,
+            Func<List<Action>> actions,
+            Func<List<ClaimSet>> claimSets,
+            Func<List<ResourceClaim>> resourceClaims,
+            Func<List<AuthorizationStrategy>> authorizationStrategies,
+            Func<List<ClaimSetResourceClaimAction>> claimSetResourceClaimActions,
+            Func<List<ResourceClaimAction>> resourceClaimActions)
         {
-            Application = application;
-            Actions = actions;
-            ClaimSets = claimSets;
-            ResourceClaims = resourceClaims;
-            AuthorizationStrategies = authorizationStrategies;
-            ClaimSetResourceClaimActions = claimSetResourceClaimActions;
-            ResourceClaimActions = resourceClaimActions;
+            Application = new ResettableLazy<Application>(application);
+            Actions = new ResettableLazy<List<Action>>(actions);
+            ClaimSets = new ResettableLazy<List<ClaimSet>>(claimSets);
+            ResourceClaims = new ResettableLazy<List<ResourceClaim>>(resourceClaims);
+            AuthorizationStrategies = new ResettableLazy<List<AuthorizationStrategy>>(authorizationStrategies);
+            ClaimSetResourceClaimActions = new ResettableLazy<List<ClaimSetResourceClaimAction>>(claimSetResourceClaimActions);
+            ResourceClaimActions = new ResettableLazy<List<ResourceClaimAction>>(resourceClaimActions);
+        }
+
+        /// <summary>
+        /// Causes all the 
+        /// </summary>
+        protected void Reset()
+        {
+            Application.Reset();
+            Actions.Reset();
+            ClaimSets.Reset();
+            ResourceClaims.Reset();
+            AuthorizationStrategies.Reset();
+            ClaimSetResourceClaimActions.Reset();
+            ResourceClaimActions.Reset();
         }
 
         public virtual Action GetActionByHttpVerb(string httpVerb)
@@ -70,18 +85,18 @@ namespace EdFi.Security.DataAccess.Repositories
 
         public virtual Action GetActionByName(string actionName)
         {
-            return Actions.First(a => a.ActionName.Equals(actionName, StringComparison.InvariantCultureIgnoreCase));
+            return Actions.Value.First(a => a.ActionName.Equals(actionName, StringComparison.InvariantCultureIgnoreCase));
         }
 
         public virtual AuthorizationStrategy GetAuthorizationStrategyByName(string authorizationStrategyName)
         {
-            return AuthorizationStrategies.First(
+            return AuthorizationStrategies.Value.First(
                 a => a.AuthorizationStrategyName.Equals(authorizationStrategyName, StringComparison.InvariantCultureIgnoreCase));
         }
 
         public virtual IEnumerable<ClaimSetResourceClaimAction> GetClaimsForClaimSet(string claimSetName)
         {
-            return ClaimSetResourceClaimActions.Where(c => c.ClaimSet.ClaimSetName.Equals(claimSetName, StringComparison.InvariantCultureIgnoreCase));
+            return ClaimSetResourceClaimActions.Value.Where(c => c.ClaimSet.ClaimSetName.Equals(claimSetName, StringComparison.InvariantCultureIgnoreCase));
         }
 
         /// <summary>
@@ -104,6 +119,7 @@ namespace EdFi.Security.DataAccess.Repositories
             try
             {
                 resourceClaim = ResourceClaims
+                    .Value
                     .SingleOrDefault(rc => rc.ClaimName.Equals(resourceClaimUri, StringComparison.InvariantCultureIgnoreCase));
             }
             catch (InvalidOperationException ex)
@@ -144,6 +160,7 @@ namespace EdFi.Security.DataAccess.Repositories
         {
             //check for exact match on resource and action
             var claimAndStrategy = ResourceClaimActions
+               .Value
                .SingleOrDefault(
                     rcas =>
                         rcas.ResourceClaim.ClaimName.Equals(resourceClaimUri, StringComparison.InvariantCultureIgnoreCase)
@@ -155,8 +172,9 @@ namespace EdFi.Security.DataAccess.Repositories
                 strategies.Add(claimAndStrategy);
             }
 
-            var resourceClaim =
-                ResourceClaims.FirstOrDefault(rc => rc.ClaimName.Equals(resourceClaimUri, StringComparison.InvariantCultureIgnoreCase));
+            var resourceClaim = ResourceClaims
+                .Value
+                .FirstOrDefault(rc => rc.ClaimName.Equals(resourceClaimUri, StringComparison.InvariantCultureIgnoreCase));
 
             // if there's a parent resource, recurse
             if (resourceClaim != null && resourceClaim.ParentResourceClaim != null)
@@ -167,7 +185,9 @@ namespace EdFi.Security.DataAccess.Repositories
 
         public virtual ResourceClaim GetResourceByResourceName(string resourceName)
         {
-            return ResourceClaims.FirstOrDefault(rc => rc.ResourceName.Equals(resourceName, StringComparison.InvariantCultureIgnoreCase));
+            return ResourceClaims
+                .Value
+                .FirstOrDefault(rc => rc.ResourceName.Equals(resourceName, StringComparison.InvariantCultureIgnoreCase));
         }
     }
 }

--- a/Application/EdFi.Security.DataAccess/Utils/ResettableLazy.cs
+++ b/Application/EdFi.Security.DataAccess/Utils/ResettableLazy.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace EdFi.Security.DataAccess.Utils
+{
+    public class ResettableLazy<T>
+    {
+        private readonly Func<T> _valueFactory;
+        private Lazy<T> _lazy;
+
+        public bool IsValueCreated => _lazy.IsValueCreated;
+        public T Value => _lazy.Value;
+
+        public ResettableLazy(Func<T> valueFactory)
+        {
+            _valueFactory = valueFactory;
+            _lazy = new Lazy<T>(_valueFactory);
+        }
+
+        public void Reset()
+        {
+            _lazy = new Lazy<T>(_valueFactory);
+        }
+    }
+}

--- a/Application/EdFi.Security.DataAccess/Utils/ValidateDatabase.cs
+++ b/Application/EdFi.Security.DataAccess/Utils/ValidateDatabase.cs
@@ -22,12 +22,7 @@ namespace EdFi.Security.DataAccess.Utils
             {
                 if (!context.Database.Exists())
                 {
-                    throw new ConfigurationErrorsException("Security database does not exist.");
-                }
-
-                if (!context.Database.CompatibleWithModel(true))
-                {
-                    throw new InvalidOperationException($"The {context.Database.Connection.Database} database is not compatible with the entity model.");
+                    throw new ConfigurationErrorsException("Unable to open connection to the Security database.");
                 }
             }
         }

--- a/Application/Test.Common/Test.Common.csproj
+++ b/Application/Test.Common/Test.Common.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="11.0.1" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.12" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Application/Test.Common/Test.Common.csproj
+++ b/Application/Test.Common/Test.Common.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="11.0.1" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.11" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
+++ b/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.21" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.12" />
     <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="ApprovalTests" Version="5.7.2" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />

--- a/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
+++ b/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
@@ -25,8 +25,8 @@
     <ProjectReference Include="..\EdFi.TestFixture\EdFi.TestFixture.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.20" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.21" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.11" />
     <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="ApprovalTests" Version="5.7.2" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />

--- a/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
+++ b/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.21" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.12" />
     <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="ApprovalTests" Version="5.7.2" />
     <PackageReference Include="ApprovalUtilities" Version="5.7.2" />

--- a/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
+++ b/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.20" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.21" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.11" />
     <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="ApprovalTests" Version="5.7.2" />
     <PackageReference Include="ApprovalUtilities" Version="5.7.2" />

--- a/tests/EdFi.Security.DataAccess.UnitTests/Repositories/CachedSecurityRepositoryTests.cs
+++ b/tests/EdFi.Security.DataAccess.UnitTests/Repositories/CachedSecurityRepositoryTests.cs
@@ -29,8 +29,9 @@ namespace EdFi.Security.DataAccess.UnitTests.Repositories
         protected void InitializeSystemUnderTest(int cacheTimeoutInMinutes)
         {
             _systemUnderTest = new CachedSecurityRepository(_securityContextFactory, cacheTimeoutInMinutes);
+            _systemUnderTest.GetClaimsForClaimSet("ClaimSet");
 
-            // Should hit the database on construction
+            // Should hit the database after calling a getter because it has lazy initialization
             A.CallTo(() => _securityContextFactory.CreateContext()).MustHaveHappened(1, Times.Exactly);
             Fake.ClearRecordedCalls(_securityContextFactory);
         }


### PR DESCRIPTION
There are 2 main changes in this PR:

1. Fix the database initializers to throw an error if the databases don't exist instead of trying to create them (see comments below).
2. Since the `SecurityRepository` hit the database in the constructor, if the database was invalid the error message was encapsulated in a `DependencyResolutionException` (from Autofac). This made the error a bit cryptic so I added lazy initialization to the repository.