### PR TITLE
[ODS-5434] - Fix Multiple Auth postman test failures

### DIFF
--- a/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
+++ b/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.1" />
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="6.0.3" />
     <PackageReference Include="EdFi.Suite3.Common" Version="6.0.3" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.12" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />

--- a/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
+++ b/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Common" Version="6.0.3" />
     <PackageReference Include="Autofac" Version="6.3.0" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.12" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.3.0" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="6.0.3" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.12" />
     <PackageReference Include="NHibernate" Version="5.3.11" />
     <PackageReference Include="Autofac.Extras.FakeItEasy" Version="7.0.0" />
     <PackageReference Include="AutoMapper" Version="11.0.1" />

--- a/Application/Test.Common/Test.Common.csproj
+++ b/Application/Test.Common/Test.Common.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="11.0.1" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.12" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Postman Test Suite/Ed-Fi ODS-API Multiple Authorization Strategy Test Suite.postman_collection.json
+++ b/Postman Test Suite/Ed-Fi ODS-API Multiple Authorization Strategy Test Suite.postman_collection.json
@@ -3717,6 +3717,136 @@
 							"response": []
 						},
 						{
+							"name": "Delete Student A (Registered)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 204\", () => {",
+											"  pm.expect(pm.response.code).to.equal(204);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{AccessToken_255901}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"studentUniqueId\": \"AAAAAA\",\r\n  \"birthDate\": \"2010-01-01\",\r\n  \"firstName\": \"Joe\",\r\n  \"lastSurname\": \"Registered\"\r\n}"
+								},
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/students/{{known:student:registered:id}}",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"students",
+										"{{known:student:registered:id}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete Student B (Responsibility)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 204\", () => {",
+											"  pm.expect(pm.response.code).to.equal(204);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{AccessToken_255901}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"studentUniqueId\": \"AAAAAA\",\r\n  \"birthDate\": \"2010-01-01\",\r\n  \"firstName\": \"Joe\",\r\n  \"lastSurname\": \"Registered\"\r\n}"
+								},
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/students/{{known:student:responsibility:id}}",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"students",
+										"{{known:student:responsibility:id}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
 							"name": "Clean up Environment Variables",
 							"event": [
 								{

--- a/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
+++ b/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="6.0.3" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.12" />
     <PackageReference Include="NHibernate" Version="5.3.11" />
     <PackageReference Include="ApprovalTests" Version="5.7.2" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />

--- a/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
+++ b/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="6.0.3" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.12" />
     <PackageReference Include="NHibernate" Version="5.3.11" />
     <PackageReference Include="ApprovalTests" Version="5.7.2" />
     <PackageReference Include="ApprovalUtilities" Version="5.7.2" />


### PR DESCRIPTION
All that was needed was updating the edfi.suite3.security.dataaccess package since the one being referenced before (6.0.11) was built from a branch and not main, and was from before all of the multiple auth changes were made.

Additionally while looking at the tests it was found that all the cleanup was not being done and the students were not being deleted, so the test was updated to do that as part of the cleanup.