### PR TITLE
[ODS-5308] Clearing expired tokens in background could potentially allow access via expired tokens

### DIFF
--- a/Application/EdFi.Admin.DataAccess/Models/OAuthTokenClient.cs
+++ b/Application/EdFi.Admin.DataAccess/Models/OAuthTokenClient.cs
@@ -3,6 +3,8 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System;
+
 namespace EdFi.Admin.DataAccess.Models
 {
     public class OAuthTokenClient
@@ -24,5 +26,7 @@ namespace EdFi.Admin.DataAccess.Models
         public short? CreatorOwnershipTokenId { get; set; }
 
         public short? OwnershipTokenId { get; set; }
+        
+        public DateTime Expiration { get; set; }
     }
 }

--- a/Application/EdFi.Admin.DataAccess/Repositories/AccessTokenClientRepo.cs
+++ b/Application/EdFi.Admin.DataAccess/Repositories/AccessTokenClientRepo.cs
@@ -46,7 +46,7 @@ namespace EdFi.Admin.DataAccess.Repositories
         {
             using (var context = _contextFactory.CreateContext())
             {
-                const string Sql = "SELECT \"Key\", UseSandbox, StudentIdentificationSystemDescriptor, EducationOrganizationId, ClaimSetName, NamespacePrefix, ProfileName, CreatorOwnershipTokenId, OwnershipTokenId FROM dbo.GetClientForToken(@p0);";
+                const string Sql = "SELECT \"Key\", UseSandbox, StudentIdentificationSystemDescriptor, EducationOrganizationId, ClaimSetName, NamespacePrefix, ProfileName, CreatorOwnershipTokenId, OwnershipTokenId, Expiration FROM dbo.GetClientForToken(@p0);";
                 return await context.ExecuteQueryAsync<OAuthTokenClient>(Sql, accessToken);
             }
         }

--- a/Application/EdFi.Ods.Api/Authentication/ApiClientDetails.cs
+++ b/Application/EdFi.Ods.Api/Authentication/ApiClientDetails.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using EdFi.Admin.DataAccess.Models;
@@ -33,11 +34,16 @@ namespace EdFi.Ods.Api.Authentication
         public string ApiKey { get; set; }
 
         /// <summary>
-        /// Indicates whether the API bearer token was valid.
+        /// Gets or sets the UTC expiration time of the token.
+        /// </summary>
+        public DateTime ExpiresUtc { get; set; }
+        
+        /// <summary>
+        /// Indicates whether the API bearer token is valid and hasn't expired.
         /// </summary>
         public bool IsTokenValid
         {
-            get => !string.IsNullOrWhiteSpace(ApiKey);
+            get => !string.IsNullOrWhiteSpace(ApiKey) && DateTime.UtcNow < ExpiresUtc;
         }
 
         /// <summary>
@@ -116,7 +122,8 @@ namespace EdFi.Ods.Api.Authentication
                     ClaimSetName = input.ClaimSetName,
                     IsSandboxClient = input.UseSandbox,
                     StudentIdentificationSystemDescriptor = input.StudentIdentificationSystemDescriptor,
-                    CreatorOwnershipTokenId = input.CreatorOwnershipTokenId
+                    CreatorOwnershipTokenId = input.CreatorOwnershipTokenId,
+                    ExpiresUtc = input.Expiration
                 };
 
                 return dto;

--- a/Application/EdFi.Ods.Api/Authentication/CachingOAuthTokenValidatorDecorator.cs
+++ b/Application/EdFi.Ods.Api/Authentication/CachingOAuthTokenValidatorDecorator.cs
@@ -18,13 +18,12 @@ namespace EdFi.Ods.Api.Authentication
     /// </summary>
     public class CachingOAuthTokenValidatorDecorator : IOAuthTokenValidator
     {
-        private const string CacheKeyFormat = "OAuthTokenValidator.ApiClientDetails.{0}";
+        public const string CacheKeyFormat = "OAuthTokenValidator.ApiClientDetails.{0}";
 
         private readonly ApiSettings _apiSettings;
         private readonly IInstanceIdContextProvider _instanceIdContextProvider;
 
         // Lazy initialized fields
-        private readonly Lazy<int> _bearerTokenTimeoutMinutes;
         private readonly ICacheProvider _cacheProvider;
 
         // Dependencies
@@ -35,13 +34,11 @@ namespace EdFi.Ods.Api.Authentication
         /// </summary>
         /// <param name="next">The decorated implementation.</param>
         /// <param name="cacheProvider">The cache provider.</param>
-        /// <param name="configuration"></param>
         /// <param name="apiSettings"></param>
         /// <param name="instanceIdContextProvider"></param>
         public CachingOAuthTokenValidatorDecorator(
             IOAuthTokenValidator next,
             ICacheProvider cacheProvider,
-            IConfigurationRoot configuration,
             ApiSettings apiSettings,
             IInstanceIdContextProvider instanceIdContextProvider = null)
         {
@@ -50,12 +47,6 @@ namespace EdFi.Ods.Api.Authentication
 
             _next = next;
             _cacheProvider = cacheProvider;
-
-            // Lazy initialization
-            _bearerTokenTimeoutMinutes = new Lazy<int>(
-                () => int.TryParse(configuration.GetSection("BearerTokenTimeoutMinutes").Value, out int bearerTokenTimeoutMinutes)
-                    ? bearerTokenTimeoutMinutes
-                    : 30);
         }
 
         /// <summary>

--- a/Application/EdFi.Ods.Api/Authentication/OAuthTokenValidator.cs
+++ b/Application/EdFi.Ods.Api/Authentication/OAuthTokenValidator.cs
@@ -42,6 +42,5 @@ namespace EdFi.Ods.Api.Authentication
 
             return ApiClientDetails.Create(clientForToken);
         }
-
     }
 }

--- a/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
+++ b/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
@@ -21,7 +21,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.1" />
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.27" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.29" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.15" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />

--- a/Application/EdFi.Ods.Api/Middleware/AuthenticationResult.cs
+++ b/Application/EdFi.Ods.Api/Middleware/AuthenticationResult.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System;
 using System.Security.Claims;
 using EdFi.Ods.Common.Security;
 using Microsoft.AspNetCore.Authentication;
@@ -15,5 +16,7 @@ namespace EdFi.Ods.Api.Middleware {
         public ClaimsIdentity ClaimsIdentity { get; set; }
 
         public ApiKeyContext ApiKeyContext { get; set; }
+
+        public DateTime? ExpiresUtc { get; set; }
     }
 }

--- a/Application/EdFi.Ods.Api/Middleware/EdFiOAuthAuthenticationHandler.cs
+++ b/Application/EdFi.Ods.Api/Middleware/EdFiOAuthAuthenticationHandler.cs
@@ -3,14 +3,13 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System.Collections.Generic;
+using System;
 using System.Configuration;
 using System.Net.Http.Headers;
-using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using EdFi.Common.Extensions;
 using EdFi.Ods.Api.Providers;
-using EdFi.Ods.Common.Security;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -19,72 +18,73 @@ namespace EdFi.Ods.Api.Middleware
 {
     public class EdFiOAuthAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
     {
+        private const string BearerHeaderScheme = "Bearer";
+        
+        private const string UnknownAuthorizationHeaderScheme = "Unknown Authorization header scheme";
+        private const string MissingAuthorizationHeaderBearerTokenValue = "Missing Authorization header bearer token value";
+        private const string InvalidAuthorizationHeader = "Invalid Authorization header";
+
         private readonly IAuthenticationProvider _authenticationProvider;
+
+        private readonly ILogger _logger;
 
         public EdFiOAuthAuthenticationHandler(
             IOptionsMonitor<AuthenticationSchemeOptions> options,
-            ILoggerFactory logger,
+            ILoggerFactory loggerFactory,
             UrlEncoder encoder,
             ISystemClock clock,
             IAuthenticationProvider authenticationProvider)
-            : base(options, logger, encoder, clock)
+            : base(options, loggerFactory, encoder, clock)
         {
+            _logger = loggerFactory.CreateLogger(typeof(EdFiOAuthAuthenticationHandler).FullName!);
             _authenticationProvider = authenticationProvider;
         }
 
         protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
         {
-            AuthenticationResult authenticationResult;
-
+            AuthenticationHeaderValue authHeader;
+            
             try
             {
-                if (!AuthenticationHeaderValue.TryParse(Request.Headers["Authorization"], out AuthenticationHeaderValue authHeader))
+                if (!AuthenticationHeaderValue.TryParse(Request.Headers["Authorization"], out authHeader))
                 {
                     return AuthenticateResult.NoResult();
                 }
 
-                authenticationResult = await _authenticationProvider.GetAuthenticationResultAsync(authHeader);
-
-                if (authenticationResult == null)
+                // If there is an authorization header, but we do not recognize the authentication scheme, do nothing.
+                if (!authHeader.Scheme.EqualsIgnoreCase(BearerHeaderScheme))
                 {
+                    _logger.LogDebug(UnknownAuthorizationHeaderScheme);
                     return AuthenticateResult.NoResult();
                 }
 
-                if (authenticationResult.ClaimsIdentity == null && authenticationResult.AuthenticateResult == null)
+                // If the token value is missing, fail authentication
+                if (string.IsNullOrEmpty(authHeader.Parameter))
                 {
-                    return AuthenticateResult.NoResult();
-                }
-
-                if (authenticationResult.AuthenticateResult != null)
-                {
-                    return authenticationResult.AuthenticateResult;
+                    _logger.LogDebug(MissingAuthorizationHeaderBearerTokenValue);
+                    return AuthenticateResult.Fail(MissingAuthorizationHeaderBearerTokenValue);
                 }
             }
-            catch(ConfigurationException)
+            catch (ConfigurationException)
             {
                 // The Security repository couldn't open a connection to the Security database
                 throw;
             }
-            catch
+            catch (Exception ex)
             {
-                return AuthenticateResult.Fail("Invalid Authorization Header");
+                _logger.LogError(ex, "Token authentication failed...");
+                return AuthenticateResult.Fail(InvalidAuthorizationHeader);
             }
 
-            var principal = new ClaimsPrincipal(authenticationResult.ClaimsIdentity);
-
-            var ticket = new AuthenticationTicket(principal, CreateAuthenticationProperties(), Scheme.Name);
-
-            return AuthenticateResult.Success(ticket);
-
-            AuthenticationProperties CreateAuthenticationProperties()
+            try
             {
-                var properties = new Dictionary<string, string>();
-                var parameters = new Dictionary<string, object>()
-                {
-                    {"ApiKeyContext", authenticationResult.ApiKeyContext}
-                };
+                var result = await _authenticationProvider.AuthenticateAsync(authHeader);
 
-                return new AuthenticationProperties(properties, parameters);
+                return result;
+            }
+            catch (Exception ex)
+            {
+                return AuthenticateResult.Fail(ex);
             }
         }
     }

--- a/Application/EdFi.Ods.Api/Providers/IAuthenticationProvider.cs
+++ b/Application/EdFi.Ods.Api/Providers/IAuthenticationProvider.cs
@@ -6,11 +6,12 @@
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using EdFi.Ods.Api.Middleware;
+using Microsoft.AspNetCore.Authentication;
 
 namespace EdFi.Ods.Api.Providers
 {
     public interface IAuthenticationProvider
     {
-        Task<AuthenticationResult> GetAuthenticationResultAsync(AuthenticationHeaderValue authHeader);
+        Task<AuthenticateResult> AuthenticateAsync(AuthenticationHeaderValue authHeader);
     }
 }

--- a/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
+++ b/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
@@ -13,7 +13,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.27" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.29" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Authentication/CachingOAuthTokenValidatorDecoratorTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Authentication/CachingOAuthTokenValidatorDecoratorTests.cs
@@ -189,14 +189,14 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Services.Authorization
                 {
                     // Valid token
                     ApiKey = Guid.NewGuid().ToString("n"),
-                    ExpiresUtc = DateTime.Now.AddDays(1)
+                    ExpiresUtc = DateTime.UtcNow.AddDays(1)
                 };
 
                 _suppliedCachedClientDetailsForExpiredToken = new ApiClientDetails
                 {
                     // Expired token
                     ApiKey = Guid.NewGuid().ToString("n"),
-                    ExpiresUtc = DateTime.Now.AddDays(-1)
+                    ExpiresUtc = DateTime.UtcNow.AddDays(-1)
                 };
 
                 _decoratedValidator = Stub<IOAuthTokenValidator>();

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.27" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.29" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.15" />
     <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="Autofac.Extras.FakeItEasy" Version="7.0.0" />

--- a/Artifacts/MsSql/Structure/Admin/0090-Add-Expiration-to-GetClientForToken.sql
+++ b/Artifacts/MsSql/Structure/Admin/0090-Add-Expiration-to-GetClientForToken.sql
@@ -1,0 +1,55 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+SET QUOTED_IDENTIFIER ON;
+GO
+SET ANSI_NULLS ON;
+GO
+
+IF EXISTS (SELECT 1 FROM dbo.sysobjects WHERE id = OBJECT_ID(N'dbo.GetClientForToken') AND OBJECTPROPERTY(id, N'IsTableFunction') = 1 )
+BEGIN
+    DROP FUNCTION [dbo].[GetClientForToken];
+END
+GO
+
+CREATE FUNCTION [dbo].[GetClientForToken] (
+    @AccessToken uniqueidentifier
+)
+RETURNS TABLE
+RETURN
+    SELECT
+        ac.[Key]
+        ,ac.[UseSandbox]
+        ,ac.[StudentIdentificationSystemDescriptor]
+        ,aeo.[EducationOrganizationId]
+        ,app.[ClaimSetName]
+        ,vnp.[NamespacePrefix]
+        ,p.[ProfileName]
+        ,ac.[CreatorOwnershipTokenId_OwnershipTokenId] as CreatorOwnershipTokenId
+        ,acot.[OwnershipToken_OwnershipTokenId] as OwnershipTokenId
+        ,cat.Expiration
+    FROM ClientAccessTokens cat
+    INNER JOIN ApiClients ac ON
+        cat.[ApiClient_ApiClientId] = ac.[ApiClientId]
+        AND cat.[ID] = @AccessToken
+    INNER JOIN Applications app ON
+        app.[ApplicationID] = ac.[Application_ApplicationID]
+    LEFT OUTER JOIN Vendors v ON
+        v.[VendorId] = app.[Vendor_VendorId]
+    LEFT OUTER JOIN [dbo].[VendorNamespacePrefixes] vnp ON
+        v.VendorId = vnp.Vendor_VendorId
+    -- Outer join so client key is always returned even if no EdOrgs have been enabled
+    LEFT OUTER JOIN [dbo].[ApiClientApplicationEducationOrganizations] acaeo ON
+        acaeo.[ApiClient_ApiClientId] = cat.[ApiClient_ApiClientId]
+    LEFT OUTER JOIN [dbo].[ApplicationEducationOrganizations] aeo ON
+        aeo.[ApplicationEducationOrganizationId] = acaeo.[ApplicationEducationOrganization_ApplicationEducationOrganizationId]
+		AND (cat.Scope IS NULL OR aeo.EducationOrganizationId = CONVERT(int, cat.Scope))
+    LEFT OUTER JOIN [dbo].[ProfileApplications] ap on
+        ap.[Application_ApplicationId] = app.[ApplicationId]
+    LEFT OUTER JOIN [dbo].[Profiles] p on
+        p.[ProfileId] = ap.[Profile_ProfileId]
+    LEFT OUTER JOIN [dbo].[ApiClientOwnershipTokens] acot ON
+        ac.ApiClientId = acot.ApiClient_ApiClientId
+GO

--- a/Artifacts/PgSql/Structure/Admin/0090-Add-Expiration-to-GetClientForToken.sql
+++ b/Artifacts/PgSql/Structure/Admin/0090-Add-Expiration-to-GetClientForToken.sql
@@ -1,0 +1,60 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+DROP FUNCTION dbo.GetClientForToken;
+
+CREATE FUNCTION dbo.GetClientForToken (AccessToken UUID)
+RETURNS TABLE (
+    Key VARCHAR(50)
+    ,UseSandbox BOOLEAN
+    ,StudentIdentificationSystemDescriptor VARCHAR(306)
+    ,EducationOrganizationId INT
+    ,ClaimSetName VARCHAR(255)
+    ,NamespacePrefix VARCHAR(255)
+    ,ProfileName VARCHAR
+    ,CreatorOwnershipTokenId SMALLINT
+    ,OwnershipTokenId SMALLINT
+    ,Expiration TIMESTAMP
+)
+AS
+$$
+BEGIN
+    RETURN QUERY
+    SELECT
+        ac.Key
+        ,ac.UseSandbox
+        ,ac.StudentIdentificationSystemDescriptor
+        ,aeo.EducationOrganizationId
+        ,app.ClaimSetName
+        ,vnp.NamespacePrefix
+        ,p.ProfileName
+        ,ac.CreatorOwnershipTokenId_OwnershipTokenId as CreatorOwnershipTokenId
+        ,acot.OwnershipToken_OwnershipTokenId as OwnershipTokenId
+        ,cat.Expiration
+    FROM dbo.ClientAccessTokens cat
+         INNER JOIN dbo.ApiClients ac ON
+        cat.ApiClient_ApiClientId = ac.ApiClientId
+        AND cat.Id = AccessToken
+         INNER JOIN dbo.Applications app ON
+        app.ApplicationId = ac.Application_ApplicationId
+         LEFT OUTER JOIN dbo.Vendors v ON
+        v.VendorId = app.Vendor_VendorId
+         LEFT OUTER JOIN dbo.VendorNamespacePrefixes vnp ON
+        v.VendorId = vnp.Vendor_VendorId
+         -- Outer join so client key is always returned even if no EdOrgs have been enabled
+         LEFT OUTER JOIN dbo.ApiClientApplicationEducationOrganizations acaeo ON
+        acaeo.ApiClient_ApiClientId = cat.ApiClient_ApiClientId
+         LEFT OUTER JOIN dbo.ApplicationEducationOrganizations aeo ON
+        aeo.ApplicationEducationOrganizationId = acaeo.ApplicationEdOrg_ApplicationEdOrgId
+            AND (cat.Scope IS NULL OR aeo.EducationOrganizationId = CAST(cat.Scope AS INTEGER))
+         LEFT OUTER JOIN dbo.ProfileApplications ap ON
+        ap.Application_ApplicationId = app.ApplicationId
+         LEFT OUTER JOIN dbo.Profiles p ON
+        p.ProfileId = ap.Profile_ProfileId
+        LEFT OUTER JOIN dbo.ApiClientOwnershipTokens acot ON
+        ac.ApiClientId = acot.ApiClient_ApiClientId;
+END
+$$
+LANGUAGE plpgsql;

--- a/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
+++ b/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
@@ -25,7 +25,7 @@
     <ProjectReference Include="..\EdFi.TestFixture\EdFi.TestFixture.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.27" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.29" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.15" />
     <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="ApprovalTests" Version="5.7.2" />

--- a/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/FakedAuthenticationProvider.cs
+++ b/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/FakedAuthenticationProvider.cs
@@ -12,6 +12,7 @@ using EdFi.Ods.Api.Middleware;
 using EdFi.Ods.Api.Providers;
 using EdFi.Ods.Common.Security;
 using EdFi.Ods.Common.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
 
 namespace EdFi.Ods.WebApi.CompositeSpecFlowTests
 {
@@ -45,14 +46,25 @@ namespace EdFi.Ods.WebApi.CompositeSpecFlowTests
                     null));
         }
 
-        public Task<AuthenticationResult> GetAuthenticationResultAsync(AuthenticationHeaderValue authHeader)
+        public Task<AuthenticateResult> AuthenticateAsync(AuthenticationHeaderValue authHeader)
         {
-            return Task.FromResult(
-                new AuthenticationResult
+            var principal = new ClaimsPrincipal(_identity.Value);
+            var ticket = new AuthenticationTicket(principal, CreateAuthenticationProperties(), authHeader.Scheme);
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+
+            AuthenticationProperties CreateAuthenticationProperties()
+            {
+                var parameters = new Dictionary<string, object?>()
                 {
-                    ClaimsIdentity = _identity.Value,
-                    ApiKeyContext = _apiKeyContext.Value
-                });
+                    {
+                        "ApiKeyContext", _apiKeyContext.Value
+                    }
+                };
+
+                var items = new Dictionary<string, string?>() { { ".expires", DateTime.UtcNow.AddYears(1).ToString("O") } };
+
+                return new AuthenticationProperties(items, parameters);
+            }
         }
     }
 }

--- a/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
+++ b/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.27" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.29" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.15" />
     <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="ApprovalTests" Version="5.7.2" />


### PR DESCRIPTION
Adds support for returning the expiration time of the token from the GetClientForToken function in SQL Server and PostgreSQL, checking immediately for expired tokens (and when the token is subsequently retrieved from cache) using C# logic.

Also, refines and reduces the amount of code involved in the authentication handler that was written for ASP.NET Core integration.