### PR TITLE
[ODS-5477] - Setup workflow to trigger implementation repo workflows on PRs

### DIFF
--- a/.github/workflows/InitDev Implementation.yml
+++ b/.github/workflows/InitDev Implementation.yml
@@ -1,0 +1,22 @@
+name: Trigger InitDev workflows in Implementation repo
+
+on:
+  pull_request:
+    branches: [main]
+
+env:
+  EDFI_ODS_TOKEN: ${{ secrets.REPO_DISPATCH_TOKEN }}
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Dispatch to Implementation repo
+      uses: peter-evans/repository-dispatch@11ba7d3f32dc7cc919d1c43f1fec1c05260c26b5 # v2
+      with:
+        token: ${{ env.EDFI_ODS_TOKEN }}
+        repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation
+        event-type: triggered-from-ods-repo
+        client-payload: '{"branch": "${{ GITHUB.HEAD_REF }}"}'

--- a/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
+++ b/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />


### PR DESCRIPTION
A new workflow has been setup utilizing the repository dispatch event, so that any PR activity on the ODS repo will trigger the new InitDev workflows created in the Implementation repo, ensuring that commits to both repos trigger the same workflows.