### PR TITLE
[ODS-5601] Issues to do with Profiles on TEA project (only some references with unified key included)

### DIFF
--- a/.github/workflows/CodeQL Security Scan.yml
+++ b/.github/workflows/CodeQL Security Scan.yml
@@ -12,7 +12,7 @@ on:
   push:
     branches:
       - main
-  workflow-dispatch:
+  workflow_dispatch:
 env:
   INFORMATIONAL_VERSION: "6.1"
   BUILD_INCREMENTER: "1"

--- a/.github/workflows/CodeQL Security Scan.yml
+++ b/.github/workflows/CodeQL Security Scan.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - main
+  workflow-dispatch:
 env:
   INFORMATIONAL_VERSION: "6.1"
   BUILD_INCREMENTER: "1"

--- a/Application/EdFi.Ods.Profiles.Test/Profiles.xml
+++ b/Application/EdFi.Ods.Profiles.Test/Profiles.xml
@@ -669,4 +669,14 @@
     </Resource>
   </Profile>
 
+  <!-- SchoolYear is not included, but its code-generated implicit reference artifacts are needed for the CalendarReference to prevent compilation failure -->
+  <Profile name="Test-Profile-Some-References-With-Unified-Keys-Included">
+    <Resource name="StudentSchoolAssociation">
+      <ReadContentType memberSelection="IncludeOnly">
+        <Property name="SchoolReference" />
+        <Property name="CalendarReference" />
+      </ReadContentType>
+    </Resource>
+  </Profile>
+
 </Profiles>

--- a/Application/EdFi.Ods.Profiles.Test/Profiles.xml
+++ b/Application/EdFi.Ods.Profiles.Test/Profiles.xml
@@ -679,4 +679,19 @@
     </Resource>
   </Profile>
 
+  <!-- Covers an invalid profile validation error which resulted in code generation failure, consider removal if validation logic is rewritten --> 
+  <Profile name="Profile-Validation-Regression-References">
+    <Resource name="StudentCTEProgramAssociation">
+      <ReadContentType memberSelection="IncludeOnly">
+        <Property name="BeginDate" />
+        <Property name="EndDate" />
+        <Property name="StudentReference" /> <!-- Incorrect validation failure here -->
+        <Collection name="StudentCTEProgramAssociationCTEProgramServices" memberSelection="IncludeOnly">
+          <Property name="CTEProgramServiceDescriptor" />
+          <Property name="ServiceBeginDate" />
+          <Property name="ServiceEndDate" />
+        </Collection>
+      </ReadContentType>
+    </Resource>
+  </Profile>
 </Profiles>

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Profiles.Test_Controllers_Controllers.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Profiles.Test_Controllers_Controllers.generated.approved.cs
@@ -545,6 +545,72 @@ namespace EdFi.Ods.Api.Services.Controllers.StudentSchoolAssociations.EdFi.Minim
     }
 }
 
+namespace EdFi.Ods.Api.Services.Controllers.StudentCTEProgramAssociations.EdFi.Profile_Validation_Regression_References
+{
+    [ExcludeFromCodeCoverage]
+    public class StudentCTEProgramAssociationsNullWriteRequest : NullRequestBase { }
+
+    [ApiExplorerSettings(IgnoreApi = true)]
+    [ExcludeFromCodeCoverage]
+    [ApiController]
+    [Authorize]
+    [ProfileContentType("application/vnd.ed-fi.studentcteprogramassociation.profile-validation-regression-references")]
+    [Route("ed-fi/studentCTEProgramAssociations")]
+    public partial class StudentCTEProgramAssociationsController : DataManagementControllerBase<
+        Api.Common.Models.Resources.StudentCTEProgramAssociation.EdFi.Profile_Validation_Regression_References_Readable.StudentCTEProgramAssociation,
+        StudentCTEProgramAssociationsNullWriteRequest,
+        Entities.Common.EdFi.IStudentCTEProgramAssociation,
+        Entities.NHibernate.StudentCTEProgramAssociationAggregate.EdFi.StudentCTEProgramAssociation,
+        StudentCTEProgramAssociationsNullWriteRequest,
+        StudentCTEProgramAssociationsNullWriteRequest,
+        Api.Common.Models.Requests.StudentCTEProgramAssociations.EdFi.Profile_Validation_Regression_References.StudentCTEProgramAssociationDelete,
+        Api.Common.Models.Requests.StudentCTEProgramAssociations.EdFi.Profile_Validation_Regression_References.StudentCTEProgramAssociationGetByExample>
+    {
+        public StudentCTEProgramAssociationsController(IPipelineFactory pipelineFactory, ISchoolYearContextProvider schoolYearContextProvider, IRESTErrorProvider restErrorProvider, IDefaultPageSizeLimitProvider defaultPageSizeLimitProvider, ApiSettings apiSettings)
+            : base(pipelineFactory, schoolYearContextProvider, restErrorProvider, defaultPageSizeLimitProvider, apiSettings)
+        {
+        }
+
+        protected override void MapAll(Api.Common.Models.Requests.StudentCTEProgramAssociations.EdFi.Profile_Validation_Regression_References.StudentCTEProgramAssociationGetByExample request, Entities.Common.EdFi.IStudentCTEProgramAssociation specification)
+        {
+            // Copy all existing values
+            specification.SuspendReferenceAssignmentCheck();
+            specification.BeginDate = request.BeginDate;
+            specification.EducationOrganizationId = request.EducationOrganizationId;
+            specification.NonTraditionalGenderStatus = request.NonTraditionalGenderStatus;
+            specification.PrivateCTEProgram = request.PrivateCTEProgram;
+            specification.ProgramEducationOrganizationId = request.ProgramEducationOrganizationId;
+            specification.ProgramName = request.ProgramName;
+            specification.ProgramTypeDescriptor = request.ProgramTypeDescriptor;
+            specification.StudentUniqueId = request.StudentUniqueId;
+            specification.TechnicalSkillsAssessmentDescriptor = request.TechnicalSkillsAssessmentDescriptor;
+        }
+
+        protected override string GetReadContentType()
+        {
+            return "application/vnd.ed-fi.studentcteprogramassociation.profile-validation-regression-references.readable+json";
+        }
+
+        [ProducesResponseType(StatusCodes.Status405MethodNotAllowed)]
+        public override Task<IActionResult> Post(StudentCTEProgramAssociationsNullWriteRequest request)
+        {
+            return Task.FromResult<IActionResult>(
+                StatusCode(StatusCodes.Status405MethodNotAllowed,
+                ErrorTranslator
+                    .GetErrorMessage("The allowed methods for this resource with the 'Profile-Validation-Regression-References' profile are GET, DELETE and OPTIONS.")));
+        }
+
+        [ProducesResponseType(StatusCodes.Status405MethodNotAllowed)]
+        public override Task<IActionResult> Put(StudentCTEProgramAssociationsNullWriteRequest request, Guid id)
+        {
+            return Task.FromResult<IActionResult>(
+                StatusCode(StatusCodes.Status405MethodNotAllowed,
+                ErrorTranslator
+                    .GetErrorMessage("The allowed methods for this resource with the 'Profile-Validation-Regression-References' profile are GET, DELETE and OPTIONS.")));
+        }
+    }
+}
+
 namespace EdFi.Ods.Api.Services.Controllers.Students.EdFi.Student_Readable_Restricted
 {
     [ExcludeFromCodeCoverage]

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Profiles.Test_Controllers_Controllers.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Profiles.Test_Controllers_Controllers.generated.approved.cs
@@ -1965,6 +1965,85 @@ namespace EdFi.Ods.Api.Services.Controllers.Schools.EdFi.Test_Profile_Resource_W
     }
 }
 
+namespace EdFi.Ods.Api.Services.Controllers.StudentSchoolAssociations.EdFi.Test_Profile_Some_References_With_Unified_Keys_Included
+{
+    [ExcludeFromCodeCoverage]
+    public class StudentSchoolAssociationsNullWriteRequest : NullRequestBase { }
+
+    [ApiExplorerSettings(IgnoreApi = true)]
+    [ExcludeFromCodeCoverage]
+    [ApiController]
+    [Authorize]
+    [ProfileContentType("application/vnd.ed-fi.studentschoolassociation.test-profile-some-references-with-unified-keys-included")]
+    [Route("ed-fi/studentSchoolAssociations")]
+    public partial class StudentSchoolAssociationsController : DataManagementControllerBase<
+        Api.Common.Models.Resources.StudentSchoolAssociation.EdFi.Test_Profile_Some_References_With_Unified_Keys_Included_Readable.StudentSchoolAssociation,
+        StudentSchoolAssociationsNullWriteRequest,
+        Entities.Common.EdFi.IStudentSchoolAssociation,
+        Entities.NHibernate.StudentSchoolAssociationAggregate.EdFi.StudentSchoolAssociation,
+        StudentSchoolAssociationsNullWriteRequest,
+        StudentSchoolAssociationsNullWriteRequest,
+        Api.Common.Models.Requests.StudentSchoolAssociations.EdFi.Test_Profile_Some_References_With_Unified_Keys_Included.StudentSchoolAssociationDelete,
+        Api.Common.Models.Requests.StudentSchoolAssociations.EdFi.Test_Profile_Some_References_With_Unified_Keys_Included.StudentSchoolAssociationGetByExample>
+    {
+        public StudentSchoolAssociationsController(IPipelineFactory pipelineFactory, ISchoolYearContextProvider schoolYearContextProvider, IRESTErrorProvider restErrorProvider, IDefaultPageSizeLimitProvider defaultPageSizeLimitProvider, ApiSettings apiSettings)
+            : base(pipelineFactory, schoolYearContextProvider, restErrorProvider, defaultPageSizeLimitProvider, apiSettings)
+        {
+        }
+
+        protected override void MapAll(Api.Common.Models.Requests.StudentSchoolAssociations.EdFi.Test_Profile_Some_References_With_Unified_Keys_Included.StudentSchoolAssociationGetByExample request, Entities.Common.EdFi.IStudentSchoolAssociation specification)
+        {
+            // Copy all existing values
+            specification.SuspendReferenceAssignmentCheck();
+            specification.CalendarCode = request.CalendarCode;
+            specification.ClassOfSchoolYear = request.ClassOfSchoolYear;
+            specification.EducationOrganizationId = request.EducationOrganizationId;
+            specification.EmployedWhileEnrolled = request.EmployedWhileEnrolled;
+            specification.EntryDate = request.EntryDate;
+            specification.EntryGradeLevelDescriptor = request.EntryGradeLevelDescriptor;
+            specification.EntryGradeLevelReasonDescriptor = request.EntryGradeLevelReasonDescriptor;
+            specification.EntryTypeDescriptor = request.EntryTypeDescriptor;
+            specification.ExitWithdrawDate = request.ExitWithdrawDate;
+            specification.ExitWithdrawTypeDescriptor = request.ExitWithdrawTypeDescriptor;
+            specification.FullTimeEquivalency = request.FullTimeEquivalency;
+            specification.GraduationPlanTypeDescriptor = request.GraduationPlanTypeDescriptor;
+            specification.GraduationSchoolYear = request.GraduationSchoolYear;
+            specification.Id = request.Id;
+            specification.PrimarySchool = request.PrimarySchool;
+            specification.RepeatGradeIndicator = request.RepeatGradeIndicator;
+            specification.ResidencyStatusDescriptor = request.ResidencyStatusDescriptor;
+            specification.SchoolChoiceTransfer = request.SchoolChoiceTransfer;
+            specification.SchoolId = request.SchoolId;
+            specification.SchoolYear = request.SchoolYear;
+            specification.StudentUniqueId = request.StudentUniqueId;
+            specification.TermCompletionIndicator = request.TermCompletionIndicator;
+        }
+
+        protected override string GetReadContentType()
+        {
+            return "application/vnd.ed-fi.studentschoolassociation.test-profile-some-references-with-unified-keys-included.readable+json";
+        }
+
+        [ProducesResponseType(StatusCodes.Status405MethodNotAllowed)]
+        public override Task<IActionResult> Post(StudentSchoolAssociationsNullWriteRequest request)
+        {
+            return Task.FromResult<IActionResult>(
+                StatusCode(StatusCodes.Status405MethodNotAllowed,
+                ErrorTranslator
+                    .GetErrorMessage("The allowed methods for this resource with the 'Test-Profile-Some-References-With-Unified-Keys-Included' profile are GET, DELETE and OPTIONS.")));
+        }
+
+        [ProducesResponseType(StatusCodes.Status405MethodNotAllowed)]
+        public override Task<IActionResult> Put(StudentSchoolAssociationsNullWriteRequest request, Guid id)
+        {
+            return Task.FromResult<IActionResult>(
+                StatusCode(StatusCodes.Status405MethodNotAllowed,
+                ErrorTranslator
+                    .GetErrorMessage("The allowed methods for this resource with the 'Test-Profile-Some-References-With-Unified-Keys-Included' profile are GET, DELETE and OPTIONS.")));
+        }
+    }
+}
+
 namespace EdFi.Ods.Api.Services.Controllers.Staffs.EdFi.Test_Profile_StaffOnly_Resource_IncludeAll
 {
     [ApiExplorerSettings(IgnoreApi = true)]

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Profiles.Test_Pipelines_CreateOrUpdatePipelines.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Profiles.Test_Pipelines_CreateOrUpdatePipelines.generated.approved.cs
@@ -329,3 +329,7 @@ namespace EdFi.Ods.Api.Pipelines.MinimalStudentSchoolAssociation_IncludeOnly
 namespace EdFi.Ods.Api.Pipelines.MinimalStudentSchoolAssociation_ExcludeOnly
 {
 }
+
+namespace EdFi.Ods.Api.Pipelines.Test_Profile_Some_References_With_Unified_Keys_Included
+{
+}

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Profiles.Test_Pipelines_CreateOrUpdatePipelines.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Profiles.Test_Pipelines_CreateOrUpdatePipelines.generated.approved.cs
@@ -333,3 +333,7 @@ namespace EdFi.Ods.Api.Pipelines.MinimalStudentSchoolAssociation_ExcludeOnly
 namespace EdFi.Ods.Api.Pipelines.Test_Profile_Some_References_With_Unified_Keys_Included
 {
 }
+
+namespace EdFi.Ods.Api.Pipelines.Profile_Validation_Regression_References
+{
+}

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Profiles.Test_Requests_Requests.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Profiles.Test_Requests_Requests.generated.approved.cs
@@ -2226,3 +2226,60 @@ namespace EdFi.Ods.Api.Common.Models.Requests.StudentSchoolAssociations.EdFi.Min
     }
 }
 
+namespace EdFi.Ods.Api.Common.Models.Requests.StudentSchoolAssociations.EdFi.Test_Profile_Some_References_With_Unified_Keys_Included
+{
+
+    [ExcludeFromCodeCoverage]
+    public class StudentSchoolAssociationGetByExample
+    {
+        public string CalendarCode { get; set; }
+        public short ClassOfSchoolYear { get; set; }
+        public int EducationOrganizationId { get; set; }
+        public bool EmployedWhileEnrolled { get; set; }
+        public DateTime EntryDate { get; set; }
+        public string EntryGradeLevelDescriptor { get; set; }
+        public string EntryGradeLevelReasonDescriptor { get; set; }
+        public string EntryTypeDescriptor { get; set; }
+        public DateTime ExitWithdrawDate { get; set; }
+        public string ExitWithdrawTypeDescriptor { get; set; }
+        public decimal FullTimeEquivalency { get; set; }
+        public string GraduationPlanTypeDescriptor { get; set; }
+        public short GraduationSchoolYear { get; set; }
+        public Guid Id { get; set; }
+        public bool PrimarySchool { get; set; }
+        public bool RepeatGradeIndicator { get; set; }
+        public string ResidencyStatusDescriptor { get; set; }
+        public bool SchoolChoiceTransfer { get; set; }
+        public int SchoolId { get; set; }
+        public short SchoolYear { get; set; }
+        public string StudentUniqueId { get; set; }
+        public bool TermCompletionIndicator { get; set; }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class StudentSchoolAssociationGetByIds : IHasIdentifiers<Guid>
+    {
+        public StudentSchoolAssociationGetByIds() { }
+
+        public StudentSchoolAssociationGetByIds(params Guid[] ids)
+        {
+            Ids = new List<Guid>(ids);
+        }
+
+        public List<Guid> Ids { get; set; }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class StudentSchoolAssociationDelete : IHasIdentifier
+    {
+        public StudentSchoolAssociationDelete() { }
+
+        public StudentSchoolAssociationDelete(Guid id)
+        {
+            Id = id;
+        }
+
+        public Guid Id { get; set; }
+    }
+}
+

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Profiles.Test_Requests_Requests.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/ApprovalTests.Verify_All.ForScenario.Profiles.Test_Requests_Requests.generated.approved.cs
@@ -2283,3 +2283,47 @@ namespace EdFi.Ods.Api.Common.Models.Requests.StudentSchoolAssociations.EdFi.Tes
     }
 }
 
+namespace EdFi.Ods.Api.Common.Models.Requests.StudentCTEProgramAssociations.EdFi.Profile_Validation_Regression_References
+{
+
+    [ExcludeFromCodeCoverage]
+    public class StudentCTEProgramAssociationGetByExample
+    {
+        public DateTime BeginDate { get; set; }
+        public int EducationOrganizationId { get; set; }
+        public bool NonTraditionalGenderStatus { get; set; }
+        public bool PrivateCTEProgram { get; set; }
+        public int ProgramEducationOrganizationId { get; set; }
+        public string ProgramName { get; set; }
+        public string ProgramTypeDescriptor { get; set; }
+        public string StudentUniqueId { get; set; }
+        public string TechnicalSkillsAssessmentDescriptor { get; set; }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class StudentCTEProgramAssociationGetByIds : IHasIdentifiers<Guid>
+    {
+        public StudentCTEProgramAssociationGetByIds() { }
+
+        public StudentCTEProgramAssociationGetByIds(params Guid[] ids)
+        {
+            Ids = new List<Guid>(ids);
+        }
+
+        public List<Guid> Ids { get; set; }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class StudentCTEProgramAssociationDelete : IHasIdentifier
+    {
+        public StudentCTEProgramAssociationDelete() { }
+
+        public StudentCTEProgramAssociationDelete(Guid id)
+        {
+            Id = id;
+        }
+
+        public Guid Id { get; set; }
+    }
+}
+

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Generators/Resources/ResourceCollectionRenderer.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Generators/Resources/ResourceCollectionRenderer.cs
@@ -489,7 +489,7 @@ namespace EdFi.Ods.CodeGen.Generators.Resources
             var references = activeResource.References
                 .ToList();
 
-            if (!references.Any(x => profileData.IsIncluded(resource, x)))
+            if (!references.Any(r => profileData.IsIncluded(resource, r, out var implicitOnly) || implicitOnly))
             {
                 return ResourceRenderer.DoNotRenderProperty;
             }
@@ -499,7 +499,7 @@ namespace EdFi.Ods.CodeGen.Generators.Resources
                 return new
                 {
                     Collections = references
-                        .Where(x => profileData.IsIncluded(resource, x))
+                        .Where(r => profileData.IsIncluded(resource, r, out var implicitOnly) || implicitOnly)
                         .OrderBy(x => x.PropertyName)
                         .Select(
                             x =>
@@ -515,6 +515,8 @@ namespace EdFi.Ods.CodeGen.Generators.Resources
                                     ? x.ReferenceTypeName
                                     : $"{x.ReferencedResourceName}.{x.ReferencedResource.Entity.SchemaProperCaseName()}.{x.ReferenceTypeName}";
 
+                                profileData.IsIncluded(resource, x, out var implicitOnly);
+                                
                                 return new
                                 {
                                     Reference = new
@@ -537,7 +539,8 @@ namespace EdFi.Ods.CodeGen.Generators.Resources
                                         PropertyName = x.PropertyName,
                                         PropertyFieldName = x.PropertyName.ToCamelCase(),
                                         IsRequired = x.IsRequired,
-                                        IsIdentifying = x.Association.IsIdentifying
+                                        IsIdentifying = x.Association.IsIdentifying,
+                                        ImplicitOnly = implicitOnly
                                     },
                                     Standard = ResourceRenderer.DoRenderProperty
                                 };

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Metadata/ProfileMetadataValidator.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Metadata/ProfileMetadataValidator.cs
@@ -119,9 +119,7 @@ namespace EdFi.Ods.CodeGen.Metadata
 
                 if (IsReferenceProperty(propertyName))
                 {
-                    if (!domainResource.References.Any(
-                        reference => reference.PropertyName == propertyName &&
-                                     reference.ParentFullName.Name == GetContainingTable(propertyElement, resource)))
+                    if (!domainResource.ReferenceByName.ContainsKey(propertyName))
                     {
                         throw new IncomingReferenceException(propertyName, profile, domainResource.Name);
                     }

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Mustache/Resources.mustache
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Mustache/Resources.mustache
@@ -334,6 +334,7 @@ namespace {{ResourceClassesNamespace}}
             }
         }
         {{^ImplicitOnly}}
+
         [DataMember(Name="{{JsonPropertyName}}")]{{#IsIdentifying}}[NaturalKeyMember]{{/IsIdentifying}}
         public {{ReferenceTypeName}} {{PropertyName}}
         {

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Mustache/Resources.mustache
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Mustache/Resources.mustache
@@ -333,7 +333,7 @@ namespace {{ResourceClassesNamespace}}
                 return _{{PropertyFieldName}};
             }
         }
-
+        {{^ImplicitOnly}}
         [DataMember(Name="{{JsonPropertyName}}")]{{#IsIdentifying}}[NaturalKeyMember]{{/IsIdentifying}}
         public {{ReferenceTypeName}} {{PropertyName}}
         {
@@ -352,6 +352,7 @@ namespace {{ResourceClassesNamespace}}
                 _{{PropertyFieldName}} = value;
             }
         }
+        {{/ImplicitOnly}}
         {{/Reference}}
         {{/Standard}}
         {{#Backref}}


### PR DESCRIPTION
Fixed code generation issue where when a reference which has unified key properties is included, while the other reference(s) are not included, compilation would fail due to the missing private "implicit" reference artifacts.