### PR TITLE
ODS-4997 Wrong HTTP response when bulk uploading descriptors with invalid key and secret

### DIFF
--- a/Application/EdFi.Ods.Api/Controllers/TokenController.cs
+++ b/Application/EdFi.Ods.Api/Controllers/TokenController.cs
@@ -87,7 +87,7 @@ namespace EdFi.Ods.Api.Controllers
             }
             else if (!Request.Headers.ContainsKey("Authorization"))
             {
-                _logger.Debug("Authorization Header missing with  form of Basic <encoded credentials>");
+                _logger.Debug("Authorization Header missing with form of Basic <encoded credentials>");
                 return BadRequest(new TokenError(TokenErrorType.InvalidRequest));
             }
 
@@ -178,7 +178,7 @@ namespace EdFi.Ods.Api.Controllers
             }
             else if (!Request.Headers.ContainsKey("Authorization"))
             {
-                _logger.Debug("Authorization Header missing with  form of Basic <encoded credentials>");
+                _logger.Debug("Authorization Header missing with form of Basic <encoded credentials>");
                 return BadRequest(new TokenError(TokenErrorType.InvalidRequest));
             }
 

--- a/Application/EdFi.Ods.Api/Controllers/TokenController.cs
+++ b/Application/EdFi.Ods.Api/Controllers/TokenController.cs
@@ -26,7 +26,6 @@ namespace EdFi.Ods.Api.Controllers
     {
         private readonly ILog _logger = LogManager.GetLogger(typeof(TokenController));
         private readonly ITokenRequestProvider _requestProvider;
-        private const string InvalidClientValue = "invalid_client";
 
         public TokenController(ITokenRequestProvider provider)
         {
@@ -130,7 +129,7 @@ namespace EdFi.Ods.Api.Controllers
                 if (encodedClientAndSecret.Length != 2)
                 {
                     _logger.Debug("Header is not in the form of Basic <encoded credentials>");
-                    return Unauthorized();
+                    return BadRequest(new TokenError(TokenErrorType.InvalidRequest));
                 }
 
                 if (!encodedClientAndSecret[0]
@@ -138,6 +137,12 @@ namespace EdFi.Ods.Api.Controllers
                 {
                     _logger.Debug("Authorization scheme is not Basic");
                     return Unauthorized(new TokenError(TokenErrorType.InvalidClient));
+                }
+
+                if (string.IsNullOrWhiteSpace(encodedClientAndSecret[1]))
+                {
+                    _logger.Debug("Header does not have <encoded credentials> value");
+                    return BadRequest(new TokenError(TokenErrorType.InvalidRequest));
                 }
 
                 try
@@ -154,10 +159,15 @@ namespace EdFi.Ods.Api.Controllers
                     return BadRequest(new TokenError(TokenErrorType.InvalidRequest));
                 }
             }
+            else if (!Request.Headers.ContainsKey("Authorization"))
+            {
+                _logger.Debug("Authorization Header missing with  form of Basic <encoded credentials>");
+                return BadRequest(new TokenError(TokenErrorType.InvalidRequest));
+            }
 
             if (clientIdAndSecret.Length == 2)
             {
-                if (tokenRequest.Client_id != null || tokenRequest.Client_secret != null)
+                if (!string.IsNullOrWhiteSpace(tokenRequest.Client_id) || !string.IsNullOrWhiteSpace(tokenRequest.Client_secret))
                 {
                     return BadRequest(new TokenError(TokenErrorType.InvalidClient));
                 }
@@ -168,16 +178,16 @@ namespace EdFi.Ods.Api.Controllers
                 tokenRequest.Client_secret = clientIdAndSecret[1];
             }
 
-            if (tokenRequest.Client_id == null && tokenRequest.Client_secret == null)
+            if (string.IsNullOrWhiteSpace(tokenRequest.Client_id) || string.IsNullOrWhiteSpace(tokenRequest.Client_secret))
             {
-                return Unauthorized();
+               return Unauthorized(new TokenError(TokenErrorType.InvalidRequest));
             }
 
             var authenticationResult = await _requestProvider.HandleAsync(tokenRequest);
 
-            if (authenticationResult.TokenError != null && authenticationResult.TokenError.Error.EqualsIgnoreCase(InvalidClientValue))
+            if (authenticationResult.TokenError != null && authenticationResult.TokenError.Error.EqualsIgnoreCase(TokenErrorType.InvalidClient))
             {
-                return Unauthorized(authenticationResult.TokenError);
+                return Unauthorized(new TokenError(TokenErrorType.InvalidClient));
             }
 
             if (authenticationResult.TokenError != null)

--- a/Application/EdFi.Ods.Api/Controllers/TokenController.cs
+++ b/Application/EdFi.Ods.Api/Controllers/TokenController.cs
@@ -26,6 +26,7 @@ namespace EdFi.Ods.Api.Controllers
     {
         private readonly ILog _logger = LogManager.GetLogger(typeof(TokenController));
         private readonly ITokenRequestProvider _requestProvider;
+        private const string InvalidClientValue = "invalid_client";
 
         public TokenController(ITokenRequestProvider provider)
         {
@@ -173,6 +174,11 @@ namespace EdFi.Ods.Api.Controllers
             }
 
             var authenticationResult = await _requestProvider.HandleAsync(tokenRequest);
+
+            if (authenticationResult.TokenError != null && authenticationResult.TokenError.Error.EqualsIgnoreCase(InvalidClientValue))
+            {
+                return Unauthorized(authenticationResult.TokenError);
+            }
 
             if (authenticationResult.TokenError != null)
             {

--- a/Application/EdFi.Ods.Api/Providers/ClientCredentialsTokenRequestProvider.cs
+++ b/Application/EdFi.Ods.Api/Providers/ClientCredentialsTokenRequestProvider.cs
@@ -38,7 +38,7 @@ namespace EdFi.Ods.Api.Providers
             // Verify client_id and client_secret are present
             if (!HasIdAndSecret())
             {
-                return new AuthenticationResponse {TokenError = new TokenError(TokenErrorType.InvalidClient)};
+                return new AuthenticationResponse {TokenError = new TokenError(TokenErrorType.InvalidRequest)};
             }
 
             // authenticate the client and get client information

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Controllers/TokenControllerTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Controllers/TokenControllerTests.cs
@@ -33,39 +33,16 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Controllers
             private TokenController _controller;
 
             private ApiClient _suppliedClient;
-            private Guid _suppliedAccessToken;
 
-            private TimeSpan _suppliedTTL;
             private IActionResult _actionResult;
 
             protected override Task ArrangeAsync()
             {
                 _suppliedClient = new ApiClient {ApiClientId = 1};
 
-                _suppliedAccessToken = Guid.NewGuid();
-                _suppliedTTL = TimeSpan.FromMinutes(30);
-
                 _accessTokenClientRepo = Stub<IAccessTokenClientRepo>();
 
                 _apiClientAuthenticator = A.Fake<IApiClientAuthenticator>();
-
-                var accessToken = new ClientAccessToken(_suppliedTTL)
-                {
-                    ApiClient = _suppliedClient,
-                    Id = _suppliedAccessToken
-                };
-
-                A.CallTo(() => _accessTokenClientRepo.AddClientAccessTokenAsync(A<int>._, A<string>._))
-                    .Returns(accessToken);
-
-                A.CallTo(() => _apiClientAuthenticator.TryAuthenticateAsync(A<string>._, A<string>._))
-                    .Returns(
-                        Task.FromResult(
-                            new ApiClientAuthenticator.AuthenticationResult
-                            {
-                                IsAuthenticated = true,
-                                ApiClientIdentity = new ApiClientIdentity {Key = "clientId"}
-                            }));
 
                 _controller = ControllerHelper.CreateTokenController( _apiClientAuthenticator, _accessTokenClientRepo);
 
@@ -99,6 +76,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Controllers
                 A.CallTo(() => _accessTokenClientRepo.AddClientAccessTokenAsync(_suppliedClient.ApiClientId, null))
                     .MustNotHaveHappened();
             }
+
         }
 
         public class With_Header_Invalid_Bearer_Token_Request : TestFixtureAsyncBase
@@ -108,39 +86,15 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Controllers
             private TokenController _controller;
 
             private ApiClient _suppliedClient;
-            private Guid _suppliedAccessToken;
-
-            private TimeSpan _suppliedTTL;
             private IActionResult _actionResult;
 
             protected override Task ArrangeAsync()
             {
                 _suppliedClient = new ApiClient {ApiClientId = 1};
 
-                _suppliedAccessToken = Guid.NewGuid();
-                _suppliedTTL = TimeSpan.FromMinutes(30);
-
                 _accessTokenClientRepo = Stub<IAccessTokenClientRepo>();
 
                 _apiClientAuthenticator = A.Fake<IApiClientAuthenticator>();
-
-                var accessToken = new ClientAccessToken(_suppliedTTL)
-                {
-                    ApiClient = _suppliedClient,
-                    Id = _suppliedAccessToken
-                };
-
-                A.CallTo(() => _accessTokenClientRepo.AddClientAccessTokenAsync(A<int>._, A<string>._))
-                    .Returns(accessToken);
-
-                A.CallTo(() => _apiClientAuthenticator.TryAuthenticateAsync(A<string>._, A<string>._))
-                    .Returns(
-                        Task.FromResult(
-                            new ApiClientAuthenticator.AuthenticationResult
-                            {
-                                IsAuthenticated = true,
-                                ApiClientIdentity = new ApiClientIdentity {Key = "clientId"}
-                            }));
 
                 _controller = ControllerHelper.CreateTokenController( _apiClientAuthenticator, _accessTokenClientRepo);
 
@@ -156,7 +110,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Controllers
             }
 
             [Test]
-            public void Should_return_HTTP_status_of_UnAuthorised()
+            public void Should_return_HTTP_status_of_BadRequest()
             {
                 AssertHelper.All(
                     () => _actionResult.ShouldBeOfType<BadRequestObjectResult>(),
@@ -505,7 +459,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Controllers
             private TokenController _controller;
 
             private ApiClient _suppliedClient;
-            private Guid _suppliedAccessToken;
             private string _requestedScope;
 
             private IActionResult _actionResult;
@@ -520,8 +473,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Controllers
 
                 // Scope the request to something not in list above
                 _requestedScope = "9a9";
-
-                _suppliedAccessToken = Guid.NewGuid();
 
                 _accessTokenClientRepo = Stub<IAccessTokenClientRepo>();
 
@@ -612,7 +563,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Controllers
             private ApiClient _suppliedClient;
             private Guid _suppliedAccessToken;
             private IActionResult _actionResult;
-            private TokenError _tokenError;
 
             protected override Task ArrangeAsync()
             {
@@ -623,23 +573,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Controllers
                 _accessTokenClientRepo = Stub<IAccessTokenClientRepo>();
 
                 _apiClientAuthenticator = Stub<IApiClientAuthenticator>();
-
-                A.CallTo(() => _accessTokenClientRepo.AddClientAccessTokenAsync(A<int>._, A<string>._))
-                    .Returns(
-                        new ClientAccessToken(new TimeSpan(0, 10, 0))
-                        {
-                            ApiClient = _suppliedClient,
-                            Id = _suppliedAccessToken
-                        });
-
-                A.CallTo(() => _apiClientAuthenticator.TryAuthenticateAsync(A<string>._, A<string>._))
-                    .Returns(
-                        Task.FromResult(
-                            new ApiClientAuthenticator.AuthenticationResult
-                            {
-                                IsAuthenticated = true,
-                                ApiClientIdentity = new ApiClientIdentity {Key = "clientId"}
-                            }));
 
                 _controller = ControllerHelper.CreateTokenController(_apiClientAuthenticator, _accessTokenClientRepo);
 
@@ -671,7 +604,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Controllers
                         Grant_type = "client_credentials"
                     });
 
-                _tokenError = ((ObjectResult) _actionResult).Value as TokenError;
             }
 
             [Test]
@@ -709,7 +641,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Controllers
             private Guid _suppliedAccessToken;
 
             private IActionResult _actionResult;
-            private TokenResponse _tokenResponse;
 
             protected override Task ArrangeAsync()
             {
@@ -768,7 +699,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Controllers
                         Grant_type = "client_credentials"
                     });
 
-                _tokenResponse = ((ObjectResult) _actionResult).Value as TokenResponse;
             }
 
             [Test]
@@ -808,15 +738,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Controllers
                 _accessTokenClientRepo = Stub<IAccessTokenClientRepo>();
 
                 _apiClientAuthenticator = Stub<IApiClientAuthenticator>();
-
-                A.CallTo(() => _apiClientAuthenticator.TryAuthenticateAsync(A<string>._, A<string>._))
-                    .Returns(
-                        Task.FromResult(
-                            new ApiClientAuthenticator.AuthenticationResult
-                            {
-                                IsAuthenticated = true,
-                                ApiClientIdentity = new ApiClientIdentity {Key = "clientId"}
-                            }));
 
                 _controller = ControllerHelper.CreateTokenController( _apiClientAuthenticator, _accessTokenClientRepo);
 
@@ -864,15 +785,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Controllers
 
                 _apiClientAuthenticator = Stub<IApiClientAuthenticator>();
 
-                A.CallTo(() => _apiClientAuthenticator.TryAuthenticateAsync(A<string>._, A<string>._))
-                    .Returns(
-                        Task.FromResult(
-                            new ApiClientAuthenticator.AuthenticationResult
-                            {
-                                IsAuthenticated = true,
-                                ApiClientIdentity = new ApiClientIdentity {Key = "clientId"}
-                            }));
-
                 _controller = ControllerHelper.CreateTokenController( _apiClientAuthenticator, _accessTokenClientRepo);
 
                 return Task.CompletedTask;
@@ -904,7 +816,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Controllers
             }
         }
 
-
         public class Using_basic_authorization_with_unacceptable_format_value : TestFixtureAsyncBase
         {
             private IAccessTokenClientRepo _accessTokenClientRepo;
@@ -919,15 +830,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Controllers
                 _accessTokenClientRepo = Stub<IAccessTokenClientRepo>();
 
                 _apiClientAuthenticator = Stub<IApiClientAuthenticator>();
-
-                A.CallTo(() => _apiClientAuthenticator.TryAuthenticateAsync(A<string>._, A<string>._))
-                    .Returns(
-                        Task.FromResult(
-                            new ApiClientAuthenticator.AuthenticationResult
-                            {
-                                IsAuthenticated = true,
-                                ApiClientIdentity = new ApiClientIdentity { Key = "clientId" }
-                            }));
 
                 _controller = ControllerHelper.CreateTokenController(_apiClientAuthenticator, _accessTokenClientRepo);
 
@@ -1141,16 +1043,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Controllers
 
                 _apiClientAuthenticator = Stub<IApiClientAuthenticator>();
 
-                A.CallTo(() => _apiClientAuthenticator.TryAuthenticateAsync(A<string>._, A<string>._))
-                    .Returns(
-                        Task.FromResult(
-                            new ApiClientAuthenticator.AuthenticationResult
-                            {
-                                IsAuthenticated = true,
-                                ApiClientIdentity = new ApiClientIdentity {Key = "clientId"}
-                            }));
-
-                _controller = ControllerHelper.CreateTokenController( _apiClientAuthenticator, _accessTokenClientRepo);
+                 _controller = ControllerHelper.CreateTokenController( _apiClientAuthenticator, _accessTokenClientRepo);
 
                 return Task.CompletedTask;
             }

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Controllers/TokenControllerTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Controllers/TokenControllerTests.cs
@@ -1056,11 +1056,11 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Controllers
             }
 
             [Test]
-            public void Should_return_HTTP_status_of_Ok()
+            public void Should_return_HTTP_status_of_Unauthorized()
             {
                 AssertHelper.All(
-                    () => _actionResult.ShouldBeOfType<BadRequestObjectResult>(),
-                    () => ((BadRequestObjectResult) _actionResult).StatusCode.ShouldBe(StatusCodes.Status400BadRequest));
+                    () => _actionResult.ShouldBeOfType<UnauthorizedObjectResult>(),
+                    () => ((UnauthorizedObjectResult) _actionResult).StatusCode.ShouldBe(StatusCodes.Status401Unauthorized));
             }
 
             [Test]
@@ -1178,11 +1178,11 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Controllers
             }
 
             [Test]
-            public void Should_return_HTTP_status_of_BadRequest()
+            public void Should_return_HTTP_status_of_Unauthorized()
             {
                 AssertHelper.All(
-                    () => _actionResult.ShouldBeOfType<BadRequestObjectResult>(),
-                    () => ((BadRequestObjectResult) _actionResult).StatusCode.ShouldBe(StatusCodes.Status400BadRequest));
+                    () => _actionResult.ShouldBeOfType<UnauthorizedObjectResult>(),
+                    () => ((UnauthorizedObjectResult) _actionResult).StatusCode.ShouldBe(StatusCodes.Status401Unauthorized));
             }
 
             [Test]


### PR DESCRIPTION
Steps to reproduce :  Follow this document https://techdocs.ed-fi.org/pages/viewpage.action?spaceKey=ODSAPIS3V54&title=How+To%3A+Load+the+ODS+with+Sample+XML+Data+using+Bulk+Load+Client+Utility

In Step 7 : you can change invalid key/secret . 

you can test this code change using EdFi.BulkLoadClient.Console
   
   {
  "profiles": {
    "EdFi.BulkLoadClient.Console": {
      "commandName": "Project",
      "commandLineArgs": "-b \"http://localhost:54746/\"  -y 2022  -data \"C:\\Ed-Fi-SampleDataLoad\\Sample XML\" -e \"tpdm\" -w \"C:/Ed-Fi-SampleDataLoad/Working/\"  -k empty1 -s emptySecret1  -r \"1\" -l \"1\" -f"
    }
  }
}

After this code change , you will get 401 (Unauthorized) error instead of 400 (Bad Request) as per acceptance criteria 


242570 ERROR OdsRestClient - Unexpected Exception on resource post
System.AggregateException: One or more errors occurred. (Response status code does not indicate success: 401 (Unauthorized).)
 ---> System.Net.Http.HttpRequestException: Response status code does not indicate success: 401 (Unauthorized).
   at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()
   at EdFi.LoadTools.ApiClient.TokenRetriever.ObtainNewBearerToken() in C:\OSS-Workspace\Ed-Fi-ODS\Utilities\DataLoading\EdFi.LoadTools\ApiClient\TokenRetriever.cs:line 57
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait()
   at EdFi.LoadTools.ApiClient.OAuthTokenHandler.GetBearerToken() in C:\OSS-Workspace\Ed-Fi-ODS\Utilities\DataLoading\EdFi.LoadTools\ApiClient\OAuthTokenHandler.cs:line 31
   at EdFi.LoadTools.ApiClient.OdsRestClient.GetAuthHeaderValue(Boolean refreshToken) in C:\OSS-Workspace\Ed-Fi-ODS\Utilities\DataLoading\EdFi.LoadTools\ApiClient\OdsRestClient.cs:line 173
   at EdFi.LoadTools.ApiClient.OdsRestClient.PostResource(String json, String elementName, String elementSchemaName, Boolean refreshToken) in C:\OSS-Workspace\Ed-Fi-ODS\Utilities\DataLoading\EdFi.LoadTools\ApiClient\OdsRestClient.cs:line 124
