### PR TITLE
[ODS-5601] Issues to do with Profiles on TEA project - Issue no. 2

### DIFF
--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Generators/Resources/ResourceProfileData.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Generators/Resources/ResourceProfileData.cs
@@ -291,8 +291,8 @@ namespace EdFi.Ods.CodeGen.Generators.Resources
             }
 
             return SuppliedResource != null
-                ? SuppliedResource.AllContainedItemTypes.FirstOrDefault(
-                    x => ModelComparers.Entity.Equals(x.Entity, resource.Entity))
+                ? SuppliedResource.AllContainedItemTypes.SingleOrDefault(
+                    x => ModelComparers.Resource.Equals(x, resource))
                 : null;
         }
 


### PR DESCRIPTION
Resources that come from an implicit extension don't have an Entity (Resource.Entity = null), so we shouldn't use Entity equality comparer.

Note that this issue cannot be reproduced with Sample's implicit extension _StudentEducationOrganizationAssociationStudentCharacteristicExtension_ since that's the only implicit extension in _StudentEducationOrganizationAssociationStudentCharacteristic_, so FirstOrDefault succeeds. To reproduce it, there must be at least 2 implicit extensions for a given resource.

If GetContainedResource fails to find a matching Resource then [IsIncluded](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/blob/main/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Generators/Resources/Resources.cs#L555) returns false, so the Collection instantiation doesn't get rendered and since the target collection is null in the mapping phase it doesn't get mapped.