### PR TITLE
[ODS-5662] DestructiveSdk smoke tests fail if executed from Linux

### DIFF
--- a/Utilities/DataLoading/EdFi.LoadTools/Engine/Constants.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/Engine/Constants.cs
@@ -36,6 +36,8 @@ namespace EdFi.LoadTools.Engine
         public const string InterchangeNameRegex =
             @"^(?<InterchangeType>Interchange[A-Za-z]+)";
 
+        public const char PropertyPathSeparator = '\\';
+
         public static readonly AtomicTypePairs[] AtomicTypes =
         {
             new AtomicTypePairs(XmlTypes.Boolean, JsonTypes.Boolean), new AtomicTypePairs(XmlTypes.Date, JsonTypes.Date),

--- a/Utilities/DataLoading/EdFi.LoadTools/Mapping/Mapper.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/Mapping/Mapper.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.LoadTools.Engine;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -45,7 +46,7 @@ namespace EdFi.LoadTools.Mapping
                 return;
             }
 
-            var path = new Queue<string>(propertyPath.Split(Path.DirectorySeparatorChar));
+            var path = new Queue<string>(propertyPath.Split(Constants.PropertyPathSeparator));
             var propDesc = TypeDescriptor.GetProperties(component)[path.Dequeue()];
 
             while (path.Count > 0)
@@ -67,7 +68,7 @@ namespace EdFi.LoadTools.Mapping
 
         private static object GetDeepValue(object component, string propertyPath)
         {
-            var path = new Queue<string>(propertyPath.Split(Path.DirectorySeparatorChar));
+            var path = new Queue<string>(propertyPath.Split(Constants.PropertyPathSeparator));
 
             while (path.Count > 0 && component != null)
             {

--- a/Utilities/DataLoading/EdFi.LoadTools/Mapping/MapperConfigurationExpression.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/Mapping/MapperConfigurationExpression.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.LoadTools.Engine;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -115,19 +116,21 @@ namespace EdFi.LoadTools.Mapping
                     continue;
                 }
 
+                var propertyPath = $"{path}{Constants.PropertyPathSeparator}{propertyInfo.Name}".Trim(Constants.PropertyPathSeparator);
+
                 if (propertyInfo.PropertyType.IsPrimitiveType())
                 {
                     yield return
                         new PropertyInfoEx
                         {
-                            Path = Path.Combine(path, propertyInfo.Name), PropertyInfo = propertyInfo
+                            Path = propertyPath, PropertyInfo = propertyInfo
                         };
                 }
                 else
                 {
                     foreach (
                         var childPropertyInfo in
-                        GetRecursiveProperties(propertyInfo.PropertyType, Path.Combine(path, propertyInfo.Name))
+                        GetRecursiveProperties(propertyInfo.PropertyType, propertyPath)
                     )
                     {
                         yield return childPropertyInfo;


### PR DESCRIPTION
The smoke tests use fuzzy search to know how to map properties from the EvaluationRating into the needed EvaluationRatingReference in EvaluationObjectiveRatings.

The fuzzy search constructs candidates separating them with '\\', for example, to resolve EvaluationRatingReference\PersonId, a candidate is `EvaluationRating\PerformanceEvaluationRatingReference\PersonId`, another candidate is `EvaluationRating\Reviewers\PersonId`, and a score is given to each candidate based on how similar the paths are. The candidate with the highest score gets used.

In Linux, the directory separator char is '/' which is treated differently by the [method ](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/blob/66d976f8922ac0f75324a1cdc7c04d06b2e44143/Utilities/DataLoading/EdFi.LoadTools/Engine/ExtensionMethods.cs#L112)that calculates the scores, so different candidates are selected.

With this change, I always use '\\' as property path separator, which is safe since we are not working with directories.