### PR TITLE
[ODS-5254] - Update FluentValidation to 10.x

### DIFF
--- a/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
+++ b/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.15" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="FluentValidation" Version="8.6.3" />
+    <PackageReference  Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />

--- a/Application/EdFi.Ods.Api/IdentityValueMappers/FluentValidationPutPostRequestResourceValidator.cs
+++ b/Application/EdFi.Ods.Api/IdentityValueMappers/FluentValidationPutPostRequestResourceValidator.cs
@@ -75,7 +75,8 @@ namespace EdFi.Ods.Api.IdentityValueMappers
                 return new List<ValidationResult>();
             }
 
-            var result = validator.Validate(resource);
+            var context = new ValidationContext<object>(resource);
+            var result = validator.Validate(context);
 
             var validationResults = result.Errors
                 .Select( e => e.ErrorMessage)

--- a/Application/EdFi.Ods.Api/Validation/DescriptorNamespaceValidator.cs
+++ b/Application/EdFi.Ods.Api/Validation/DescriptorNamespaceValidator.cs
@@ -33,13 +33,18 @@ namespace EdFi.Ods.Api.Validation
 
         public DescriptorNamespaceValidator()
         {
-            ValidatorOptions.Global.CascadeMode = CascadeMode.StopOnFirstFailure;
+            ValidatorOptions.Global.CascadeMode = CascadeMode.Continue;
 
             RuleFor(x => x.Namespace)
                .Must(NotBeNullOrWhitespace)
                .WithMessage(RequiredMessage)
-               .Must(BeValidNamespaceFormat)
-               .WithMessage(InvalidFormatMessage + ValidNamespaceFormatMessage);
+               .DependentRules(
+                   () =>
+                   {
+                       RuleFor(x => x.Namespace)
+                           .Must(BeValidNamespaceFormat)
+                           .WithMessage(InvalidFormatMessage + ValidNamespaceFormatMessage);
+                   });
 
             RuleFor(
                     x => CaptureNamespaceGroups.Match(x.Namespace)

--- a/Application/EdFi.Ods.Api/Validation/DescriptorNamespaceValidator.cs
+++ b/Application/EdFi.Ods.Api/Validation/DescriptorNamespaceValidator.cs
@@ -33,7 +33,7 @@ namespace EdFi.Ods.Api.Validation
 
         public DescriptorNamespaceValidator()
         {
-            ValidatorOptions.CascadeMode = CascadeMode.StopOnFirstFailure;
+            ValidatorOptions.Global.CascadeMode = CascadeMode.StopOnFirstFailure;
 
             RuleFor(x => x.Namespace)
                .Must(NotBeNullOrWhitespace)

--- a/Application/EdFi.Ods.Api/Validation/DescriptorNamespaceValidator.cs
+++ b/Application/EdFi.Ods.Api/Validation/DescriptorNamespaceValidator.cs
@@ -33,24 +33,20 @@ namespace EdFi.Ods.Api.Validation
 
         public DescriptorNamespaceValidator()
         {
-            ValidatorOptions.Global.CascadeMode = CascadeMode.Continue;
-
             RuleFor(x => x.Namespace)
-               .Must(NotBeNullOrWhitespace)
-               .WithMessage(RequiredMessage)
-               .DependentRules(
-                   () =>
-                   {
-                       RuleFor(x => x.Namespace)
-                           .Must(BeValidNamespaceFormat)
-                           .WithMessage(InvalidFormatMessage + ValidNamespaceFormatMessage);
-                   });
+                .Cascade(CascadeMode.Stop)
+                .Must(NotBeNullOrWhitespace)
+                .WithMessage(RequiredMessage)
+                .Must(BeValidNamespaceFormat)
+                .WithMessage(InvalidFormatMessage + ValidNamespaceFormatMessage);
+
 
             RuleFor(
                     x => CaptureNamespaceGroups.Match(x.Namespace)
                                                .Groups["scheme"]
                                                .Value)
-               .Must(NotBeNullOrWhitespace)
+                .Cascade(CascadeMode.Stop)
+                .Must(NotBeNullOrWhitespace)
                .When(IsValidDescriptorNamespaceFormat)
                .WithMessage(RequiredMessage + ValidNamespaceFormatMessage)
                .Must(x => ValidScheme.IsMatch(x))
@@ -62,7 +58,8 @@ namespace EdFi.Ods.Api.Validation
                     x => CaptureNamespaceGroups.Match(x.Namespace)
                                                .Groups["organizationName"]
                                                .Value)
-               .Must(NotBeNullOrWhitespace)
+                .Cascade(CascadeMode.Stop)
+                .Must(NotBeNullOrWhitespace)
                .When(IsValidDescriptorNamespaceFormat)
                .WithMessage(RequiredMessage + ValidNamespaceFormatMessage)
                .Must(x => !InvalidOrganizationNameCharacters.IsMatch(x))
@@ -74,7 +71,8 @@ namespace EdFi.Ods.Api.Validation
                     x => CaptureNamespaceGroups.Match(x.Namespace)
                                                .Groups["descriptorName"]
                                                .Value)
-               .Must(NotBeNullOrWhitespace)
+                .Cascade(CascadeMode.Stop)
+                .Must(NotBeNullOrWhitespace)
                .When(IsValidDescriptorNamespaceFormat)
                .WithMessage(RequiredMessage + ValidNamespaceFormatMessage)
                .Must(x => !InvalidDescriptorNameCharacters.IsMatch(x))
@@ -83,10 +81,11 @@ namespace EdFi.Ods.Api.Validation
                .WithMessage(InvalidDescriptorNameMessage);
 
             RuleFor(x => x.CodeValue)
-               .Must(NotBeNullOrWhitespace)
-               .WithMessage(RequiredMessage)
-               .Must(x => !InvalidCodeValueCharacters.IsMatch(x))
-               .WithMessage(InvalidCodeValueMessage);
+                .Cascade(CascadeMode.Stop)
+                .Must(NotBeNullOrWhitespace)
+                .WithMessage(RequiredMessage)
+                .Must(x => !InvalidCodeValueCharacters.IsMatch(x))
+                .WithMessage(InvalidCodeValueMessage);
         }
 
         private bool NotBeNullOrWhitespace(string s) => !string.IsNullOrWhiteSpace(s);

--- a/Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj
+++ b/Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
-    <PackageReference Include="FluentValidation" Version="8.6.3" />
+    <PackageReference  Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NHibernate" Version="5.3.11" />

--- a/Application/EdFi.Ods.Common/Validation/FluentValidationObjectValidator.cs
+++ b/Application/EdFi.Ods.Common/Validation/FluentValidationObjectValidator.cs
@@ -10,7 +10,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using FluentValidation;
 using FluentValidation.Internal;
-using ValidationContext = FluentValidation.ValidationContext;
 
 namespace EdFi.Ods.Common.Validation
 {
@@ -40,10 +39,10 @@ namespace EdFi.Ods.Common.Validation
         public ICollection<ValidationResult> ValidateObject(object @object, string ruleSetName)
         {
             return PerformValidation(
-                new ValidationContext(
-                    @object,
-                    new PropertyChain(),
-                    new RulesetValidatorSelector(ruleSetName)));
+                new ValidationContext<object>(
+                    @object, 
+                    new PropertyChain(), 
+                    new RulesetValidatorSelector(new List<string> { ruleSetName })));
         }
 
         /// <summary>
@@ -54,10 +53,10 @@ namespace EdFi.Ods.Common.Validation
         public ICollection<ValidationResult> ValidateObject(object @object)
         {
             return PerformValidation(
-                new ValidationContext(@object));
+                new ValidationContext<object>(@object));
         }
 
-        private ICollection<ValidationResult> PerformValidation(ValidationContext validationContext)
+        private ICollection<ValidationResult> PerformValidation(ValidationContext<object> validationContext)
         {
             // Don't do any processing if there are no FluentValidation validators
             if (_validators == null || _validators.Length == 0)

--- a/Application/EdFi.Ods.Profiles.Test/EdFi.Ods.Profiles.Test.csproj
+++ b/Application/EdFi.Ods.Profiles.Test/EdFi.Ods.Profiles.Test.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
-    <PackageReference Include="FluentValidation" Version="8.6.3" />
+    <PackageReference  Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFrameworkTesting.FakeItEasy" Version="1.3.0" />
     <PackageReference Include="FakeItEasy" Version="7.3.0" />
-    <PackageReference Include="FluentValidation" Version="8.6.3" />
+    <PackageReference  Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/EdFi.Ods.CodeGen.Tests.csproj
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/EdFi.Ods.CodeGen.Tests.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="FakeItEasy" Version="7.3.0" />
-    <PackageReference Include="FluentValidation" Version="8.6.3" />
+    <PackageReference  Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/EdFi.Ods.CodeGen.csproj
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/EdFi.Ods.CodeGen.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="DatabaseSchemaReader" Version="2.7.11" />
-    <PackageReference Include="FluentValidation" Version="8.6.3" />
+    <PackageReference  Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/Utilities/VisualStudioProjectTemplates/EdFi.ProjectTemplates.Profiles/Template_Project.csproj
+++ b/Utilities/VisualStudioProjectTemplates/EdFi.ProjectTemplates.Profiles/Template_Project.csproj
@@ -12,7 +12,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="8.6.3" />
+    <PackageReference  Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
+++ b/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.3.0" />
-    <PackageReference Include="FluentValidation" Version="8.6.3" />
+    <PackageReference  Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="Gherkin" Version="22.0.0" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />
     <PackageReference Include="log4net" Version="2.0.13" />


### PR DESCRIPTION
For this PR, FluentValidation was updated to the latest version on Nuget, and minor changes were made to the code based on breaking changes introduced between 8.6.3 and 10.4.0, which were:

- Referencing the Global ValidatorOptions for CascadeMode
- Removed usage of non-generic Validator and ValidationContext per the [upgrade guidelines](https://docs.fluentvalidation.net/en/latest/upgrading-to-9.html#removal-of-non-generic-validate-overload) 
- Change from CascadeMode.StopOnFirstFailure to Stop since StopOnFirstFailure is [now marked as Obsolete](https://docs.fluentvalidation.net/en/latest/conditions.html#stop-vs-stoponfirstfailure) and adding Stop per field instead of globally matches how StopOnFirstFailure worked before

Related PRs:
https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-Extensions/pull/43
https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/pull/416
