### PR TITLE
[ODS-5293] Change query delete endpoint paging

### DIFF
--- a/Application/EdFi.Ods.Features/ChangeQueries/Repositories/TrackedChangesQueryTemplatePreparerBase.cs
+++ b/Application/EdFi.Ods.Features/ChangeQueries/Repositories/TrackedChangesQueryTemplatePreparerBase.cs
@@ -55,7 +55,7 @@ namespace EdFi.Ods.Features.ChangeQueries.Repositories
         protected void ApplyPaging(QueryBuilder queryBuilder, IQueryParameters queryParameters)
         {
             queryBuilder.LimitOffset(
-                limit: Math.Min(queryParameters.Limit ?? 25, _defaultPageSizeLimitProvider.GetDefaultPageSizeLimit()),
+                limit: queryParameters.Limit ?? _defaultPageSizeLimitProvider.GetDefaultPageSizeLimit(),
                 offset: queryParameters.Offset ?? 0);
         }
 


### PR DESCRIPTION
Removed `Math.Min` since it limits the results to 25 if the parameter is null (consider that `DefaultPageSizeLimit` can be greater than 25).