### PR TITLE
[ODS-5350] Update SmokeTest package name to match existing packages

### DIFF
--- a/.github/workflows/edFi.loadtools manual.yml
+++ b/.github/workflows/edFi.loadtools manual.yml
@@ -45,7 +45,7 @@ jobs:
       shell: pwsh
     - name: pack smoke test console
       run: |
-        .\build.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Utilities/DataLoading/LoadTools.sln" -ProjectFile "Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj" -PackageName "EdFi.Suite3.SmokeTestConsole"
+        .\build.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Utilities/DataLoading/LoadTools.sln" -ProjectFile "Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj" -PackageName "EdFi.Suite3.SmokeTest.Console"
       shell: pwsh          
     - name: Install-credential-handler
       run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"


### PR DESCRIPTION
In Github Workflow it was missing the dot, so it created and published to Azure Artifacts a package named `EdFi.Suite3.SmokeTestConsole` instead of `EdFi.Suite3.SmokeTest.Console`