### PR TITLE
ODS-5303 - Use hard coded Azure Artifact URL

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -11,9 +11,9 @@ on:
 env:
   INFORMATIONAL_VERSION: "5.4"
   CONFIGURATION: "Release"
-  AZURE_ARTIFACT_URL: ${{ secrets.AZURE_ARTIFACTS_FEED_URL }}
+  AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
   AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
-  VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "${{ secrets.AZURE_ARTIFACTS_FEED_URL }}","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
+  VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "${{env.AZURE_ARTIFACT_URL}}","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
 
 jobs:
   build:


### PR DESCRIPTION
This Org does not have a secret for storing it, and it is not something that changes often so it can be in hard coded here. 

In the previous run after the code was merged you can see the error message that says -k is not a valid source. 
![image](https://user-images.githubusercontent.com/1013553/159957830-38694aae-1598-4d3f-8d99-94b8aabb490f.png)


This was because there was no secret defined in this org, and -k would have been the next value to parse as part of the dotnet nuget push command as you can see here:
`dotnet nuget push $packagePath -s $env:AZURE_ARTIFACT_URL -k $env:AZURE_ARTIFACT_NUGET_KEY --force-english-output`

Which with an empty `AZURE_ARTIFACT_URL ` would have evaluated as:
`dotnet nuget push EdFi.Suite3.Admin.DataAccess.5.4.11.nupkg -s -k nuget_key_here --force-english-output`