### PR TITLE
ODS-5608 - Add x-nullable property to metadata for nullable properties

### DIFF
--- a/Application/EdFi.Ods.Features/OpenApiMetadata/Factories/OpenApiMetadataDocumentHelper.cs
+++ b/Application/EdFi.Ods.Features/OpenApiMetadata/Factories/OpenApiMetadataDocumentHelper.cs
@@ -67,7 +67,7 @@ namespace EdFi.Ods.Features.OpenApiMetadata.Factories
 
         public static Schema CreatePropertySchema(ResourceProperty resourceProperty)
         {
-            return new Schema
+            var schema =  new Schema
             {
                 type = PropertyType(resourceProperty),
                 format = resourceProperty.PropertyType.ToOpenApiFormat(),
@@ -77,6 +77,13 @@ namespace EdFi.Ods.Features.OpenApiMetadata.Factories
                 isDeprecated = GetIsDeprecated(resourceProperty),
                 deprecatedReasons = GetDeprecatedReasons(resourceProperty)
             };
+
+            if (resourceProperty.PropertyType.IsNullable)
+            {
+                schema.nullable = true;
+            }
+
+            return schema;
         }
 
         public static bool? GetIsIdentity(ResourceProperty resourceProperty)
@@ -145,15 +152,7 @@ namespace EdFi.Ods.Features.OpenApiMetadata.Factories
                                            {
                                                IsRequired = x.IsIdentifying || reference.IsRequired,
                                                PropertyName = x.JsonPropertyName,
-                                               Schema =
-                                                        new Schema
-                                                        {
-                                                            type = PropertyType(x),
-                                                            format = PropertyFormat(x),
-                                                            description = PropertyDescription(x),
-                                                            maxLength = GetMaxLength(x),
-                                                            isIdentity = GetIsIdentity(x)
-                                                        }
+                                               Schema = CreateNewSchemaFromResourceProperty(x)
                                            })
                                       .OrderBy(x => x.PropertyName)
                                       .ToList();
@@ -175,6 +174,25 @@ namespace EdFi.Ods.Features.OpenApiMetadata.Factories
                     .ToList(),
                 properties = propertyDict
             };
+        }
+
+        private static Schema CreateNewSchemaFromResourceProperty(ResourceProperty x)
+        {
+            var schema = new Schema
+            {
+                type = PropertyType(x),
+                format = PropertyFormat(x),
+                description = PropertyDescription(x),
+                maxLength = GetMaxLength(x),
+                isIdentity = GetIsIdentity(x)
+            };
+
+            if (x.PropertyType.IsNullable)
+            {
+                schema.nullable = true;
+            }
+
+            return schema;
         }
 
         public static Dictionary<string, Response> GetReadOperationResponses(string resourceName, bool isArray, bool isChangeQueryDeletes = false, bool isChangeQueryKeyChanges = false)

--- a/Application/EdFi.Ods.Features/OpenApiMetadata/Factories/OpenApiMetadataDocumentHelper.cs
+++ b/Application/EdFi.Ods.Features/OpenApiMetadata/Factories/OpenApiMetadataDocumentHelper.cs
@@ -152,7 +152,7 @@ namespace EdFi.Ods.Features.OpenApiMetadata.Factories
                                            {
                                                IsRequired = x.IsIdentifying || reference.IsRequired,
                                                PropertyName = x.JsonPropertyName,
-                                               Schema = CreateNewSchemaFromResourceProperty(x)
+                                               Schema = CreatePropertySchema(x)
                                            })
                                       .OrderBy(x => x.PropertyName)
                                       .ToList();
@@ -174,25 +174,6 @@ namespace EdFi.Ods.Features.OpenApiMetadata.Factories
                     .ToList(),
                 properties = propertyDict
             };
-        }
-
-        private static Schema CreateNewSchemaFromResourceProperty(ResourceProperty x)
-        {
-            var schema = new Schema
-            {
-                type = PropertyType(x),
-                format = PropertyFormat(x),
-                description = PropertyDescription(x),
-                maxLength = GetMaxLength(x),
-                isIdentity = GetIsIdentity(x)
-            };
-
-            if (x.PropertyType.IsNullable)
-            {
-                schema.nullable = true;
-            }
-
-            return schema;
         }
 
         public static Dictionary<string, Response> GetReadOperationResponses(string resourceName, bool isArray, bool isChangeQueryDeletes = false, bool isChangeQueryKeyChanges = false)

--- a/Application/EdFi.Ods.Features/OpenApiMetadata/Models/OpenApiMetadataDocument.cs
+++ b/Application/EdFi.Ods.Features/OpenApiMetadata/Models/OpenApiMetadataDocument.cs
@@ -209,7 +209,7 @@ namespace EdFi.Ods.Features.OpenApiMetadata.Models
         public bool? isIdentity;
 
         [JsonProperty("x-nullable")]
-        public bool nullable;
+        public bool? nullable;
 
         public Schema items;
 

--- a/Application/EdFi.Ods.Features/OpenApiMetadata/Models/OpenApiMetadataDocument.cs
+++ b/Application/EdFi.Ods.Features/OpenApiMetadata/Models/OpenApiMetadataDocument.cs
@@ -208,6 +208,9 @@ namespace EdFi.Ods.Features.OpenApiMetadata.Models
         [JsonProperty("x-Ed-Fi-isIdentity")]
         public bool? isIdentity;
 
+        [JsonProperty("x-nullable")]
+        public bool nullable;
+
         public Schema items;
 
         public int? maximum;


### PR DESCRIPTION
Now when the metadata is generated, any nullable properties will have x-nullable: true added like this:
```
        "disciplineActionLength": {
          "description": "The length of time in school days for the discipline action (e.g. removal, detention), if applicable.",
          "format": "double",
          "x-nullable": true,
          "type": "number"
        },
```
Which results in the generated sdk marking the property as nullable and setting EmitDefaultValue as true like this:

```
        [DataMember(Name = "disciplineActionLength", EmitDefaultValue = true)]
        public double? DisciplineActionLength { get; set; }
```

For any properties that are not nullable, this new x-nullable property will not show up in the metadata, and therefor will not have EmitDefaultValue = true, for example, DisciplineDate on StudentDiscipplineAction will look like this in the metadata just like before:
```
        "disciplineDate": {
          "description": "The date of the discipline action.",
          "format": "date",
          "x-Ed-Fi-isIdentity": true,
          "type": "string"
        },
```

And in the generated sdk will look like this:
```
        [DataMember(Name = "disciplineDate", IsRequired = true, EmitDefaultValue = false)]
        [JsonConverter(typeof(OpenAPIDateConverter))]
        public DateTime DisciplineDate { get; set; }
```
