### PR TITLE
[ODS-5293] Change query delete endpoint paging

### DIFF
--- a/Application/EdFi.Ods.Features/ChangeQueries/Repositories/Snapshots/IGetSnapshots.cs
+++ b/Application/EdFi.Ods.Features/ChangeQueries/Repositories/Snapshots/IGetSnapshots.cs
@@ -15,6 +15,8 @@ namespace EdFi.Ods.Features.ChangeQueries.Repositories.Snapshots
     {
         Task<IList<Snapshot>> GetAllAsync(IQueryParameters queryParameters);
 
+        Task<long> GetTotalCountAsync();
+
         Task<Snapshot> GetByIdAsync(Guid id);
     }
 }

--- a/Application/EdFi.Ods.Features/ChangeQueries/Repositories/TrackedChangesResourceDataProviderBase.cs
+++ b/Application/EdFi.Ods.Features/ChangeQueries/Repositories/TrackedChangesResourceDataProviderBase.cs
@@ -68,7 +68,7 @@ namespace EdFi.Ods.Features.ChangeQueries.Repositories
 
             async Task<IReadOnlyList<TItem>> GetDataAsync(SqlBuilder.Template dataQueryTemplate)
             {
-                if (dataQueryTemplate != null)
+                if (dataQueryTemplate != null && queryParameters.Limit is null or > 0)
                 {
                     // Execute query, casting to strong type to avoid use of dynamic
                     string templateRawSql = dataQueryTemplate.RawSql;
@@ -85,7 +85,7 @@ namespace EdFi.Ods.Features.ChangeQueries.Repositories
                     return items;
                 }
 
-                return null;
+                return Enumerable.Empty<TItem>().ToList();
             }
 
             async Task<long?> GetCountAsync(SqlBuilder.Template countQueryTemplate)

--- a/Application/EdFi.Ods.Features/Resources/ChangeQueries.json
+++ b/Application/EdFi.Ods.Features/Resources/ChangeQueries.json
@@ -40,6 +40,14 @@
       "maximum": 500,
       "minimum": 0,
       "type": "integer"
+    },
+    "totalCount": {
+      "description": "Indicates if the total number of items available should be returned in the 'Total-Count' header of the response.  If set to false, 'Total-Count' header will not be provided.",
+      "in": "query",
+      "name": "totalCount",
+      "required": false,
+      "default": false,
+      "type": "boolean"
     }
   },
   "paths": {
@@ -92,6 +100,9 @@
           },
           {
             "$ref": "#/parameters/limit"
+          },
+          {
+            "$ref": "#/parameters/totalCount"
           }
         ],
         "responses": {


### PR DESCRIPTION
The /snapshots endpoint can now return the total-count and respects the defaultPageSizeLimit defined in appsettings. 