### PR TITLE
[ODS-5350] - Move LoadTools builds to GithubActions

### DIFF
--- a/.github/workflows/edFi.admin.dataaccess manual.yml
+++ b/.github/workflows/edFi.admin.dataaccess manual.yml
@@ -28,11 +28,11 @@ jobs:
         dotnet-version: 6.0.x
     - name: build
       run: |
-        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -Solution "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.sln" -ProjectFile "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj" -PackageName  "EdFi.Suite3.Admin.DataAccess"
+        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -Solution "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.sln" -ProjectFile "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj"
       shell: pwsh
     - name: test
       run: |
-        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -Solution "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.sln" -ProjectFile "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj" -PackageName  "EdFi.Suite3.Admin.DataAccess"
+        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -Solution "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.sln" -ProjectFile "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj"
       shell: pwsh
     - name: pack
       run: |

--- a/.github/workflows/edFi.admin.dataaccess pullrequest.yml
+++ b/.github/workflows/edFi.admin.dataaccess pullrequest.yml
@@ -21,9 +21,9 @@ jobs:
         dotnet-version: 6.0.x
     - name: build
       run: |
-        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -Solution "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.sln" -ProjectFile "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj" -PackageName  "EdFi.Suite3.Admin.DataAccess"
+        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -Solution "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.sln" -ProjectFile "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj"
       shell: pwsh
     - name: test
       run: |
-        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -Solution "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.sln" -ProjectFile "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj" -PackageName  "EdFi.Suite3.Admin.DataAccess"
+        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -Solution "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.sln" -ProjectFile "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj"
       shell: pwsh

--- a/.github/workflows/edFi.loadtools manual.yml
+++ b/.github/workflows/edFi.loadtools manual.yml
@@ -1,0 +1,63 @@
+name: EdFi.LoadTools Manually triggered build
+
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+
+env:
+  INFORMATIONAL_VERSION: "5.4"
+  CONFIGURATION: "Release"
+  AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+  AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
+  VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+    - name: build
+      run: |
+        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -Solution "Utilities/DataLoading/LoadTools.sln"
+      shell: pwsh
+    - name: test
+      run: |
+        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -Solution "Utilities/DataLoading/LoadTools.sln" -TestFilter "RunManually"
+      shell: pwsh
+    - name: pack
+      run: |
+        .\build.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -Solution "Utilities/DataLoading/LoadTools.sln" -ProjectFile "Ed-Fi-ODS/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj" -PackageName "EdFi.Suite3.LoadTools"
+      shell: pwsh
+    - name: pack
+      run: |
+        .\build.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -Solution "Utilities/DataLoading/LoadTools.sln" -ProjectFile "Ed-Fi-ODS/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj" -PackageName "EdFi.Suite3.BulkLoadClient.Console"
+      shell: pwsh
+    - name: pack
+      run: |
+        .\build.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -Solution "Utilities/DataLoading/LoadTools.sln" -ProjectFile "Ed-Fi-ODS/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj" -PackageName "EdFi.Suite3.SmokeTestConsole"
+      shell: pwsh          
+    - name: Install-credential-handler
+      run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
+      shell: pwsh
+    - name: publish 
+      run: |
+        .\build.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -Solution "Utilities/DataLoading/LoadTools.sln" -ProjectFile "Ed-Fi-ODS/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj"  -PackageName "EdFi.Suite3.LoadTools"
+      shell: pwsh      
+    - name: publish 
+      run: |
+        .\build.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -Solution "Utilities/DataLoading/LoadTools.sln" -ProjectFile "Ed-Fi-ODS/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj" -PackageName "EdFi.Suite3.BulkLoadClient.Console"
+      shell: pwsh
+    - name: publish 
+      run: |
+        .\build.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -Solution "Utilities/DataLoading/LoadTools.sln" -ProjectFile "Ed-Fi-ODS/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj" -PackageName "EdFi.Suite3.SmokeTestConsole"
+      shell: pwsh      

--- a/.github/workflows/edFi.loadtools manual.yml
+++ b/.github/workflows/edFi.loadtools manual.yml
@@ -34,30 +34,30 @@ jobs:
       run: |
         .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -Solution "Utilities/DataLoading/LoadTools.sln" -TestFilter "RunManually"
       shell: pwsh
-    - name: pack
+    - name: pack load tools
       run: |
         .\build.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -Solution "Utilities/DataLoading/LoadTools.sln" -ProjectFile "Ed-Fi-ODS/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj" -PackageName "EdFi.Suite3.LoadTools"
       shell: pwsh
-    - name: pack
+    - name: pack bulk load client
       run: |
         .\build.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -Solution "Utilities/DataLoading/LoadTools.sln" -ProjectFile "Ed-Fi-ODS/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj" -PackageName "EdFi.Suite3.BulkLoadClient.Console"
       shell: pwsh
-    - name: pack
+    - name: pack smoke test console
       run: |
         .\build.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -Solution "Utilities/DataLoading/LoadTools.sln" -ProjectFile "Ed-Fi-ODS/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj" -PackageName "EdFi.Suite3.SmokeTestConsole"
       shell: pwsh          
     - name: Install-credential-handler
       run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
       shell: pwsh
-    - name: publish 
+    - name: publish load tools
       run: |
         .\build.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -Solution "Utilities/DataLoading/LoadTools.sln" -ProjectFile "Ed-Fi-ODS/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj"  -PackageName "EdFi.Suite3.LoadTools"
       shell: pwsh      
-    - name: publish 
+    - name: publish bulk load client
       run: |
         .\build.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -Solution "Utilities/DataLoading/LoadTools.sln" -ProjectFile "Ed-Fi-ODS/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj" -PackageName "EdFi.Suite3.BulkLoadClient.Console"
       shell: pwsh
-    - name: publish 
+    - name: publish smoke test console
       run: |
         .\build.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -Solution "Utilities/DataLoading/LoadTools.sln" -ProjectFile "Ed-Fi-ODS/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj" -PackageName "EdFi.Suite3.SmokeTestConsole"
       shell: pwsh      

--- a/.github/workflows/edFi.loadtools manual.yml
+++ b/.github/workflows/edFi.loadtools manual.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@dc30e5defeb4a0047e149c684eab597f5f37f67d # v1
+      uses: actions/setup-dotnet@9211491ffb35dd6a6657ca4f45d43dfe6e97c829 # v2
       with:
         dotnet-version: 6.0.x
     - name: build

--- a/.github/workflows/edFi.loadtools manual.yml
+++ b/.github/workflows/edFi.loadtools manual.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@dc30e5defeb4a0047e149c684eab597f5f37f67d # v1
       with:
         dotnet-version: 6.0.x
     - name: build

--- a/.github/workflows/edFi.loadtools pullrequest.yml
+++ b/.github/workflows/edFi.loadtools pullrequest.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@dc30e5defeb4a0047e149c684eab597f5f37f67d # v1
+      uses: actions/setup-dotnet@9211491ffb35dd6a6657ca4f45d43dfe6e97c829 # v2
       with:
         dotnet-version: 6.0.x
     - name: build

--- a/.github/workflows/edFi.loadtools pullrequest.yml
+++ b/.github/workflows/edFi.loadtools pullrequest.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@dc30e5defeb4a0047e149c684eab597f5f37f67d # v1
       with:
         dotnet-version: 6.0.x
     - name: build

--- a/.github/workflows/edFi.loadtools pullrequest.yml
+++ b/.github/workflows/edFi.loadtools pullrequest.yml
@@ -1,0 +1,29 @@
+name: EdFi.LoadTools Pull request build and test
+
+on:
+  pull_request:
+    branches: [main]
+
+env:
+  INFORMATIONAL_VERSION: "5.4"
+  CONFIGURATION: "Release"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+    - name: build
+      run: |
+        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -Solution "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.sln" -ProjectFile "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj"
+      shell: pwsh
+    - name: test
+      run: |
+        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -Solution "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.sln" -ProjectFile "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj"
+      shell: pwsh

--- a/.github/workflows/edFi.loadtools pullrequest.yml
+++ b/.github/workflows/edFi.loadtools pullrequest.yml
@@ -21,9 +21,9 @@ jobs:
         dotnet-version: 6.0.x
     - name: build
       run: |
-        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -Solution "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.sln" -ProjectFile "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj"
+        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -Solution "Utilities/DataLoading/LoadTools.sln"
       shell: pwsh
     - name: test
       run: |
-        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -Solution "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.sln" -ProjectFile "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj"
+        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -Solution "Utilities/DataLoading/LoadTools.sln" -TestFilter "RunManually"
       shell: pwsh

--- a/.github/workflows/edFi.security.dataaccess manual.yml
+++ b/.github/workflows/edFi.security.dataaccess manual.yml
@@ -28,11 +28,11 @@ jobs:
         dotnet-version: 6.0.x
     - name: build
       run: |
-        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -Solution "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.sln" -ProjectFile "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj" -PackageName  "EdFi.Suite3.Security.DataAccess"
+        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -Solution "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.sln" -ProjectFile "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj"
       shell: pwsh
     - name: test
       run: |
-        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -Solution "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.sln" -ProjectFile "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj" -PackageName  "EdFi.Suite3.Security.DataAccess"
+        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -Solution "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.sln" -ProjectFile "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj"
       shell: pwsh
     - name: pack
       run: |

--- a/.github/workflows/edFi.security.dataaccess pullrequest.yml
+++ b/.github/workflows/edFi.security.dataaccess pullrequest.yml
@@ -21,9 +21,9 @@ jobs:
         dotnet-version: 6.0.x
     - name: build
       run: |
-        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -Solution "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.sln" -ProjectFile "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj" -PackageName  "EdFi.Suite3.Security.DataAccess"
+        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -Solution "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.sln" -ProjectFile "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj"
       shell: pwsh
     - name: test
       run: |
-        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -Solution "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.sln" -ProjectFile "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj" -PackageName  "EdFi.Suite3.Security.DataAccess"
+        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -Solution "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.sln" -ProjectFile "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj"
       shell: pwsh

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,5 @@ Application/EdFi.Ods.CodeGen/App_Packages
 Utilities/SdkGen/EdFi.SdkGen.Console/csharp
 
 *.log
+
+NugetPackages/

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/UtilitiesTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/UtilitiesTests.cs
@@ -37,7 +37,7 @@ namespace EdFi.LoadTools.Test
             Assert.IsTrue(queryStr.Contains("FirstName=Test"));
             Assert.IsTrue(queryStr.Contains("LastName=User"));
             Assert.IsTrue(queryStr.Contains("Spaces=This%20string%20has%20spaces"));
-            Assert.IsTrue(queryStr.Contains("Birthdate=11%2F28%2F2000%2012"));
+            Assert.IsTrue(queryStr.Contains("Birthdate=11%2F28%2F2000"));
         }
     }
 }

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/UtilitiesTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/UtilitiesTests.cs
@@ -24,7 +24,7 @@ namespace EdFi.LoadTools.Test
             _foo.Bar.FirstName = "Test";
             _foo.Bar.LastName = "User";
             _foo.Bar.Spaces = "This string has spaces";
-            _foo.Bar.Birthdate = new DateTime(2000, 6, 1);
+            _foo.Bar.Birthdate = new DateTime(2000, 11, 28);
             _json = Convert.ToString(JObject.FromObject(_foo));
             Console.WriteLine(_json);
         }
@@ -37,7 +37,7 @@ namespace EdFi.LoadTools.Test
             Assert.IsTrue(queryStr.Contains("FirstName=Test"));
             Assert.IsTrue(queryStr.Contains("LastName=User"));
             Assert.IsTrue(queryStr.Contains("Spaces=This%20string%20has%20spaces"));
-            Assert.IsTrue(queryStr.Contains("Birthdate=6%2F1%2F2000%2012"));
+            Assert.IsTrue(queryStr.Contains("Birthdate=11%2F28%2F2000%2012"));
         }
     }
 }

--- a/build.ps1
+++ b/build.ps1
@@ -43,7 +43,10 @@ param(
     $ProjectFile,
 
     [string]
-    $PackageName
+    $PackageName,
+
+    [string]
+    $TestFilter
 
 )
 
@@ -145,7 +148,11 @@ function Publish {
 }
 
 function Test {
-    Invoke-Execute { dotnet test $solution  -c $Configuration --no-build -v normal }
+    if(-not $TestFilter) {
+        Invoke-Execute { dotnet test $solution  -c $Configuration --no-build -v normal }
+    } else {
+        Invoke-Execute { dotnet test $solution  -c $Configuration --no-build -v normal --filter TestCategory!~"$TestFilter" }
+    }
 }
 
 function Invoke-Build {

--- a/build.ps1
+++ b/build.ps1
@@ -43,7 +43,6 @@ param(
     $ProjectFile,
 
     [string]
-    [ValidateSet("EdFi.Suite3.Admin.DataAccess", "EdFi.Suite3.Security.DataAccess")]
     $PackageName
 
 )
@@ -113,8 +112,14 @@ function Compile {
 }
 
 function Pack {
-    Invoke-Execute {
-        dotnet pack $ProjectFile -c $Configuration --output $packageOutput --no-build --verbosity normal -p:VersionPrefix=$version -p:NoWarn=NU5123 -p:PackageId=$PackageName
+    if (-not $PackageName){
+        Invoke-Execute {
+            dotnet pack $ProjectFile -c $Configuration --output $packageOutput --no-build --verbosity normal -p:VersionPrefix=$version -p:NoWarn=NU5123
+        }
+    } else {
+        Invoke-Execute {
+            dotnet pack $ProjectFile -c $Configuration --output $packageOutput --no-build --verbosity normal -p:VersionPrefix=$version -p:NoWarn=NU5123 -p:PackageId=$PackageName
+        }
     }
 }
 


### PR DESCRIPTION
This is similar to previous additions where EdFi.Admin.DataAccess and EdFi.Security.DataAccess was moved from TeamCity to Github.

Two additional changes made as part of this work were:

- Removing the PackageName script parameter from being required, since the build and test steps of the script do not need them and only the pack and publish did.
- Adding a test category filtering parameter for the test step. The LoadTools build skipped the RunManually tests so a way to do that here was needed as well.

Due to an existing issue, [ODS-5391](https://tracker.ed-fi.org/browse/ODS-5391) the test step of the builds will fail right now. So you can either:
1. Comment out `MappingTests_for_EdFi_models()` in MapperTests OR
2. Make the following changes to the JSON for the test to get it passing, which is the work that would need to be done for ODS-5391:
  electronicMailType > electronicMailTypeDescriptor
  personalInformationVerificationType > personalInformationVerificationDescriptor
  identificationDocumentUseType > identificationDocumentUseDescriptor
  raceType > raceDescriptor


Once this PR is merged then [this PR](https://github.com/Ed-Fi-Alliance/Ed-Fi-TeamCity-Configs/pull/47) should be reviewed for removing the builds from the TeamCity Kotlin configuration.