### PR TITLE
[ODS-5680] Descriptor cache performs full refresh with a cache miss

### DIFF
--- a/Application/EdFi.Ods.Api/Caching/DescriptorsCache.cs
+++ b/Application/EdFi.Ods.Api/Caching/DescriptorsCache.cs
@@ -8,6 +8,7 @@ using EdFi.Ods.Api.Dtos;
 using EdFi.Ods.Api.Extensions;
 using EdFi.Ods.Api.Providers;
 using EdFi.Ods.Common.Caching;
+using EdFi.Ods.Common.Configuration;
 using EdFi.Ods.Common.Exceptions;
 using EdFi.Ods.Common.Providers;
 using EdFi.Ods.Common.Specifications;
@@ -19,7 +20,6 @@ namespace EdFi.Ods.Api.Caching
 {
     public class DescriptorsCache : IDescriptorsCache
     {
-        private const int DatabaseSynchronizationExpirationSeconds = 60;
         private const string DescriptorCacheKeyPrefix = "Descriptors";
         private const string InitializedKeyPrefix = "DescriptorsCache.Initialized";
         private const string LastSyncedKey = "DescriptorsCache.LastSynced";
@@ -33,15 +33,18 @@ namespace EdFi.Ods.Api.Caching
         private readonly ICacheProvider _cacheProvider;
         private readonly IDescriptorLookupProvider _descriptorLookupProvider;
         private readonly IEdFiOdsInstanceIdentificationProvider _edFiOdsInstanceIdentificationProvider;
+        private readonly int _databaseSynchronizationExpirationSeconds;
 
         public DescriptorsCache(
             IDescriptorLookupProvider descriptorLookupProvider,
             ICacheProvider cacheProvider,
-            IEdFiOdsInstanceIdentificationProvider edFiOdsInstanceIdentificationProvider)
+            IEdFiOdsInstanceIdentificationProvider edFiOdsInstanceIdentificationProvider,
+            ApiSettings apiSettings)
         {
             _descriptorLookupProvider = descriptorLookupProvider;
             _cacheProvider = cacheProvider;
             _edFiOdsInstanceIdentificationProvider = edFiOdsInstanceIdentificationProvider;
+            _databaseSynchronizationExpirationSeconds = apiSettings.Caching.Descriptors.AbsoluteExpirationSeconds;
         }
 
         private bool HasLastDatabaseSynchronizationExpired
@@ -56,7 +59,7 @@ namespace EdFi.Ods.Api.Caching
                 }
 
                 var totalSeconds = (currentTime - (DateTime) lastSynced).TotalSeconds;
-                return totalSeconds > DatabaseSynchronizationExpirationSeconds;
+                return totalSeconds > _databaseSynchronizationExpirationSeconds;
             }
         }
 

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/DescriptorsCacheTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/DescriptorsCacheTests.cs
@@ -58,8 +58,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
 
         protected IEdFiOdsInstanceIdentificationProvider MockEdFiOdsInstanceIdentificationProvider { get; set; }
 
-        protected DescriptorsCache descriptionCache;
-
         private IDescriptorsCache MockNHibernateCallsAndInitializeCache()
         {
             MockDescriptorCacheDataProvider = A.Fake<IDescriptorLookupProvider>();
@@ -103,9 +101,8 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
             A.CallTo(() => MockEdFiOdsInstanceIdentificationProvider.GetInstanceIdentification())
                 .Returns(1UL);
 
-            descriptionCache = new DescriptorsCache(
+            return new DescriptorsCache(
                 MockDescriptorCacheDataProvider, CacheProvider, MockEdFiOdsInstanceIdentificationProvider);
-            return descriptionCache;
         }
 
         [Test]
@@ -113,7 +110,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
         {
             var cache = MockNHibernateCallsAndInitializeCache();
 
-            var returnedId = descriptionCache.GetId(TestDescriptorName, "uri://www.changetest.org/academicSubjectDescriptor#mathematics");
+            var returnedId = cache.GetId(TestDescriptorName, "uri://www.changetest.org/academicSubjectDescriptor#mathematics");
             Assert.AreEqual(TestDescriptorWithCodeValue.Id, returnedId);
         }
 

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/DescriptorsCacheTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/DescriptorsCacheTests.cs
@@ -20,7 +20,7 @@ using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using Shouldly;
 
-namespace EdFi.Ods.Tests.EdFi.Ods.Entities.NHibernate
+namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
 {
     [TestFixture]
     public class DescriptorsCacheTests


### PR DESCRIPTION
Added tests for the following scenarios:

1. A cache miss when the descriptor cache is empty (uninitialized)
2. A cache miss with an INVALID descriptor value
3. A cache miss with a newly added descriptor value