### PR TITLE
[ODS-5732] Trgr EdFi.Ods.DB.Templates workflow in ODS repo removed

### DIFF
--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
@@ -16,7 +16,7 @@ on:
         required: false
         default: 'distinct_id'
   repository_dispatch:
-    types: [triggered-from-implementation-repo ,triggered-from-datastandard-repo]
+    types: [triggered-from-datastandard-repo]
 
 env:
   EDFI_STANDARD_REFERENCE: "v4.0.0"

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.PostgreSQL.yml
@@ -16,7 +16,7 @@ on:
         required: false
         default: 'distinct_id'
   repository_dispatch:
-    types: [triggered-from-implementation-repo ,triggered-from-datastandard-repo ,triggered-from-tpdmartifacts-repo]
+    types: [triggered-from-datastandard-repo ,triggered-from-tpdmartifacts-repo]
 
 env:
   EDFI_STANDARD_REFERENCE: "v4.0.0"

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.yml
@@ -16,7 +16,7 @@ on:
         required: false
         default: 'distinct_id'
   repository_dispatch:
-    types: [triggered-from-implementation-repo ,triggered-from-datastandard-repo ,triggered-from-tpdmartifacts-repo]
+    types: [triggered-from-datastandard-repo ,triggered-from-tpdmartifacts-repo]
 env:
   EDFI_STANDARD_REFERENCE: "v4.0.0"
   INFORMATIONAL_VERSION: "7.0"

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.yml
@@ -16,7 +16,7 @@ on:
         required: false
         default: 'distinct_id'
   repository_dispatch:
-    types: [triggered-from-implementation-repo ,triggered-from-datastandard-repo]
+    types: [triggered-from-datastandard-repo]
 
 env:
   EDFI_STANDARD_REFERENCE: "v4.0.0"

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
@@ -16,7 +16,7 @@ on:
         required: false
         default: 'distinct_id'
   repository_dispatch:
-    types: [triggered-from-implementation-repo ,triggered-from-datastandard-repo]
+    types: [triggered-from-datastandard-repo]
 
 env:
   EDFI_STANDARD_REFERENCE: "v4.0.0"

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.PostgreSQL.yml
@@ -18,7 +18,7 @@ on:
         default: 'distinct_id'
 
   repository_dispatch:
-    types: [triggered-from-implementation-repo ,triggered-from-datastandard-repo ,triggered-from-tpdmartifacts-repo]
+    types: [triggered-from-datastandard-repo ,triggered-from-tpdmartifacts-repo]
 env:
   EDFI_STANDARD_REFERENCE: "v4.0.0"
   INFORMATIONAL_VERSION: "7.0"

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.yml
@@ -17,7 +17,7 @@ on:
         default: 'distinct_id'
 
   repository_dispatch:
-    types: [triggered-from-implementation-repo ,triggered-from-datastandard-repo ,triggered-from-tpdmartifacts-repo]
+    types: [triggered-from-datastandard-repo ,triggered-from-tpdmartifacts-repo]
 
 env:
   EDFI_STANDARD_REFERENCE: "v4.0.0"

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.yml
@@ -17,7 +17,7 @@ on:
         default: 'distinct_id'
 
   repository_dispatch:
-    types: [triggered-from-implementation-repo ,triggered-from-datastandard-repo]
+    types: [triggered-from-datastandard-repo]
 env:
   EDFI_STANDARD_REFERENCE: "v4.0.0"
   INFORMATIONAL_VERSION: "7.0"


### PR DESCRIPTION
Any code Changes to scripts in https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/tree/main/DatabaseTemplate/Modules possibly need template run and definitely handled by  manual run of [Rebuild Database Templates.yml](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/blob/main/.github/workflows/Rebuild%20Database%20Templates.yml)  .so removing Trgr EdFi.Ods.DB.Templates workflow in ODS repo workflow