### PR TITLE
ODS-5549 - Move EdFi.Database.Security build to Github Actions

### DIFF
--- a/.github/workflows/Packages - EdFi.Database.Admin.yml
+++ b/.github/workflows/Packages - EdFi.Database.Admin.yml
@@ -38,38 +38,21 @@ jobs:
         dotnet-version: 6.0.x
     - name: Support longpaths
       run: git config --system core.longpaths true
+    - name: Checkout Ed-Fi-ODS
+      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
+      with:
+          repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
+          path: Ed-Fi-ODS/
     - name: Checkout Ed-Fi-ODS-Implementation
       uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
       with:
           repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation
           path: Ed-Fi-ODS-Implementation/
     - name: Is pull request branch exists in Ed-Fi-ODS-Implementation
-      working-directory: ./Ed-Fi-ODS-Implementation/
-      shell: pwsh
-      run: |
-          $patternName = 'refs/heads/' +  '${{ env.CURRENT_BRANCH }}'
-          $is_pull_request_branch = 'False'
-          $is_pull_request_branch = git ls-remote --heads origin ${{ env.CURRENT_BRANCH }} | Select-String -Pattern $patternName -SimpleMatch -Quiet
-          if ($is_pull_request_branch -eq $true) {
-            git fetch origin ${{ env.CURRENT_BRANCH }}
-            git checkout ${{ env.CURRENT_BRANCH }}
-          }          
-    - name: Checkout Ed-Fi-ODS
-      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
-      with:
-          repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
-          path: Ed-Fi-ODS/
-    - name: Is pull request branch exists in Ed-Fi-ODS
       working-directory: ./Ed-Fi-ODS/
       shell: pwsh
       run: |
-          $patternName = 'refs/heads/' +  '${{ env.CURRENT_BRANCH }}'
-          $is_pull_request_branch = 'False'
-          $is_pull_request_branch = git ls-remote --heads origin ${{ env.CURRENT_BRANCH }} | Select-String -Pattern $patternName -SimpleMatch -Quiet
-          if ($is_pull_request_branch -eq $true) {
-            git fetch origin ${{ env.CURRENT_BRANCH }}
-            git checkout ${{ env.CURRENT_BRANCH }}
-          }
+        ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"
     - name: Install sql-server-2019, sqlpackage, and postgres13
       shell: pwsh
       run: |
@@ -96,7 +79,7 @@ jobs:
         [int]$BuildIncrementer = "${{ env.BUILD_INCREMENTER }}"
         [int]$newRevision =  $BuildCounter + $BuildIncrementer
         [string]$version = "${{env.INFORMATIONAL_VERSION}}"+ "." + $newRevision.ToString()
-        $packageOutput = "$env:GITHUB_WORKSPACE/NugetPackages"
+        $packageOutput = "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/NugetPackages"
         $AdminNuspecFilePath = "$env:GITHUB_WORKSPACE/NugetPackages/EdFi.Database.Admin.nuspec"
         $AdminBACPACNuspecFilePath = "$env:GITHUB_WORKSPACE/NugetPackages/EdFi.Database.Admin.BACPAC.nuspec"
         $AdminPostgreSQLNuspecFilePath = "$env:GITHUB_WORKSPACE/NugetPackages/EdFi.Database.Admin.PostgreSQL.nuspec"
@@ -105,13 +88,13 @@ jobs:
         nuget pack $AdminPostgreSQLNuspecFilePath -OutputDirectory $packageOutput -Version $version -Properties "configuration=release" -Properties "authors=Ed-Fi Alliance" -Properties "owners=Ed-Fi Alliance" -Properties "copyright=Copyright ©Ed-Fi Alliance, LLC. 2020" -NoPackageAnalysis -NoDefaultExcludes
     - name: Install-credential-handler
       run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
-      shell: powershell
+      shell: pwsh
     - name: Publish Nuget package
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
-        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Admin"
-        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Admin.BACPAC"
-        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Admin.PostgreSQL"
+        ./build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Admin"
+        ./build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Admin.BACPAC"
+        ./build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Admin.PostgreSQL"
     - name: Upload EdFi.Database.Admin Artifacts
       if: success()
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0

--- a/.github/workflows/Packages - EdFi.Database.Admin.yml
+++ b/.github/workflows/Packages - EdFi.Database.Admin.yml
@@ -24,7 +24,8 @@ env:
   AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
   VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
   CONFIGURATION: "Release"
-  CURRENT_BRANCH:  ${{ GITHUB.HEAD_REF }}
+  HEAD_REF:  ${{ GITHUB.HEAD_REF }}
+  REF_NAME:  ${{ GITHUB.REF_NAME }}
 
 jobs:
   build:

--- a/.github/workflows/Packages - EdFi.Database.Admin.yml
+++ b/.github/workflows/Packages - EdFi.Database.Admin.yml
@@ -104,7 +104,15 @@ jobs:
         nuget pack $AdminNuspecFilePath -OutputDirectory $packageOutput -Version $version -Properties "configuration=release" -Properties "authors=Ed-Fi Alliance" -Properties "owners=Ed-Fi Alliance" -Properties "copyright=Copyright ©Ed-Fi Alliance, LLC. 2020" -NoPackageAnalysis -NoDefaultExcludes
         nuget pack $AdminBACPACNuspecFilePath -OutputDirectory $packageOutput -Version $version -Properties "configuration=release" -Properties "authors=Ed-Fi Alliance" -Properties "owners=Ed-Fi Alliance" -Properties "copyright=Copyright ©Ed-Fi Alliance, LLC. 2020" -NoPackageAnalysis -NoDefaultExcludes
         nuget pack $AdminPostgreSQLNuspecFilePath -OutputDirectory $packageOutput -Version $version -Properties "configuration=release" -Properties "authors=Ed-Fi Alliance" -Properties "owners=Ed-Fi Alliance" -Properties "copyright=Copyright ©Ed-Fi Alliance, LLC. 2020" -NoPackageAnalysis -NoDefaultExcludes
- 
+    - name: Install-credential-handler
+      run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
+      shell: powershell
+    - name: Publish Nuget package
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      run: |
+        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Admin"
+        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Admin.BACPAC"
+        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Admin.PostgreSQL"
     - name: Upload EdFi.Database.Admin Artifacts
       if: success()
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0

--- a/.github/workflows/Packages - EdFi.Database.Admin.yml
+++ b/.github/workflows/Packages - EdFi.Database.Admin.yml
@@ -16,11 +16,7 @@ on:
     paths:
       - '**.sql'
   workflow_dispatch:
-    inputs:
-      logLevel:
-        description: 'Log level'
-        required: true
-        default: 'warning'
+
 env:
   INFORMATIONAL_VERSION: "6.1"
   BUILD_INCREMENTER: "1"

--- a/.github/workflows/Packages - EdFi.Database.Admin.yml
+++ b/.github/workflows/Packages - EdFi.Database.Admin.yml
@@ -24,6 +24,9 @@ on:
 env:
   INFORMATIONAL_VERSION: "6.1"
   BUILD_INCREMENTER: "1"
+  AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+  AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
+  VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
   CONFIGURATION: "Release"
   CURRENT_BRANCH:  ${{ GITHUB.HEAD_REF }}
 

--- a/.github/workflows/Packages - EdFi.Database.Security.yml
+++ b/.github/workflows/Packages - EdFi.Database.Security.yml
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: Packages - EdFi.Database.Security
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**.sql'
+  push:
+    branches:
+      - main
+    paths:
+      - '**.sql'
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+env:
+  INFORMATIONAL_VERSION: "6.1"
+  BUILD_INCREMENTER: "19"
+  CONFIGURATION: "Release"
+  HEAD_REF:  ${{ GITHUB.HEAD_REF }}
+  REF_NAME:  ${{ GITHUB.REF_NAME }}
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Setup .NET
+      uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # v2.1.0
+      with:
+        dotnet-version: 6.0.x
+    - name: Support longpaths
+      run: git config --system core.longpaths true
+    - name: Checkout Ed-Fi-ODS
+      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
+      with:
+          repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
+          path: Ed-Fi-ODS/
+    - name: Checkout Ed-Fi-ODS-Implementation
+      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
+      with:
+          repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation
+          path: Ed-Fi-ODS-Implementation/
+    - name: Is pull request branch exists in Ed-Fi-ODS-Implementation
+      working-directory: ./Ed-Fi-ODS/
+      shell: powershell
+      run: |
+        .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"
+    - name: Install sql-server-2019, sqlpackage, and postgres13
+      shell: pwsh
+      run: |
+          choco install sql-server-2019  -y --params "'/IGNOREPENDINGREBOOT /IACCEPTSQLSERVERLICENSETERMS /Q /ACTION=install /INSTANCEID=MSSQLSERVER /INSTANCENAME=MSSQLSERVER /TCPENABLED=1 /UPDATEENABLED=FALSE /FEATURES=SQL,Tools'" --execution-timeout=$installTimeout
+          choco install sqlpackage
+          choco install postgresql13 --params '/Password:postgres'
+          $confPath = "C:\Program Files\PostgreSQL\13\data\pg_hba.conf"
+          (Get-Content $confPath).Replace("scram-sha-256","trust") | Set-Content $confPath
+          Restart-Service postgresql-x64-13
+    - name: Create Security Database 
+      shell: pwsh
+      run: |
+          $ErrorActionPreference = 'Stop'
+          $PSVersionTable
+          . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/logistics/scripts/activities/build/create-database-package.ps1 -Output NugetPackages -DatabaseType Security -SQLPackage "C:\ProgramData\chocolatey\lib\sqlpackage\tools"
+    - name: Use NuGet
+      uses: nuget/setup-nuget@b2bc17b761a1d88cab755a776c7922eb26eefbfa # v1
+      with:
+        nuget-version: '5.x'
+    - name: Create NuGet package
+      shell: pwsh
+      run: |
+        [int]$BuildCounter =  "${{ github.run_number }}"
+        [int]$BuildIncrementer = "${{ env.BUILD_INCREMENTER }}"
+        [int]$newRevision =  $BuildCounter + $BuildIncrementer
+        [string]$version = "${{env.INFORMATIONAL_VERSION}}"+ "." + $newRevision.ToString()
+        $packageOutput = "$env:GITHUB_WORKSPACE/NugetPackages"
+        $SecurityNuspecFilePath = "$env:GITHUB_WORKSPACE/NugetPackages/EdFi.Database.Security.nuspec"
+        $SecurityBACPACNuspecFilePath = "$env:GITHUB_WORKSPACE/NugetPackages/EdFi.Database.Security.BACPAC.nuspec"
+        $SecurityPostgreSQLNuspecFilePath = "$env:GITHUB_WORKSPACE/NugetPackages/EdFi.Database.Security.PostgreSQL.nuspec"
+        nuget pack $SecurityNuspecFilePath -OutputDirectory $packageOutput -Version $version -Properties "configuration=release" -Properties "authors=Ed-Fi Alliance" -Properties "owners=Ed-Fi Alliance" -Properties "copyright=Copyright ©Ed-Fi Alliance, LLC. 2020" -NoPackageAnalysis -NoDefaultExcludes
+        nuget pack $SecurityBACPACNuspecFilePath -OutputDirectory $packageOutput -Version $version -Properties "configuration=release" -Properties "authors=Ed-Fi Alliance" -Properties "owners=Ed-Fi Alliance" -Properties "copyright=Copyright ©Ed-Fi Alliance, LLC. 2020" -NoPackageAnalysis -NoDefaultExcludes
+        nuget pack $SecurityPostgreSQLNuspecFilePath -OutputDirectory $packageOutput -Version $version -Properties "configuration=release" -Properties "authors=Ed-Fi Alliance" -Properties "owners=Ed-Fi Alliance" -Properties "copyright=Copyright ©Ed-Fi Alliance, LLC. 2020" -NoPackageAnalysis -NoDefaultExcludes
+    - name: Upload EdFi.Database.Security Artifacts
+      if: success()
+      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+      with:
+        name: NugetPackages.Artifacts
+        path: ${{ github.workspace }}/NugetPackages/*.nupkg

--- a/.github/workflows/Packages - EdFi.Database.Security.yml
+++ b/.github/workflows/Packages - EdFi.Database.Security.yml
@@ -16,11 +16,7 @@ on:
     paths:
       - '**.sql'
   workflow_dispatch:
-    inputs:
-      logLevel:
-        description: 'Log level'
-        required: true
-        default: 'warning'
+
 env:
   INFORMATIONAL_VERSION: "6.1"
   BUILD_INCREMENTER: "19"

--- a/.github/workflows/Packages - EdFi.Database.Security.yml
+++ b/.github/workflows/Packages - EdFi.Database.Security.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   INFORMATIONAL_VERSION: "6.1"
-  BUILD_INCREMENTER: "19"
+  BUILD_INCREMENTER: "25"
   AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
   AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
   VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'

--- a/.github/workflows/Packages - EdFi.Database.Security.yml
+++ b/.github/workflows/Packages - EdFi.Database.Security.yml
@@ -88,6 +88,16 @@ jobs:
         nuget pack $SecurityNuspecFilePath -OutputDirectory $packageOutput -Version $version -Properties "configuration=release" -Properties "authors=Ed-Fi Alliance" -Properties "owners=Ed-Fi Alliance" -Properties "copyright=Copyright ©Ed-Fi Alliance, LLC. 2020" -NoPackageAnalysis -NoDefaultExcludes
         nuget pack $SecurityBACPACNuspecFilePath -OutputDirectory $packageOutput -Version $version -Properties "configuration=release" -Properties "authors=Ed-Fi Alliance" -Properties "owners=Ed-Fi Alliance" -Properties "copyright=Copyright ©Ed-Fi Alliance, LLC. 2020" -NoPackageAnalysis -NoDefaultExcludes
         nuget pack $SecurityPostgreSQLNuspecFilePath -OutputDirectory $packageOutput -Version $version -Properties "configuration=release" -Properties "authors=Ed-Fi Alliance" -Properties "owners=Ed-Fi Alliance" -Properties "copyright=Copyright ©Ed-Fi Alliance, LLC. 2020" -NoPackageAnalysis -NoDefaultExcludes
+    - name: Install-credential-handler
+      run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
+      shell: powershell
+    - name: Publish Nuget package
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      run: |
+        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Security"
+        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Security.BACPAC"
+        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Security.PostgreSQL"
+      shell: powershell
     - name: Upload EdFi.Database.Security Artifacts
       if: success()
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0

--- a/.github/workflows/Packages - EdFi.Database.Security.yml
+++ b/.github/workflows/Packages - EdFi.Database.Security.yml
@@ -24,6 +24,9 @@ on:
 env:
   INFORMATIONAL_VERSION: "6.1"
   BUILD_INCREMENTER: "19"
+  AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+  AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
+  VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
   CONFIGURATION: "Release"
   HEAD_REF:  ${{ GITHUB.HEAD_REF }}
   REF_NAME:  ${{ GITHUB.REF_NAME }}

--- a/.github/workflows/Packages - EdFi.Database.Security.yml
+++ b/.github/workflows/Packages - EdFi.Database.Security.yml
@@ -51,9 +51,9 @@ jobs:
           path: Ed-Fi-ODS-Implementation/
     - name: Is pull request branch exists in Ed-Fi-ODS-Implementation
       working-directory: ./Ed-Fi-ODS/
-      shell: powershell
+      shell: pwsh
       run: |
-        .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"
+        ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"
     - name: Install sql-server-2019, sqlpackage, and postgres13
       shell: pwsh
       run: |
@@ -80,7 +80,7 @@ jobs:
         [int]$BuildIncrementer = "${{ env.BUILD_INCREMENTER }}"
         [int]$newRevision =  $BuildCounter + $BuildIncrementer
         [string]$version = "${{env.INFORMATIONAL_VERSION}}"+ "." + $newRevision.ToString()
-        $packageOutput = "$env:GITHUB_WORKSPACE/NugetPackages"
+        $packageOutput = "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/NugetPackages"
         $SecurityNuspecFilePath = "$env:GITHUB_WORKSPACE/NugetPackages/EdFi.Database.Security.nuspec"
         $SecurityBACPACNuspecFilePath = "$env:GITHUB_WORKSPACE/NugetPackages/EdFi.Database.Security.BACPAC.nuspec"
         $SecurityPostgreSQLNuspecFilePath = "$env:GITHUB_WORKSPACE/NugetPackages/EdFi.Database.Security.PostgreSQL.nuspec"
@@ -89,14 +89,14 @@ jobs:
         nuget pack $SecurityPostgreSQLNuspecFilePath -OutputDirectory $packageOutput -Version $version -Properties "configuration=release" -Properties "authors=Ed-Fi Alliance" -Properties "owners=Ed-Fi Alliance" -Properties "copyright=Copyright ©Ed-Fi Alliance, LLC. 2020" -NoPackageAnalysis -NoDefaultExcludes
     - name: Install-credential-handler
       run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
-      shell: powershell
+      shell: pwsh
     - name: Publish Nuget package
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
-        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Security"
-        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Security.BACPAC"
-        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Security.PostgreSQL"
-      shell: powershell
+        ./build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Security"
+        ./build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Security.BACPAC"
+        ./build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Security.PostgreSQL"
+      shell: pwsh
     - name: Upload EdFi.Database.Security Artifacts
       if: success()
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0

--- a/Artifacts/MsSql/Data/Security/2100-UpdateClaimSetInternalUseOnlyColum.sql
+++ b/Artifacts/MsSql/Data/Security/2100-UpdateClaimSetInternalUseOnlyColum.sql
@@ -4,6 +4,6 @@
 -- See the LICENSE and NOTICES files in the project root for more information.
 
 UPDATE [dbo].[ClaimSets]
-SET [IsEdfiPreset] = 1  
+SET [IsEdfiPreset] = 1   
 WHERE [ClaimSetName] in ('Ed-Fi API Publisher - Reader','Ed-Fi API Publisher - Writer','Finance Vendor')
 GO

--- a/Artifacts/MsSql/Data/Security/2100-UpdateClaimSetInternalUseOnlyColum.sql
+++ b/Artifacts/MsSql/Data/Security/2100-UpdateClaimSetInternalUseOnlyColum.sql
@@ -4,6 +4,6 @@
 -- See the LICENSE and NOTICES files in the project root for more information.
 
 UPDATE [dbo].[ClaimSets]
-SET [IsEdfiPreset] = 1   
+SET [IsEdfiPreset] = 1 
 WHERE [ClaimSetName] in ('Ed-Fi API Publisher - Reader','Ed-Fi API Publisher - Writer','Finance Vendor')
 GO

--- a/Artifacts/MsSql/Data/Security/2100-UpdateClaimSetInternalUseOnlyColum.sql
+++ b/Artifacts/MsSql/Data/Security/2100-UpdateClaimSetInternalUseOnlyColum.sql
@@ -4,6 +4,6 @@
 -- See the LICENSE and NOTICES files in the project root for more information.
 
 UPDATE [dbo].[ClaimSets]
-SET [IsEdfiPreset] = 1
+SET [IsEdfiPreset] = 1  
 WHERE [ClaimSetName] in ('Ed-Fi API Publisher - Reader','Ed-Fi API Publisher - Writer','Finance Vendor')
 GO

--- a/Artifacts/MsSql/Data/Security/2100-UpdateClaimSetInternalUseOnlyColum.sql
+++ b/Artifacts/MsSql/Data/Security/2100-UpdateClaimSetInternalUseOnlyColum.sql
@@ -4,6 +4,6 @@
 -- See the LICENSE and NOTICES files in the project root for more information.
 
 UPDATE [dbo].[ClaimSets]
-SET [IsEdfiPreset] = 1
+SET [IsEdfiPreset] = 1 
 WHERE [ClaimSetName] in ('Ed-Fi API Publisher - Reader','Ed-Fi API Publisher - Writer','Finance Vendor')
 GO

--- a/Artifacts/MsSql/Data/Security/2100-UpdateClaimSetInternalUseOnlyColum.sql
+++ b/Artifacts/MsSql/Data/Security/2100-UpdateClaimSetInternalUseOnlyColum.sql
@@ -4,6 +4,6 @@
 -- See the LICENSE and NOTICES files in the project root for more information.
 
 UPDATE [dbo].[ClaimSets]
-SET [IsEdfiPreset] = 1 
+SET [IsEdfiPreset] = 1
 WHERE [ClaimSetName] in ('Ed-Fi API Publisher - Reader','Ed-Fi API Publisher - Writer','Finance Vendor')
 GO


### PR DESCRIPTION
This added a new workflow for building and publishing the EdFi.Database.Security packages:
EdFi.Database.Security
EdFi.Database.Security.BACPAC
EdFi.Database.Security.PostgreSQL

Additionally, the EdFi.Database.Admin workflow was cleaned up to use pwsh, fix paths for use in linux, remove manual workflow dispath inputs, use the new Powreshell script for checking out the right branch, and added the publish step that was not in there before (due to it originally running against Postgres14).

If you look at the commit `Cleanup Database.Admin workflow` that is where you will be able to see the successful building and publishing of the packages for both of these workflows.