### PR TITLE
ODS-5303 - Move Admin.DataAccess build to GithubActions

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -8,36 +8,8 @@ on:
         required: true
         default: 'warning'
 
-env:
-  INFORMATIONAL_VERSION: "5.4"
-  CONFIGURATION: "Release"
-  AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
-  AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
-
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-    - name: build
-      run: |
-        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }}
-      shell: pwsh
-    - name: test
-      run: |
-        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }}
-      shell: pwsh
-    - name: pack
-      run: |
-        .\build.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }}
-      shell: pwsh
-    - name: publish
-      run: |
-        .\build.ps1 publish -BuildCounter ${{ github.run_number }}
-      shell: pwsh
+  call-shared-workflow:
+    uses: ./.github/workflows/shared.yml
+    with:
+      publish: true

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,0 +1,43 @@
+name: Manually triggered build
+
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+
+env:
+  INFORMATIONAL_VERSION: "5.4"
+  CONFIGURATION: "Release"
+  AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+  AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACT_KEY }}
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+    - name: build
+      run: |
+        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }}
+      shell: pwsh
+    - name: test
+      run: |
+        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }}
+      shell: pwsh
+    - name: pack
+      run: |
+        .\build.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }}
+      shell: pwsh
+    - name: publish
+      run: |
+        .\build.ps1 publish -BuildCounter ${{ github.run_number }}
+      shell: pwsh

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -12,7 +12,7 @@ env:
   INFORMATIONAL_VERSION: "5.4"
   CONFIGURATION: "Release"
   AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
-  AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACT_KEY }}
+  AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
 
 jobs:
   build:

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,4 +1,4 @@
-name: Manually triggered build
+name: EdFi.Admin.DataAccess Manually triggered build
 
 on:
   workflow_dispatch:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -11,21 +11,7 @@ env:
   AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-    - name: build
-      run: |
-        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }}
-      shell: pwsh
-    - name: test
-      run: |
-        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }}
-      shell: pwsh
+  call-shared-workflow:
+    uses: ./.github/workflows/shared.yml
+    with:
+      publish: false

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,0 +1,31 @@
+name: Pull request build and test
+
+on:
+  pull_request:
+    branches: [ main ]
+
+env:
+  INFORMATIONAL_VERSION: "5.4"
+  CONFIGURATION: "Release"
+  AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+  AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+    - name: build
+      run: |
+        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }}
+      shell: pwsh
+    - name: test
+      run: |
+        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }}
+      shell: pwsh

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,4 +1,4 @@
-name: Pull request build and test
+name: EdFi.Admin.DataAccess Pull request build and test
 
 on:
   pull_request:

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@dc30e5defeb4a0047e149c684eab597f5f37f67d # v1
+      uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
     - name: build

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -1,4 +1,4 @@
-name: Shared workflow
+name: EdFi.Admin.DataAccess Shared workflow
 
 on:
   workflow_call:

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@dc30e5defeb4a0047e149c684eab597f5f37f67d # v1
       with:
         dotnet-version: 6.0.x
     - name: build

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -1,0 +1,45 @@
+name: Shared workflow
+
+on:
+  workflow_call:
+    inputs:
+      publish:
+        required: true
+        type: boolean
+
+
+env:
+  INFORMATIONAL_VERSION: "5.4"
+  CONFIGURATION: "Release"
+  AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+  AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+    - name: build
+      run: |
+        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }}
+      shell: pwsh
+    - name: test
+      run: |
+        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }}
+      shell: pwsh
+    - name: pack
+      if: ${{inputs.publish == true}}
+      run: |
+        .\build.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }}
+      shell: pwsh
+    - name: publish
+      if: ${{inputs.publish == true}}
+      run: |
+        .\build.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }}
+      shell: pwsh      

--- a/build.ps1
+++ b/build.ps1
@@ -28,7 +28,8 @@ param(
 
 $solution = "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.sln"
 $projectFile = "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj"
-$version = "$InformationalVersion.$BuildCounter"
+$newRevision = ([int]$BuildCounter) + 10
+$version = "$InformationalVersion.$newRevision"
 $packageName = "EdFi.Suite3.Admin.DataAccess"
 $packageOutput = "$PSScriptRoot/NugetPackages"
 $packagePath = "$packageOutput/$packageName.$version.nupkg"

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+[CmdLetBinding()]
+param(
+    # Command to execute, defaults to "Build".
+    [string]
+    [ValidateSet("Clean", "Build", "Test", "Pack", "Publish")]
+    $Command = "Build",
+
+    [switch] $SelfContained,
+
+    # Informational version number, defaults 1.0
+    [string]
+    $InformationalVersion = "1.0",
+
+    # Build counter from the automation tool.
+    [string]
+    $BuildCounter = "1",
+
+    # .NET project build configuration, defaults to "Release". Options are: Debug, Release.
+    [string]
+    [ValidateSet("Debug", "Release")]
+    $Configuration = "Release"
+)
+
+$solution = "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.sln"
+$projectFile = "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj"
+$version = "$InformationalVersion.$BuildCounter"
+$packageName = "EdFi.Suite3.Admin.DataAccess"
+$packageOutput = "$PSScriptRoot/NugetPackages"
+$packagePath = "$packageOutput/$packageName.$version.nupkg"
+
+function Invoke-Execute {
+    param (
+        [ScriptBlock]
+        $Command
+    )
+
+    $global:lastexitcode = 0
+    & $Command
+
+    if ($lastexitcode -ne 0) {
+        throw "Error executing command: $Command"
+    }
+}
+
+function Invoke-Step {
+    param (
+        [ScriptBlock]
+        $block
+    )
+
+    $command = $block.ToString().Trim()
+
+    Write-Host
+    Write-Host $command -fore CYAN
+
+    &$block
+}
+
+function Invoke-Main {
+    param (
+        [ScriptBlock]
+        $MainBlock
+    )
+
+    try {
+        &$MainBlock
+        Write-Host
+        Write-Host "Build Succeeded" -fore GREEN
+        exit 0
+    } catch [Exception] {
+        Write-Host
+        Write-Error $_.Exception.Message
+        Write-Host
+        Write-Error "Build Failed"
+        exit 1
+    }
+}
+
+function Clean {
+    Invoke-Execute { dotnet clean $solution -c $Configuration --nologo -v minimal }
+}
+
+function Compile {
+    Invoke-Execute {
+        dotnet --info
+        dotnet build $solution -c $Configuration -p:AssemblyVersion=$version -p:FileVersion=$version -p:InformationalVersion=$InformationalVersion
+    }
+}
+
+function Pack {
+    Invoke-Execute {
+        dotnet pack $projectFile -c $Configuration --output $packageOutput --no-build --verbosity normal -p:VersionPrefix=$version -p:NoWarn=NU5123 -p:PackageId=$packageName
+    }
+}
+
+function Publish {
+    Invoke-Execute {
+        dotnet nuget push $packagePath -s $env:AZURE_ARTIFACT_URL -k $env:AZURE_ARTIFACT_NUGET_KEY --force-english-output
+    }
+}
+
+function Test {
+    Invoke-Execute { dotnet test $solution  -c $Configuration --no-build -v normal }
+}
+
+function Invoke-Build {
+    Write-Host "Building Version $version" -ForegroundColor Cyan
+    Invoke-Step { Clean }
+    Invoke-Step { Compile }
+}
+
+function Invoke-Publish {
+    Invoke-Step { Publish }
+}
+
+function Invoke-Tests {
+    Invoke-Step { Test }
+}
+
+function Invoke-Pack {
+    Invoke-Step { Pack }
+}
+
+Invoke-Main {
+    switch ($Command) {
+        Clean { Invoke-Clean }
+        Build { Invoke-Build }
+        Test { Invoke-Tests }
+        Pack { Invoke-Pack }
+        Publish { Invoke-Publish }
+        default { throw "Command '$Command' is not recognized" }
+    }
+}


### PR DESCRIPTION
This creates two new GithubActions, one workflow that can be manually triggered and a second that gets triggered on a pull request to main. The manually triggered one mimics what exists in TeamCity right now to build, test, pack, and publish, while the pull request one will only run a build and test.

You will not see the ability to manually run the github workflow since it has to exist in main first before it will show up there, so to test these workflows out I forked ODS, applied the workflows in the main branch and then tested them there in the fork. But you will be able to see the pull request workflow building and passing as part of the checks here.

You will also notice how 10 is being added to the run number for determining the revision in the version for packing and publishing. This is due to the existing TC build having published all the way to to version 5.4.10, so we do not want to override that number.