### PR TITLE
ODS-5625 - Use Forwarded Headers in API when configured to use reverse proxy headers

### DIFF
--- a/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
+++ b/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
@@ -259,6 +259,11 @@ namespace EdFi.Ods.Api.Startup
 
             Container = app.ApplicationServices.GetAutofacRoot();
 
+            if (ApiSettings.UseReverseProxyHeaders.HasValue && ApiSettings.UseReverseProxyHeaders.Value)
+            {
+                app.UseForwardedHeaders();
+            }
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();


### PR DESCRIPTION
This is similar to what we already do in Sandbox and Swagger projects. Currently [we are configured](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/blob/main/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs#L199) to only forward the following already:
- XForwardedFor
- XForwardedHost
- XForwardedProto

So if more need to be forwarded an additional code change would be needed.