### PR TITLE
ODS-5659 UTC plus 6 hours is CST midnight

### DIFF
--- a/.github/workflows/CodeQL Security Scan.yml
+++ b/.github/workflows/CodeQL Security Scan.yml
@@ -7,7 +7,7 @@ name: CodeQL Security Scan Schedule request
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 6 * * *'
 env:
   INFORMATIONAL_VERSION: "7.0"
   BUILD_INCREMENTER: "1"


### PR DESCRIPTION
Cron Job Schedule in Github Actions runs on UTC time ,so yesterday executed on 7 pm CST ,  There is no way to change the time zone . Can I add another 6 hours to Cron scheduler in new PR and then it will be 12 am for CST 

UTC is is 6 hours ahead of [Central Standard Time]