### PR TITLE
ODS-5639 - Update to use latest supported System.Data.SqlClient

### DIFF
--- a/Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj
+++ b/Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.7" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.16" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="log4net" Version="2.0.13" />

--- a/Application/EdFi.Common/EdFi.Common.csproj
+++ b/Application/EdFi.Common/EdFi.Common.csproj
@@ -16,6 +16,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Npgsql" Version="6.0.3" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 </Project>

--- a/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
+++ b/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.1" />
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="6.1.13" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.7" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.16" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.1.19" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FluentValidation" Version="10.4.0" />

--- a/Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj
+++ b/Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.7" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.16" />
     <PackageReference Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
@@ -27,7 +27,7 @@
     <PackageReference Include="Sandwych.QuickGraph.Core" Version="1.0.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />

--- a/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
+++ b/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.7" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.16" />
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.3.0" />

--- a/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
+++ b/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="6.1.13" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.7" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.16" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="Dapper" Version="2.0.123" />

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Autofac.Extras.FakeItEasy" Version="7.0.0" />
     <PackageReference Include="AutoMapper" Version="11.0.1" />
     <PackageReference Include="CompareNETObjects" Version="4.76.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.7" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.16" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFrameworkTesting.FakeItEasy" Version="1.3.0" />
     <PackageReference Include="FakeItEasy" Version="7.3.0" />

--- a/Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj
+++ b/Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj
@@ -15,7 +15,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.7" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.16" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="Npgsql" Version="6.0.3" />

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/EdFi.Ods.CodeGen.csproj
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/EdFi.Ods.CodeGen.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="DatabaseSchemaReader" Version="2.7.11" />
-    <PackageReference  Include="FluentValidation" Version="10.4.0" />
+    <PackageReference Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
@@ -41,7 +41,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Stubble.Core" Version="1.9.3" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Application\EdFi.Ods.Common\EdFi.Ods.Common.csproj" />

--- a/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj
+++ b/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.7" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.16" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
@@ -21,7 +21,7 @@
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="aqua-graphcompare" Version="1.2.2" />
-      <PackageReference Include="EdFi.Suite3.Common" Version="6.1.7" />
+      <PackageReference Include="EdFi.Suite3.Common" Version="6.1.16" />
       <PackageReference Include="EdFi.Suite3.OdsApi.TestSdk" Version="6.1.2" />
       <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
       <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />

--- a/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.3.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.7" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.16" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
     <PackageReference Include="log4net" Version="2.0.13" />

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.7" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.16" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
     <PackageReference Include="log4net" Version="2.0.13" />

--- a/Utilities/DataLoading/EdFi.XmlLookup.Console/EdFi.XmlLookup.Console.csproj
+++ b/Utilities/DataLoading/EdFi.XmlLookup.Console/EdFi.XmlLookup.Console.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.7" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.16" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />

--- a/Utilities/GenerateSecurityGraphs/GenerateSecurityGraphs/GenerateSecurityGraphs.csproj
+++ b/Utilities/GenerateSecurityGraphs/GenerateSecurityGraphs/GenerateSecurityGraphs.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="QuikGraph" Version="2.3.0" />
     <PackageReference Include="QuikGraph.Graphviz" Version="2.3.1" />
     <PackageReference Include="QuikGraph.Serialization" Version="2.3.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -7,7 +7,7 @@
 param(
     # Command to execute, defaults to "Build".
     [string]
-    [ValidateSet("Clean", "Build", "Test", "Pack", "Publish", "CheckoutBranch")]
+    [ValidateSet("Cleanup", "Build", "Test", "Pack", "Publish", "CheckoutBranch")]
     $Command = "Build",
 
     [switch] $SelfContained,
@@ -115,7 +115,7 @@ function Invoke-Main {
     }
 }
 
-function Clean {
+function Cleanup {
     Invoke-Execute { dotnet clean $Solution -c $Configuration --nologo -v minimal }
 }
 
@@ -209,8 +209,12 @@ function CheckoutBranch {
 
 function Invoke-Build {
     Write-Host "Building Version $version" -ForegroundColor Cyan
-    Invoke-Step { Clean }
+    Invoke-Step { Cleanup }
     Invoke-Step { Compile }
+}
+
+function Invoke-Cleanup {
+    Invoke-Step { Cleanup }
 }
 
 function Invoke-Publish {
@@ -231,7 +235,7 @@ function Invoke-CheckoutBranch {
 
 Invoke-Main {
     switch ($Command) {
-        Clean { Invoke-Clean }
+        Cleanup { Invoke-Cleanup }
         Build { Invoke-Build }
         Test { Invoke-Tests }
         Pack { Invoke-Pack }

--- a/tests/EdFi.Admin.DataAccess.UnitTests/EdFi.Admin.DataAccess.UnitTests.csproj
+++ b/tests/EdFi.Admin.DataAccess.UnitTests/EdFi.Admin.DataAccess.UnitTests.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.7" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.16" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />

--- a/tests/EdFi.Ods.Api.IntegrationTests/EdFi.Ods.Api.IntegrationTests.csproj
+++ b/tests/EdFi.Ods.Api.IntegrationTests/EdFi.Ods.Api.IntegrationTests.csproj
@@ -24,7 +24,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Shouldly" Version="4.0.3" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.36" />
   </ItemGroup>
 

--- a/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
+++ b/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="ApprovalTests" Version="5.7.2" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.7" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.16" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.3.0" />
     <PackageReference Include="FluentValidation" Version="10.4.0" />

--- a/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
+++ b/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="ApprovalUtilities" Version="5.7.2" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.7" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.16" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.2" />

--- a/tests/EdFi.Security.DataAccess.UnitTests/EdFi.Security.DataAccess.UnitTests.csproj
+++ b/tests/EdFi.Security.DataAccess.UnitTests/EdFi.Security.DataAccess.UnitTests.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.7" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="6.1.16" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFrameworkTesting.FakeItEasy" Version="1.3.0" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />


### PR DESCRIPTION
Along with relevant updates to EdFi.Suite3.Common and Edfi.Suite3.Ods.Common packages to utilize the newer versions built with the newer SqlClient