### PR TITLE
[ODS-5664] Relationship-based authorization of PUT/POST/DELETE requests returns 500 status for API client with no ed orgs

### DIFF
--- a/Application/EdFi.Ods.Api/Security/Authorization/Repositories/RepositoryOperationAuthorizationDecoratorBase.cs
+++ b/Application/EdFi.Ods.Api/Security/Authorization/Repositories/RepositoryOperationAuthorizationDecoratorBase.cs
@@ -379,18 +379,11 @@ namespace EdFi.Ods.Api.Security.Authorization.Repositories
 
                 const int MaximumEdOrgClaimValuesToDisplay = 5;
 
-                var claimEndpointValuesAsString =
+                var claimEndpointValuesAsStrings =
                     claimEndpointValues?.Select(v => v.ToString()).Take(MaximumEdOrgClaimValuesToDisplay + 1).ToArray()
                     ?? Array.Empty<string>();
 
-                var claimEndpointValuesForDisplayText = claimEndpointValuesAsString?.Take(MaximumEdOrgClaimValuesToDisplay).ToList();
-
-                if (claimEndpointValuesAsString.Length > MaximumEdOrgClaimValuesToDisplay)
-                {
-                    claimEndpointValuesForDisplayText.Add("...");
-                }
-
-                string claimEndpointValuesText = string.Join(", ", claimEndpointValuesForDisplayText);
+                string claimEndpointValuesText = GetClaimEndpointValuesText(claimEndpointValuesAsStrings, MaximumEdOrgClaimValuesToDisplay);
 
                 if (subjectEndpointNames.Length == 1)
                 {
@@ -398,6 +391,25 @@ namespace EdFi.Ods.Api.Security.Authorization.Repositories
                 }
 
                 return $"Authorization denied. No relationships have been established between the caller's education organization id {claimOrClaims} ({claimEndpointValuesText}) and one or more of the following properties of the resource item: {subjectEndpointNamesText}.";
+            }
+
+            string GetClaimEndpointValuesText(string[] claimEndpointValuesAsStrings, int maximumEdOrgClaimValuesToDisplay)
+            {
+                if (claimEndpointValuesAsStrings == null || claimEndpointValuesAsStrings.Length == 0)
+                {
+                    return "none";
+                }
+                
+                var claimEndpointValuesForDisplayText = claimEndpointValuesAsStrings?.Take(maximumEdOrgClaimValuesToDisplay).ToList();
+
+                if (claimEndpointValuesAsStrings.Length > maximumEdOrgClaimValuesToDisplay)
+                {
+                    claimEndpointValuesForDisplayText.Add("...");
+                }
+
+                string claimEndpointValuesText = string.Join(", ", claimEndpointValuesForDisplayText);
+
+                return claimEndpointValuesText;
             }
         }
 

--- a/Application/EdFi.Ods.Api/Security/AuthorizationStrategies/Relationships/Filters/PostgresViewBasedSingleItemAuthorizationQuerySupport.cs
+++ b/Application/EdFi.Ods.Api/Security/AuthorizationStrategies/Relationships/Filters/PostgresViewBasedSingleItemAuthorizationQuerySupport.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Data.Common;
+using System.Linq;
 using EdFi.Ods.Common.Security.Authorization;
 using EdFi.Ods.Common.Security.Claims;
 
@@ -14,8 +15,10 @@ public class PostgresViewBasedSingleItemAuthorizationQuerySupport : IViewBasedSi
     public string GetItemExistenceCheckSql(ViewBasedAuthorizationFilterDefinition filterDefinition, AuthorizationFilterContext filterContext)
     {
         // Use literal IN clause approach
-        var edOrgIdsList = string.Join(',', filterContext.ClaimEndpointValues);
-            
+        var edOrgIdsList = filterContext.ClaimEndpointValues.Any()
+            ? string.Join(',', filterContext.ClaimEndpointValues)
+            : "NULL";
+
         return
             $"SELECT 1 FROM auth.{filterDefinition.ViewName} AS authvw WHERE authvw.{filterDefinition.ViewTargetEndpointName} = @{filterContext.SubjectEndpointName} AND authvw.{RelationshipAuthorizationConventions.ViewSourceColumnName} IN ({edOrgIdsList})";  
     }

--- a/Application/EdFi.Ods.Api/Security/AuthorizationStrategies/Relationships/Filters/SqlServerViewBasedSingleItemAuthorizationQuerySupport.cs
+++ b/Application/EdFi.Ods.Api/Security/AuthorizationStrategies/Relationships/Filters/SqlServerViewBasedSingleItemAuthorizationQuerySupport.cs
@@ -6,6 +6,7 @@
 using System.Data;
 using System.Data.Common;
 using System.Data.SqlClient;
+using System.Linq;
 using EdFi.Ods.Common.Security.Authorization;
 using EdFi.Ods.Common.Security.Claims;
 
@@ -20,7 +21,9 @@ public class SqlServerViewBasedSingleItemAuthorizationQuerySupport : IViewBasedS
         if (filterContext.ClaimEndpointValues.Length < SqlServerParameterCountThreshold)
         {
             // Use literal IN clause approach
-            var edOrgIdsList = string.Join(',', filterContext.ClaimEndpointValues);
+            var edOrgIdsList = filterContext.ClaimEndpointValues.Any()
+                ? string.Join(',', filterContext.ClaimEndpointValues)
+                : "NULL";
             
             return
                 $"SELECT 1 FROM auth.{filterDefinition.ViewName} AS authvw WHERE authvw.{filterDefinition.ViewTargetEndpointName} = @{filterContext.SubjectEndpointName} AND authvw.{RelationshipAuthorizationConventions.ViewSourceColumnName} IN ({edOrgIdsList})";  

--- a/Postman Test Suite/Ed-Fi ODS-API Integration Test Suite AuthorizationTests.postman_collection.json
+++ b/Postman Test Suite/Ed-Fi ODS-API Integration Test Suite AuthorizationTests.postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "b1db9ed4-9da8-4c4d-ad97-9b9e068047cd",
+		"_postman_id": "80551eba-8e6d-47ac-aca6-12aeb9806ad2",
 		"name": "Ed-Fi ODS/API Integration Test Suite AuthorizationTests",
 		"description": "Localhost integration testing using Postman Scripts",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "1713280"
+		"_exporter_id": "2374196"
 	},
 	"item": [
 		{
@@ -4828,6 +4828,169 @@
 							]
 						},
 						{
+ 							"name": "When_deleting_organizationDepartment_with_noEdOrg_client_should_fail_with_403_forbidden",
+ 							"item": [
+ 								{
+ 									"name": "Initialize Organization Departments for Request",
+ 									"event": [
+ 										{
+ 											"listen": "test",
+ 											"script": {
+ 												"exec": [
+ 													"pm.test(\"Status code is 200 or 201\", () => {\r",
+ 													"    pm.expect(pm.response.code).to.be.oneOf([200, 201]);\r",
+ 													"});\r",
+ 													"\r",
+ 													"pm.environment.set('known:organizationDepartmentGuid',pm.response.headers.one('Location').value.split(\"/\").pop());"
+ 												],
+ 												"type": "text/javascript"
+ 											}
+ 										}
+ 									],
+ 									"request": {
+ 										"method": "POST",
+ 										"header": [],
+ 										"body": {
+ 											"mode": "raw",
+ 											"raw": "{\r\n  \"categories\": [\r\n    {\r\n      \"educationOrganizationCategoryDescriptor\": \"uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Organization Department\"\r\n    }\r\n  ],\r\n  \"organizationDepartmentId\": 2559018,\r\n  \"parentEducationOrganizationReference\": {\r\n    \"educationOrganizationId\": 255901044\r\n  },\r\n  \"nameOfInstitution\": \"Forbidden 403 - No EdOrg Organization Department\"\r\n}",
+ 											"options": {
+ 												"raw": {
+ 													"language": "json"
+ 												}
+ 											}
+ 										},
+ 										"url": {
+ 											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/organizationDepartments",
+ 											"host": [
+ 												"{{ApiBaseUrl}}"
+ 											],
+ 											"path": [
+ 												"data",
+ 												"v3",
+ 												"ed-fi",
+ 												"organizationDepartments"
+ 											]
+ 										}
+ 									},
+ 									"response": []
+ 								},
+ 								{
+ 									"name": "When_deleting_organizationDepartment_with_noEdOrg_client_should_fail_with_403_forbidden",
+ 									"event": [
+ 										{
+ 											"listen": "test",
+ 											"script": {
+ 												"exec": [
+ 													"pm.test(\"Status code is 403\", () => {\r",
+ 													"    pm.expect(pm.response.code).to.equal(403);\r",
+ 													"});\r",
+ 													"\r",
+ 													"const message = pm.response.json().message;\r",
+ 													"\r",
+ 													"pm.test(\"Message should indicate that client doesn't have access to any EdOrgs\", () => {\r",
+ 													"  pm.expect(message).to.contain(\"Authorization denied. No relationships have been established between the caller's education organization id claims (none) and the resource item's 'ParentEducationOrganizationId' value.\");\r",
+ 													"});"
+ 												],
+ 												"type": "text/javascript"
+ 											}
+ 										}
+ 									],
+ 									"request": {
+ 										"auth": {
+ 											"type": "bearer",
+ 											"bearer": [
+ 												{
+ 													"key": "token",
+ 													"value": "{{AccessToken_NoEdorg}}",
+ 													"type": "string"
+ 												}
+ 											]
+ 										},
+ 										"method": "DELETE",
+ 										"header": [],
+ 										"url": {
+ 											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/organizationDepartments/{{known:organizationDepartmentGuid}}",
+ 											"host": [
+ 												"{{ApiBaseUrl}}"
+ 											],
+ 											"path": [
+ 												"data",
+ 												"v3",
+ 												"ed-fi",
+ 												"organizationDepartments",
+ 												"{{known:organizationDepartmentGuid}}"
+ 											]
+ 										}
+ 									},
+ 									"response": []
+ 								}
+ 							]
+ 						},
+ 						{
+ 							"name": "When_creating_organizationDepartment_with_noEdOrg_client_should_fail_with_403_forbidden",
+ 							"item": [
+ 								{
+ 									"name": "When_creating_organizationDepartment_with_noEdOrg_client_should_fail_with_403_forbidden",
+ 									"event": [
+ 										{
+ 											"listen": "test",
+ 											"script": {
+ 												"exec": [
+ 													"pm.test(\"Status code is 403\", () => {\r",
+ 													"    pm.expect(pm.response.code).to.equal(403);\r",
+ 													"});\r",
+ 													"\r",
+ 													"const message = pm.response.json().message;\r",
+ 													"\r",
+ 													"pm.test(\"Message should indicate that client doesn't have access to any EdOrgs\", () => {\r",
+ 													"  pm.expect(message).to.contain(\"Authorization denied. No relationships have been established between the caller's education organization id claims (none) and the resource item's 'ParentEducationOrganizationId' value.\");\r",
+ 													"});\r",
+ 													""
+ 												],
+ 												"type": "text/javascript"
+ 											}
+ 										}
+ 									],
+ 									"request": {
+ 										"auth": {
+ 											"type": "bearer",
+ 											"bearer": [
+ 												{
+ 													"key": "token",
+ 													"value": "{{AccessToken_NoEdorg}}",
+ 													"type": "string"
+ 												}
+ 											]
+ 										},
+ 										"method": "POST",
+ 										"header": [],
+ 										"body": {
+ 											"mode": "raw",
+ 											"raw": "{\r\n  \"categories\": [\r\n    {\r\n      \"educationOrganizationCategoryDescriptor\": \"uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Organization Department\"\r\n    }\r\n  ],\r\n  \"organizationDepartmentId\": 2559018,\r\n  \"parentEducationOrganizationReference\": {\r\n    \"educationOrganizationId\": 255901044\r\n  },\r\n  \"nameOfInstitution\": \"Forbidden 403 - No EdOrg Organization Department\"\r\n}",
+ 											"options": {
+ 												"raw": {
+ 													"language": "json"
+ 												}
+ 											}
+ 										},
+ 										"url": {
+ 											"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/organizationDepartments",
+ 											"host": [
+ 												"{{ApiBaseUrl}}"
+ 											],
+ 											"path": [
+ 												"data",
+ 												"v3",
+ 												"ed-fi",
+ 												"organizationDepartments"
+ 											]
+ 										}
+ 									},
+ 									"response": []
+ 								}
+ 							]
+ 						},
+						{
 							"name": "Teardown",
 							"item": [
 								{
@@ -8292,6 +8455,8 @@
 					"",
 					"CreateAccessToken(\"TokenExpiry_Other_Namespace\", \"AccessToken_Other_Namespace\", \"ApiKey_Other_Namespace\", \"ApiSecret_Other_Namespace\")",
 					"",
+					"CreateAccessToken(\"TokenExpiry_NoEdorg\", \"AccessToken_NoEdorg\", \"ApiKey_NoEdorg\", \"ApiSecret_NoEdorg\")",
+ 					"",
 					"// Adapted from: https://marcin-chwedczuk.github.io/automatically-generate-new-oauth2-tokens-when-using-postman",
 					"// Assumes Environment with Environment Variables: ApiBaseUrl, ApiKey, ApiSecret",
 					"// See https://gist.github.com/blmeyers/21138bbe6f80b8c35701a8754bfe59d5 for an environment sample for Local (NOTE: environment variable names have been changed from the gist -- you must adjust accordingly)",


### PR DESCRIPTION
Fix SQL used for authorization so that it returns no results rather than cause runtime error due to SQL syntax error.