### PR TITLE
[ODS-5259] Update security visualization tool to visualize multiple auth strategies

### DIFF
--- a/Utilities/GenerateSecurityGraphs/GenerateSecurityGraphs/Models/AuthorizationMetadata/ActionAndStrategy.cs
+++ b/Utilities/GenerateSecurityGraphs/GenerateSecurityGraphs/Models/AuthorizationMetadata/ActionAndStrategy.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace GenerateSecurityGraphs.Models.AuthorizationMetadata
 {
@@ -11,22 +12,18 @@ namespace GenerateSecurityGraphs.Models.AuthorizationMetadata
     {
         public static readonly ActionAndStrategy Empty = new ActionAndStrategy();
 
-        public ActionAndStrategy()
-        {
-            ExplicitActionAndStrategyByClaimSetName = new Dictionary<string, ActionAndStrategy>();
-        }
-
-        public string AuthorizationStrategy { get; set; }
+        public HashSet<string> AuthorizationStrategy { get; set; }
 
         public string ActionName { get; set; }
 
-        public Dictionary<string, ActionAndStrategy> ExplicitActionAndStrategyByClaimSetName { get; }
+        public Dictionary<string, HashSet<string>> StrategyOverridesByClaimSetName { get; } 
+            = new Dictionary<string, HashSet<string>>();
 
         public override string ToString()
         {
             return ActionName
                    + " ("
-                   + (AuthorizationStrategy ?? "*No Strategy*")
+                   + (string.Join(", ", AuthorizationStrategy ?? Enumerable.Empty<string>()) ?? "*No Strategy*")
                    + ")";
         }
     }

--- a/Utilities/GenerateSecurityGraphs/GenerateSecurityGraphs/Models/AuthorizationMetadata/ActionAndStrategy.cs
+++ b/Utilities/GenerateSecurityGraphs/GenerateSecurityGraphs/Models/AuthorizationMetadata/ActionAndStrategy.cs
@@ -21,10 +21,7 @@ namespace GenerateSecurityGraphs.Models.AuthorizationMetadata
 
         public override string ToString()
         {
-            return ActionName
-                   + " ("
-                   + (string.Join(", ", AuthorizationStrategy ?? Enumerable.Empty<string>()) ?? "*No Strategy*")
-                   + ")";
+            return $"{ActionName} ({(AuthorizationStrategy == null ? "*No Strategy*" : string.Join(", ", AuthorizationStrategy))})";
         }
     }
 }

--- a/Utilities/GenerateSecurityGraphs/GenerateSecurityGraphs/Models/AuthorizationMetadata/EffectiveActionAndStrategy.cs
+++ b/Utilities/GenerateSecurityGraphs/GenerateSecurityGraphs/Models/AuthorizationMetadata/EffectiveActionAndStrategy.cs
@@ -105,24 +105,14 @@ namespace GenerateSecurityGraphs.Models.AuthorizationMetadata
 
         public bool IsIndeterminate()
         {
-            if (ActionGranted != true // We're not dealing with an actual claim grant
-                && (AuthorizationStrategy == null || AuthorizationStrategy != null && AuthorizationStrategyInherited)) // No local authorization
-            {
-                return true;
-            }
-
-            return false;
+            return ActionGranted != true // We're not dealing with an actual claim grant
+                && (AuthorizationStrategy == null || AuthorizationStrategy != null && AuthorizationStrategyInherited); // No local authorization
         }
 
         public override string ToString()
         {
-            return ActionGranted == true
-                ? "Granted - "
-                  + (AuthorizationStrategy == null
-                      ? "*No Strategy*"
-                      : AuthorizationStrategy)
-                  + " (inherited=" + AuthorizationStrategyInherited
-                  + "; isDefault=" + AuthorizationStrategyIsDefault + ")"
+            return ActionGranted == true 
+                ? $"Granted - {(AuthorizationStrategy == null ? "*No Strategy*" : string.Join(", ", AuthorizationStrategy))} (inherited={AuthorizationStrategyInherited}; isDefault={AuthorizationStrategyIsDefault})"
                 : "Not Granted";
         }
     }

--- a/Utilities/GenerateSecurityGraphs/GenerateSecurityGraphs/Models/AuthorizationMetadata/EffectiveActionAndStrategy.cs
+++ b/Utilities/GenerateSecurityGraphs/GenerateSecurityGraphs/Models/AuthorizationMetadata/EffectiveActionAndStrategy.cs
@@ -3,6 +3,8 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Collections.Generic;
+
 namespace GenerateSecurityGraphs.Models.AuthorizationMetadata
 {
     public class EffectiveActionAndStrategy
@@ -21,7 +23,7 @@ namespace GenerateSecurityGraphs.Models.AuthorizationMetadata
 
         public bool ActionInherited { get; private set; }
 
-        public string AuthorizationStrategy { get; private set; }
+        public HashSet<string> AuthorizationStrategy { get; private set; }
 
         public string AuthorizationStrategyOriginatingClaimName { get; private set; }
 
@@ -29,15 +31,13 @@ namespace GenerateSecurityGraphs.Models.AuthorizationMetadata
 
         public bool AuthorizationStrategyIsDefault { get; private set; }
 
-        //public bool AuthorizationStrategyDefaulted { private set; get; }
-
-        public string OverriddenClaimSetAuthorizationStrategy { get; private set; }
+        public HashSet<string> OverriddenClaimSetAuthorizationStrategy { get; private set; }
 
         public string OverriddenClaimSetAuthorizationStrategyOriginatingClaimName { get; private set; }
 
         public bool OverriddenClaimSetAuthorizationStrategyInherited { get; private set; }
 
-        public string OverriddenDefaultAuthorizationStrategy { get; private set; }
+        public HashSet<string> OverriddenDefaultAuthorizationStrategy { get; private set; }
 
         public string OverriddenDefaultAuthorizationStrategyOriginatingClaimName { get; private set; }
 
@@ -56,22 +56,20 @@ namespace GenerateSecurityGraphs.Models.AuthorizationMetadata
             return true;
         }
 
-        // This method must be called in increasing order of significance
-
-        public bool TrySetAuthorizationStrategy(string strategyName, string originatingClaimName, bool inherited, bool isDefault)
+        /// <summary>
+        /// Sets the effective authorization strategy.
+        /// This method must be called in increasing order of significance.
+        /// </summary>
+        public bool TrySetAuthorizationStrategy(HashSet<string> strategyName, string originatingClaimName, bool inherited, bool isDefault)
         {
             // Strategy name is required
-            if (string.IsNullOrEmpty(strategyName))
+            if (strategyName == null || strategyName.Count == 0)
             {
                 return false;
             }
 
-            // Check for no change in strategy name...
-            //if (AuthorizationStrategy == strategyName)
-            //    return false;
-
             // If we already have a strategy, where should it go?
-            if (!string.IsNullOrEmpty(AuthorizationStrategy))
+            if (AuthorizationStrategy != null)
             {
                 if (AuthorizationStrategyIsDefault)
                 {
@@ -116,22 +114,11 @@ namespace GenerateSecurityGraphs.Models.AuthorizationMetadata
             return false;
         }
 
-        public bool TrySetOverriddenDefaultAuthorizationStrategy(string authorizationStrategy)
-        {
-            if (OverriddenDefaultAuthorizationStrategy != null || AuthorizationStrategy == authorizationStrategy)
-            {
-                return false;
-            }
-
-            OverriddenDefaultAuthorizationStrategy = authorizationStrategy;
-            return true;
-        }
-
         public override string ToString()
         {
             return ActionGranted == true
                 ? "Granted - "
-                  + (string.IsNullOrEmpty(AuthorizationStrategy)
+                  + (AuthorizationStrategy == null
                       ? "*No Strategy*"
                       : AuthorizationStrategy)
                   + " (inherited=" + AuthorizationStrategyInherited

--- a/Utilities/GenerateSecurityGraphs/GenerateSecurityGraphs/Models/AuthorizationMetadata/Resource.cs
+++ b/Utilities/GenerateSecurityGraphs/GenerateSecurityGraphs/Models/AuthorizationMetadata/Resource.cs
@@ -10,31 +10,16 @@ namespace GenerateSecurityGraphs.Models.AuthorizationMetadata
 {
     public class Resource
     {
-        public Resource(string name)
+        public Resource(string claimName)
         {
-            Name = name;
-
-            ActionAndStrategyPairs = new List<ActionAndStrategy>();
+            ClaimName = claimName;
         }
 
-        public string Name { get; set; }
+        public string ClaimName { get; set; }
 
-        public List<ActionAndStrategy> ActionAndStrategyPairs { get; set; }
+        public List<ActionAndStrategy> ActionAndStrategyPairs { get; set; } = new List<ActionAndStrategy>();
 
         public Resource Parent { get; set; }
-
-        public IEnumerable<Resource> AncestorsOrSelf
-        {
-            get
-            {
-                yield return this;
-
-                foreach (var ancestor in Ancestors)
-                {
-                    yield return ancestor;
-                }
-            }
-        }
 
         public IEnumerable<Resource> Ancestors
         {
@@ -54,19 +39,9 @@ namespace GenerateSecurityGraphs.Models.AuthorizationMetadata
             }
         }
 
-        public override int GetHashCode()
-        {
-            return Name.GetHashCode();
-        }
-
-        public override bool Equals(object obj)
-        {
-            return Name.Equals(((Resource) obj).Name);
-        }
-
         public override string ToString()
         {
-            return Name + string.Format(
+            return ClaimName + string.Format(
                        "({{{0}}})",
                        string.Join("}, {", ActionAndStrategyPairs.Select(x => x.ToString())));
         }


### PR DESCRIPTION
Changes included in this PR:
- To support multiple authorization strategies, I changed `string` to `HashSet<string>` where appropriate
- Removed dead code
- Removed obsolete comments
- Renamed `Resource.Name` to `Resource.ClaimName` and other miscellaneous renames
- Changed `WebClient` to `HttpClient` (since `WebClient` is now deprecated) to download Graphviz
- Changed explicitly typed variables to implicit
- Changed LINQ query expressions to method chaining