### PR TITLE
ODS-5303 - Install artifact credential provider to authenticate to Azure Artifacts

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -39,6 +39,10 @@ jobs:
       run: |
         .\build.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }}
       shell: pwsh
+    - name: Install-credential-handler
+      if: ${{inputs.publish == true}}
+      run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
+      shell: pwsh
     - name: publish
       if: ${{inputs.publish == true}}
       run: |


### PR DESCRIPTION
This provider is needed to take advantage of the env var `VSS_NUGET_EXTERNAL_FEED_ENDPOINTS` that stores the credentials that are used when publishing to Azure Artifacts.