### PR TITLE
Update API error messages for duplicate keys and no authorizing claim

### DIFF
--- a/Application/EdFi.Ods.Api/ExceptionHandling/Translators/DuplicateNaturalKeyUpdateExceptionTranslator.cs
+++ b/Application/EdFi.Ods.Api/ExceptionHandling/Translators/DuplicateNaturalKeyUpdateExceptionTranslator.cs
@@ -21,7 +21,7 @@ namespace EdFi.Ods.Api.ExceptionHandling.Translators
                 webServiceError = new RESTError
                                   {
                                       Code = (int) HttpStatusCode.Conflict, Type = HttpStatusCode.Conflict.ToString(), Message =
-                                          "A natural key conflict occurred when attempting to update a new resource with a duplicate key. This is likely caused by multiple resources with the same key in the same file. Exactly one of these resources was updated."
+                                          "A natural key conflict occurred when attempting to update a new resource with a duplicate key."
                                   };
 
                 return true;

--- a/Application/EdFi.Ods.Api/ExceptionHandling/Translators/SqlServer/DuplicateNaturalKeyCreateExceptionTranslator.cs
+++ b/Application/EdFi.Ods.Api/ExceptionHandling/Translators/SqlServer/DuplicateNaturalKeyCreateExceptionTranslator.cs
@@ -17,7 +17,7 @@ namespace EdFi.Ods.Api.ExceptionHandling.Translators.SqlServer
     public class DuplicateNaturalKeyCreateExceptionTranslator : IExceptionTranslator
     {
         private const string MessageFormat =
-            "A natural key conflict occurred when attempting to create a new resource '{0}' with a duplicate key.  The duplicated columns and values are [{1}] {2} This is likely caused by multiple resources with the same key in the same file. Exactly one of these resources was inserted.";
+            "A natural key conflict occurred when attempting to create a new resource '{0}' with a duplicate key.  The duplicated columns and values are [{1}] {2}.";
 
         private static readonly Regex MatchPattern = new Regex(
             @"^Violation of PRIMARY KEY constraint '(?<IndexName>\w+)'\.\s+Cannot insert duplicate key in object '[a-z]+\.(?<TableName>\w+)'\.\s+The duplicate key value is (?<Values>\(.*\))\.\s+The statement has been terminated\.\s*$");

--- a/Application/EdFi.Ods.Api/Security/Authorization/AuthorizationBasisMetadataSelector.cs
+++ b/Application/EdFi.Ods.Api/Security/Authorization/AuthorizationBasisMetadataSelector.cs
@@ -289,10 +289,9 @@ public class AuthorizationBasisMetadataSelector : IAuthorizationBasisMetadataSel
                     principal.Claims.SingleOrDefault(c => c.Type == EdFiOdsApiClaimTypes.ClaimSetName)?.Value;
 
                 response.SecurityExceptionMessage =
-                    $@"Access to the resource could not be authorized. Are you missing a claim? This resource can be authorized by the following claims:
-    {string.Join(Environment.NewLine + "    ", authorizingClaimNames)}
-The API client has been assigned the '{apiClientClaimSetName}' claim set with the following resource claims:
-    {string.Join(Environment.NewLine + "    ", apiClientResourceClaims)}";
+                    $@"Access to the resource could not be authorized. The API client has been assigned the '
+                        {apiClientClaimSetName}' claim set. Assign different claim set which includes one of the following claims to access this resource:
+                        {string.Join(Environment.NewLine + "    ", authorizingClaimNames)}";
 
                 return response;
             }

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Api/ExceptionHandling/Translators/SqlServer/DuplicateNaturalKeyCreateExceptionTranslatorTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Api/ExceptionHandling/Translators/SqlServer/DuplicateNaturalKeyCreateExceptionTranslatorTests.cs
@@ -144,7 +144,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Common.ExceptionHandling
             public void Should_set_a_reasonable_message()
             {
                 actualError.Message.ShouldBe(
-                    "A natural key conflict occurred when attempting to create a new resource 'Session' with a duplicate key.  The duplicated columns and values are [Column1, Column2, Column3] (900007, 9, 2014) This is likely caused by multiple resources with the same key in the same file. Exactly one of these resources was inserted.");
+                    "A natural key conflict occurred when attempting to create a new resource 'Session' with a duplicate key.  The duplicated columns and values are [Column1, Column2, Column3] (900007, 9, 2014).");
             }
 
             [Test]
@@ -195,7 +195,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Common.ExceptionHandling
             public void Should_set_a_reasonable_message()
             {
                 actualError.Message.ShouldBe(
-                    "A natural key conflict occurred when attempting to create a new resource 'unknown' with a duplicate key.  The duplicated columns and values are [unknown] (900007, 9, 2014) This is likely caused by multiple resources with the same key in the same file. Exactly one of these resources was inserted.");
+                    "A natural key conflict occurred when attempting to create a new resource 'unknown' with a duplicate key.  The duplicated columns and values are [unknown] (900007, 9, 2014).");
             }
         }
 

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Api/ExceptionHandling/Translators/SqlServer/DuplicateNaturalKeyUpdateExceptionTranslatorTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Api/ExceptionHandling/Translators/SqlServer/DuplicateNaturalKeyUpdateExceptionTranslatorTests.cs
@@ -127,7 +127,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Common.ExceptionHandling
             public void Should_set_a_reasonable_message()
             {
                 actualError.Message.ShouldBe(
-                    "A natural key conflict occurred when attempting to update a new resource with a duplicate key. This is likely caused by multiple resources with the same key in the same file. Exactly one of these resources was updated.");
+                    "A natural key conflict occurred when attempting to update a new resource with a duplicate key.");
             }
 
             [Test]


### PR DESCRIPTION
This updates the API error messages referenced in the ticket and another with the same form to be more concise and removes non-applicable wording. Tests that include the changed error messages were also updated to align with the new formats.