### PR TITLE
[ODS-5352] Add new workflows for Edfi.Ods.Common

### DIFF
--- a/.github/workflows/edFi.ods.common manual.yml
+++ b/.github/workflows/edFi.ods.common manual.yml
@@ -1,0 +1,48 @@
+name: EdFi.Ods.Common Manually triggered build
+
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+
+env:
+  INFORMATIONAL_VERSION: "5.4"
+  BUILD_INCREMENTER: "4"
+  CONFIGURATION: "Release"
+  AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+  AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
+  VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@9211491ffb35dd6a6657ca4f45d43dfe6e97c829 # v2
+      with:
+        dotnet-version: 6.0.x
+    - name: build
+      run: |
+        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"
+      shell: pwsh
+    - name: test
+      run: |
+        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -ProjectFile "application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"
+      shell: pwsh
+    - name: pack load tools
+      run: |
+        .\build.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj" -PackageName "EdFi.Suite3.Ods.Common"
+      shell: pwsh
+    - name: Install-credential-handler
+      run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
+      shell: pwsh
+    - name: publish load tools
+      run: |
+        .\build.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"  -PackageName "EdFi.Suite3.Ods.Common"
+      shell: pwsh

--- a/.github/workflows/edFi.ods.common manual.yml
+++ b/.github/workflows/edFi.ods.common manual.yml
@@ -29,20 +29,20 @@ jobs:
         dotnet-version: 6.0.x
     - name: build
       run: |
-        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"
+        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Application/EdFi.Ods.Common/EdFi.Ods.Common.sln" -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"
       shell: pwsh
     - name: test
       run: |
-        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -ProjectFile "application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"
+        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -Solution "Application/EdFi.Ods.Common/EdFi.Ods.Common.sln" -ProjectFile "application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"
       shell: pwsh
     - name: pack
       run: |
-        .\build.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj" -PackageName "EdFi.Suite3.Ods.Common"
+        .\build.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Application/EdFi.Ods.Common/EdFi.Ods.Common.sln" -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj" -PackageName "EdFi.Suite3.Ods.Common"
       shell: pwsh
     - name: Install-credential-handler
       run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
       shell: pwsh
     - name: publish
       run: |
-        .\build.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"  -PackageName "EdFi.Suite3.Ods.Common"
+        .\build.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -Solution "Application/EdFi.Ods.Common/EdFi.Ods.Common.sln" -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"  -PackageName "EdFi.Suite3.Ods.Common"
       shell: pwsh

--- a/.github/workflows/edFi.ods.common manual.yml
+++ b/.github/workflows/edFi.ods.common manual.yml
@@ -35,14 +35,14 @@ jobs:
       run: |
         .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -ProjectFile "application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"
       shell: pwsh
-    - name: pack load tools
+    - name: pack
       run: |
         .\build.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj" -PackageName "EdFi.Suite3.Ods.Common"
       shell: pwsh
     - name: Install-credential-handler
       run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
       shell: pwsh
-    - name: publish load tools
+    - name: publish
       run: |
         .\build.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"  -PackageName "EdFi.Suite3.Ods.Common"
       shell: pwsh

--- a/.github/workflows/edFi.ods.common pullrequest.yml
+++ b/.github/workflows/edFi.ods.common pullrequest.yml
@@ -21,9 +21,9 @@ jobs:
         dotnet-version: 6.0.x
     - name: build
       run: |
-        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"
+        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -Solution "Application/EdFi.Ods.Common/EdFi.Ods.Common.sln" -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"
       shell: pwsh
     - name: test
       run: |
-        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"
+        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -Solution "Application/EdFi.Ods.Common/EdFi.Ods.Common.sln" -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"
       shell: pwsh

--- a/.github/workflows/edFi.ods.common pullrequest.yml
+++ b/.github/workflows/edFi.ods.common pullrequest.yml
@@ -1,0 +1,29 @@
+name: EdFi.Ods.Common Pull request build and test
+
+on:
+  pull_request:
+    branches: [main]
+
+env:
+  INFORMATIONAL_VERSION: "5.4"
+  CONFIGURATION: "Release"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@9211491ffb35dd6a6657ca4f45d43dfe6e97c829 # v2
+      with:
+        dotnet-version: 6.0.x
+    - name: build
+      run: |
+        .\build.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"
+      shell: pwsh
+    - name: test
+      run: |
+        .\build.ps1 test -Configuration ${{ env.CONFIGURATION }} -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"
+      shell: pwsh

--- a/Application/EdFi.Ods.Common/EdFi.Ods.Common.sln
+++ b/Application/EdFi.Ods.Common/EdFi.Ods.Common.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32328.378
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EdFi.Ods.Common", "EdFi.Ods.Common.csproj", "{ECB13DD5-3240-4FA1-A6E9-C00EBB13B912}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{ECB13DD5-3240-4FA1-A6E9-C00EBB13B912}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ECB13DD5-3240-4FA1-A6E9-C00EBB13B912}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ECB13DD5-3240-4FA1-A6E9-C00EBB13B912}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ECB13DD5-3240-4FA1-A6E9-C00EBB13B912}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {874592A4-B44E-41C3-B8B0-1DDC3CEF2F31}
+	EndGlobalSection
+EndGlobal

--- a/Application/EdFi.Ods.Common/EdFi.Ods.Common.sln.DotSettings
+++ b/Application/EdFi.Ods.Common/EdFi.Ods.Common.sln.DotSettings
@@ -1,0 +1,5 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=E37C6CDD6B9EFE489876731BC67E4228/RelativePath/@EntryValue">..\..\..\..\Ed-Fi-ODS-Implementation\Application\Ed-Fi-Ods.sln.DotSettings</s:String>	
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=E37C6CDD6B9EFE489876731BC67E4228/@KeyIndexDefined">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileE37C6CDD6B9EFE489876731BC67E4228/@KeyIndexDefined">True</s:Boolean>
+	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileE37C6CDD6B9EFE489876731BC67E4228/RelativePriority/@EntryValue">1</s:Double></wpf:ResourceDictionary>

--- a/Application/EdFi.Ods.Common/EdFi.Ods.Common.sln.licenseheader
+++ b/Application/EdFi.Ods.Common/EdFi.Ods.Common.sln.licenseheader
@@ -1,0 +1,20 @@
+﻿extensions: designer.cs generated.cs xml .config .xsd .json .xsd .xml aspx .ascx
+extensions: .cs .cpp .h .js
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+extensions:  .cshtml .html
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Licensed to the Ed-Fi Alliance under one or more agreements.
+  The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+  See the LICENSE and NOTICES files in the project root for more information.
+-->
+
+extensions: .sql
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.

--- a/build.ps1
+++ b/build.ps1
@@ -53,6 +53,9 @@ param(
 
 )
 
+if(-not $Solution){
+    $Solution = $ProjectFile
+}
 $newRevision = ([int]$BuildCounter) + ([int]$BuildIncrementer)
 $version = "$InformationalVersion.$newRevision"
 $packageOutput = "$PSScriptRoot/NugetPackages"

--- a/build.ps1
+++ b/build.ps1
@@ -53,9 +53,6 @@ param(
 
 )
 
-if(-not $Solution){
-    $Solution = $ProjectFile
-}
 $newRevision = ([int]$BuildCounter) + ([int]$BuildIncrementer)
 $version = "$InformationalVersion.$newRevision"
 $packageOutput = "$PSScriptRoot/NugetPackages"


### PR DESCRIPTION
In addition to adding these two new workflows a new solution file, dotsettings file, and license update file was added so that the build script could call the solution file instead of a project file.

Additionally you will notice that the manual workflow specifies a `BUILD_INCREMENTER` but the pull request workflow does not. This is because we need the incrementer for the manual workflow since it packages up the build and we need its packages to not overlap with the ones from TeamCity, but the pull request workflow does not package up anything so it does not need the incrementer.