### PR TITLE
[ODS-5317] Fix destructive Smoke Test errors related to unauthorized namespace access

### DIFF
--- a/Utilities/DataLoading/EdFi.LoadTools/Common/EdFiConstants.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/Common/EdFiConstants.cs
@@ -18,7 +18,7 @@ namespace EdFi.LoadTools.Common
         public const string Authorization = "Authorization";
         public const string EdOrgReference = "EdFiEducationOrganizationReference";
         public const string Namespace = "Namespace";
-        public static readonly Uri DefaultDescriptorUri = new Uri("uri://ed-fi.org/");
+        public static readonly Uri DefaultNamespaceUri = new Uri("uri://ed-fi.org/");
         public const string EdFiNamespace = "ed-fi";
         public const string CreateOperation = "Create";
     }

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/DescriptorPropertyBuilder.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/DescriptorPropertyBuilder.cs
@@ -65,7 +65,7 @@ namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
 
             var descriptorValue = uri != null &&  !string.IsNullOrEmpty(uri.ToString())
                 ? new Uri(new Uri(uri.ToString()), $"#{codeValue}")
-                : new Uri(EdFiConstants.DefaultDescriptorUri, $"{propertyInfo.Name}#{codeValue}");
+                : new Uri(EdFiConstants.DefaultNamespaceUri, $"{propertyInfo.Name}#{codeValue}");
 
             propertyInfo.SetValue(obj, descriptorValue.ToString());
             return true;

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/NamespacePropertyBuilder.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/NamespacePropertyBuilder.cs
@@ -11,13 +11,13 @@ using EdFi.LoadTools.Engine;
 namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
 {
     /// <summary>
-    ///     Build an appropriate Descriptor Namespace. Adjust using command line parameter.
+    ///     Build an appropriate Namespace. Adjust using command line parameter.
     /// </summary>
-    public class DescriptorNamespacePropertyBuilder : BaseBuilder
+    public class NamespacePropertyBuilder : BaseBuilder
     {
         private readonly IDestructiveTestConfiguration _configuration;
 
-        public DescriptorNamespacePropertyBuilder(IDestructiveTestConfiguration configuration, IPropertyInfoMetadataLookup metadataLookup)
+        public NamespacePropertyBuilder(IDestructiveTestConfiguration configuration, IPropertyInfoMetadataLookup metadataLookup)
             : base(metadataLookup)
         {
             _configuration = configuration;
@@ -27,17 +27,16 @@ namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
         {
             var typeName = obj.GetType().Name;
 
-            if (propertyInfo.PropertyType != typeof(string) || !typeName.EndsWith(EdFiConstants.Descriptor)
-                                                            || propertyInfo.Name != EdFiConstants.Namespace)
+            if (propertyInfo.PropertyType != typeof(string) || propertyInfo.Name != EdFiConstants.Namespace)
             {
                 return false;
             }
 
-            var descriptorUri = !string.IsNullOrEmpty(_configuration.NamespacePrefix)
+            var namespaceUri = !string.IsNullOrEmpty(_configuration.NamespacePrefix)
                 ? new Uri(_configuration.NamespacePrefix)
-                : EdFiConstants.DefaultDescriptorUri;
+                : EdFiConstants.DefaultNamespaceUri;
 
-            propertyInfo.SetValue(obj, descriptorUri.ToString());
+            propertyInfo.SetValue(obj, namespaceUri.ToString());
 
             return true;
         }

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/SmokeTestsDestructiveSdkModule.cs
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/SmokeTestsDestructiveSdkModule.cs
@@ -65,7 +65,7 @@ namespace EdFi.SmokeTest.Console
                     // note these are in order of precedence
                     typeof(IgnorePropertyBuilder),
                     typeof(SimplePropertyBuilder),
-                    typeof(DescriptorNamespacePropertyBuilder),
+                    typeof(NamespacePropertyBuilder),
                     typeof(ListPropertyBuilder),
                     typeof(ExistingResourceBuilder),
                     typeof(UniqueIdPropertyBuilder),


### PR DESCRIPTION
There is already a `PropertyBuilder` responsible for initializing namespaces; however, it was limited to properties of _Descriptors_. I have removed this filter, so it now initializes all properties that require a namespace.
To ensure that this change didn't affect other cases, I compared the logs before and after the change.