### PR TITLE
ODS-5303 - Add env var needed for Nuget publishing to Azure in Github Action

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -11,8 +11,9 @@ on:
 env:
   INFORMATIONAL_VERSION: "5.4"
   CONFIGURATION: "Release"
-  AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+  AZURE_ARTIFACT_URL: ${{ secrets.AZURE_ARTIFACTS_FEED_URL }}
   AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
+  VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "${{ secrets.AZURE_ARTIFACTS_FEED_URL }}","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
 
 jobs:
   build:


### PR DESCRIPTION
Without this env variable, nuget publishing fails.

Also to keep this consistent with other Github Actions that has been setup, the Azure Artifact Url has been moved to a secret that is shared in the org.

For more information around why this is needed, you can see it referenced in the documentation [here](https://docs.microsoft.com/en-us/azure/devops/artifacts/nuget/dotnet-exe?view=azure-devops#restore-nuget-packages)