### PR TITLE
[ODS-5741] Nuget package caching enabled in Github Actions builds of Ed-Fi-ODS repo

### DIFF
--- a/.github/workflows/Cleanup Caches by a branch.yml
+++ b/.github/workflows/Cleanup Caches by a branch.yml
@@ -20,19 +20,28 @@ jobs:
           gh extension install actions/gh-actions-cache
           
           REPO=${{ github.repository }}
-          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+          PULLREQUESTBRANCH = "refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          cacheKeysForPR = $(gh actions-cache list -R $REPO -B $PULLREQUESTBRANCH | cut -f 1 )          
+          ## Setting this to not fail the workflow while deleting cache keys. 
+          set +e
+          echo "Deleting caches for  PULLREQUESTBRANCH..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $PULLREQUESTBRANCH --confirm
+          done
+
+          WORKINGBRANCH =  ${{ GITHUB.HEAD_REF }}         
           echo "HEAD_REF: " ${{ GITHUB.HEAD_REF }}
           echo "REF_NAME: " ${{ GITHUB.REF_NAME }}
           echo "Fetching list of cache key"
-          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
-
-          ## Setting this to not fail the workflow while deleting cache keys. 
+          cacheKeysForPR = $(gh actions-cache list -R $REPO -B $WORKINGBRANCH | cut -f 1 )
           set +e
-          echo "Deleting caches..."
+          echo "Deleting caches for WORKINGBRANCH..."
           for cacheKey in $cacheKeysForPR
           do
-              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
-          done
+              gh actions-cache delete $cacheKey -R $REPO -B $WORKINGBRANCH --confirm
+          done          
           echo "Done"
         env:
           GH_TOKEN: ${{ secrets.REPO_DISPATCH_TOKEN }}

--- a/.github/workflows/Cleanup Caches by a branch.yml
+++ b/.github/workflows/Cleanup Caches by a branch.yml
@@ -24,7 +24,7 @@ jobs:
           cacheKeysForPR=$(gh actions-cache list -R $REPO -B $PULLREQUESTBRANCH | cut -f 1 )          
           ## Setting this to not fail the workflow while deleting cache keys. 
           set +e
-          echo "Deleting caches for  PULLREQUESTBRANCH..."
+          echo "Deleting caches for  PULLREQUESTBRANCH $PULLREQUESTBRANCH..."
           for cacheKey in $cacheKeysForPR
           do
               gh actions-cache delete $cacheKey -R $REPO -B $PULLREQUESTBRANCH --confirm
@@ -36,7 +36,7 @@ jobs:
           echo "Fetching list of cache key"
           cacheKeysForPR=$(gh actions-cache list -R $REPO -B $WORKINGBRANCH | cut -f 1 )
           set +e
-          echo "Deleting caches for WORKINGBRANCH..."
+          echo "Deleting caches for WORKINGBRANCH $WORKINGBRANCH..."
           for cacheKey in $cacheKeysForPR
           do
               gh actions-cache delete $cacheKey -R $REPO -B $WORKINGBRANCH --confirm

--- a/.github/workflows/Cleanup Caches by a branch.yml
+++ b/.github/workflows/Cleanup Caches by a branch.yml
@@ -21,7 +21,8 @@ jobs:
           
           REPO=${{ github.repository }}
           BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
-
+          echo "HEAD_REF: " ${{ GITHUB.HEAD_REF }}
+          echo "REF_NAME: " ${{ GITHUB.REF_NAME }}
           echo "Fetching list of cache key"
           cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
 

--- a/.github/workflows/Cleanup Caches by a branch.yml
+++ b/.github/workflows/Cleanup Caches by a branch.yml
@@ -6,16 +6,15 @@
 name: Cleanup Caches by a branch
 on:
   pull_request:
-    types:
-      - opened
+    branches: [main, 'ODS-*']
+    types: [ assigned, opened, synchronize ]
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
-        
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3.0.2
       - name: Cleanup
         run: |
           gh extension install actions/gh-actions-cache
@@ -35,4 +34,4 @@ jobs:
           done
           echo "Done"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPO_DISPATCH_TOKEN }}

--- a/.github/workflows/Cleanup Caches by a branch.yml
+++ b/.github/workflows/Cleanup Caches by a branch.yml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: Cleanup Caches by a branch
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+          
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys. 
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Cleanup Caches by a branch.yml
+++ b/.github/workflows/Cleanup Caches by a branch.yml
@@ -7,7 +7,7 @@ name: Cleanup Caches by a branch
 on:
   pull_request:
     branches: [main, 'ODS-*']
-    types: [ assigned, opened, synchronize ]
+    types: [ closed ]
 
 jobs:
   cleanup:

--- a/.github/workflows/Cleanup Caches by a branch.yml
+++ b/.github/workflows/Cleanup Caches by a branch.yml
@@ -20,9 +20,8 @@ jobs:
           gh extension install actions/gh-actions-cache
           
           REPO=${{ github.repository }}
-          PULLREQUESTBRANCH = "refs/pull/${{ github.event.pull_request.number }}/merge"
-
-          cacheKeysForPR = $(gh actions-cache list -R $REPO -B $PULLREQUESTBRANCH | cut -f 1 )          
+          PULLREQUESTBRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $PULLREQUESTBRANCH | cut -f 1 )          
           ## Setting this to not fail the workflow while deleting cache keys. 
           set +e
           echo "Deleting caches for  PULLREQUESTBRANCH..."
@@ -31,11 +30,11 @@ jobs:
               gh actions-cache delete $cacheKey -R $REPO -B $PULLREQUESTBRANCH --confirm
           done
 
-          WORKINGBRANCH =  ${{ GITHUB.HEAD_REF }}         
+          WORKINGBRANCH=${{ GITHUB.HEAD_REF }}         
           echo "HEAD_REF: " ${{ GITHUB.HEAD_REF }}
           echo "REF_NAME: " ${{ GITHUB.REF_NAME }}
           echo "Fetching list of cache key"
-          cacheKeysForPR = $(gh actions-cache list -R $REPO -B $WORKINGBRANCH | cut -f 1 )
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $WORKINGBRANCH | cut -f 1 )
           set +e
           echo "Deleting caches for WORKINGBRANCH..."
           for cacheKey in $cacheKeysForPR

--- a/.github/workflows/CodeQL Security Scan.yml
+++ b/.github/workflows/CodeQL Security Scan.yml
@@ -64,6 +64,18 @@ jobs:
             $PSVersionTable
             . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Initialize-PowershellForDevelopment.ps1
             Invoke-CodeGen -Engine PostgreSQL -RepositoryRoot $env:GITHUB_WORKSPACE/
+      - name: Cache Nuget packages
+        uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+      - name: Restore NuGet packages
+        working-directory: ./Ed-Fi-ODS/
+        run: |
+          .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
+        shell: pwsh            
       - name: build
         shell: pwsh
         working-directory: ./Ed-Fi-ODS/

--- a/.github/workflows/Lib edFi.admin.dataaccess manual.yml
+++ b/.github/workflows/Lib edFi.admin.dataaccess manual.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*',  '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages

--- a/.github/workflows/Lib edFi.admin.dataaccess manual.yml
+++ b/.github/workflows/Lib edFi.admin.dataaccess manual.yml
@@ -7,8 +7,6 @@ name: Lib EdFi.Admin.DataAccess Manually triggered build
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [main, 'ODS-*']  
 
 env:
   INFORMATIONAL_VERSION: "7.0"

--- a/.github/workflows/Lib edFi.admin.dataaccess manual.yml
+++ b/.github/workflows/Lib edFi.admin.dataaccess manual.yml
@@ -7,6 +7,8 @@ name: Lib EdFi.Admin.DataAccess Manually triggered build
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [main, 'ODS-*']  
 
 env:
   INFORMATIONAL_VERSION: "7.0"
@@ -32,21 +34,11 @@ jobs:
       with:
         repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
         path: Ed-Fi-ODS/
-    - name: Checkout Ed-Fi-ODS-Implementation
-      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
-      with:
-        repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation
-        path: Ed-Fi-ODS-Implementation/
-    - name: Is pull request branch exists in Ed-Fi-ODS-Implementation
-      working-directory: ./Ed-Fi-ODS/
-      shell: pwsh
-      run: |
-        ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"
     - name: Cache Nuget packages       
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*',  '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages
@@ -66,7 +58,6 @@ jobs:
         .\build.githubactions.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.sln" -ProjectFile "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj" -PackageName  "EdFi.Suite3.Admin.DataAccess"
       shell: pwsh
     - name: Install-credential-handler
-      working-directory: ./Ed-Fi-ODS/
       run: |
         .\build.githubactions.ps1 InstallCredentialHandler
       shell: pwsh 

--- a/.github/workflows/Lib edFi.admin.dataaccess manual.yml
+++ b/.github/workflows/Lib edFi.admin.dataaccess manual.yml
@@ -42,6 +42,17 @@ jobs:
       shell: pwsh
       run: |
         ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      run: |
+        .\build.githubactions.ps1 restore -Solution "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.sln"
+      shell: pwsh                
     - name: build
       run: |
         .\build.githubactions.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.sln" -ProjectFile "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj"

--- a/.github/workflows/Lib edFi.admin.dataaccess pullrequest.yml
+++ b/.github/workflows/Lib edFi.admin.dataaccess pullrequest.yml
@@ -20,6 +20,17 @@ jobs:
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
       with:
         dotnet-version: 6.0.x
+    - name: Cache Nuget packages   
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      run: |
+        .\build.githubactions.ps1 restore -Solution "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.sln"
+      shell: pwsh
     - name: build
       run: |
         .\build.githubactions.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.sln" -ProjectFile "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj"

--- a/.github/workflows/Lib edFi.admin.dataaccess pullrequest.yml
+++ b/.github/workflows/Lib edFi.admin.dataaccess pullrequest.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages

--- a/.github/workflows/Lib edFi.common manual.yml
+++ b/.github/workflows/Lib edFi.common manual.yml
@@ -41,7 +41,18 @@ jobs:
       working-directory: ./Ed-Fi-ODS/
       shell: pwsh
       run: |
-        ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"        
+        ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      run: |
+        .\build.githubactions.ps1 restore -Solution "Application/EdFi.Common/EdFi.Common.sln"
+      shell: pwsh                
     - name: build
       run: |
         .\build.githubactions.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Application/EdFi.Common/EdFi.Common.sln" -ProjectFile "Application/EdFi.Common/EdFi.Common.csproj"

--- a/.github/workflows/Lib edFi.common manual.yml
+++ b/.github/workflows/Lib edFi.common manual.yml
@@ -7,8 +7,6 @@ name: Lib EdFi.Common Manually triggered build
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [main, 'ODS-*']  
 
 env:
   INFORMATIONAL_VERSION: "7.0"

--- a/.github/workflows/Lib edFi.common manual.yml
+++ b/.github/workflows/Lib edFi.common manual.yml
@@ -7,6 +7,8 @@ name: Lib EdFi.Common Manually triggered build
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [main, 'ODS-*']  
 
 env:
   INFORMATIONAL_VERSION: "7.0"
@@ -32,21 +34,11 @@ jobs:
       with:
         repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
         path: Ed-Fi-ODS/
-    - name: Checkout Ed-Fi-ODS-Implementation
-      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
-      with:
-        repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation
-        path: Ed-Fi-ODS-Implementation/
-    - name: Is pull request branch exists in Ed-Fi-ODS-Implementation
-      working-directory: ./Ed-Fi-ODS/
-      shell: pwsh
-      run: |
-        ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"
     - name: Cache Nuget packages       
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages
@@ -66,7 +58,6 @@ jobs:
         .\build.githubactions.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Application/EdFi.Common/EdFi.Common.sln" -ProjectFile "Application/EdFi.Common/EdFi.Common.csproj" -PackageName  "EdFi.Suite3.Common"
       shell: pwsh
     - name: Install-credential-handler
-      working-directory: ./Ed-Fi-ODS/
       run: |
         .\build.githubactions.ps1 InstallCredentialHandler
       shell: pwsh

--- a/.github/workflows/Lib edFi.common pullrequest.yml
+++ b/.github/workflows/Lib edFi.common pullrequest.yml
@@ -19,6 +19,17 @@ jobs:
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
       with:
         dotnet-version: 6.0.x
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      run: |
+        .\build.githubactions.ps1 restore -Solution "Application/EdFi.Common/EdFi.Common.sln"
+      shell: pwsh
     - name: build
       run: |
         .\build.githubactions.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -Solution "Application/EdFi.Common/EdFi.Common.sln" -ProjectFile "Application/EdFi.Common/EdFi.Common.csproj"

--- a/.github/workflows/Lib edFi.common pullrequest.yml
+++ b/.github/workflows/Lib edFi.common pullrequest.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages

--- a/.github/workflows/Lib edFi.loadtools manual.yml
+++ b/.github/workflows/Lib edFi.loadtools manual.yml
@@ -42,6 +42,17 @@ jobs:
       shell: pwsh
       run: |
         ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"        
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      run: |
+        .\build.githubactions.ps1 restore -Solution "Utilities/DataLoading/LoadTools.sln"
+      shell: pwsh
     - name: build
       run: |
         .\build.githubactions.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Utilities/DataLoading/LoadTools.sln"

--- a/.github/workflows/Lib edFi.loadtools manual.yml
+++ b/.github/workflows/Lib edFi.loadtools manual.yml
@@ -7,8 +7,6 @@ name: Lib EdFi.LoadTools Manually triggered build
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [main, 'ODS-*']  
 
 env:
   INFORMATIONAL_VERSION: "7.0"

--- a/.github/workflows/Lib edFi.loadtools manual.yml
+++ b/.github/workflows/Lib edFi.loadtools manual.yml
@@ -7,6 +7,8 @@ name: Lib EdFi.LoadTools Manually triggered build
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [main, 'ODS-*']  
 
 env:
   INFORMATIONAL_VERSION: "7.0"
@@ -32,21 +34,11 @@ jobs:
       with:
         repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
         path: Ed-Fi-ODS/
-    - name: Checkout Ed-Fi-ODS-Implementation
-      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
-      with:
-        repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation
-        path: Ed-Fi-ODS-Implementation/
-    - name: Is pull request branch exists in Ed-Fi-ODS-Implementation
-      working-directory: ./Ed-Fi-ODS/
-      shell: pwsh
-      run: |
-        ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"        
     - name: Cache Nuget packages       
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages
@@ -74,7 +66,6 @@ jobs:
         .\build.githubactions.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Utilities/DataLoading/LoadTools.sln" -ProjectFile "Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj" -PackageName "EdFi.Suite3.SmokeTest.Console"
       shell: pwsh          
     - name: Install-credential-handler
-      working-directory: ./Ed-Fi-ODS/
       run: |
         .\build.githubactions.ps1 InstallCredentialHandler
       shell: pwsh

--- a/.github/workflows/Lib edFi.loadtools pullrequest.yml
+++ b/.github/workflows/Lib edFi.loadtools pullrequest.yml
@@ -20,6 +20,17 @@ jobs:
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
       with:
         dotnet-version: 6.0.x
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      run: |
+        .\build.githubactions.ps1 restore -Solution "Utilities/DataLoading/LoadTools.sln"
+      shell: pwsh
     - name: build
       run: |
         .\build.githubactions.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Utilities/DataLoading/LoadTools.sln"

--- a/.github/workflows/Lib edFi.loadtools pullrequest.yml
+++ b/.github/workflows/Lib edFi.loadtools pullrequest.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages

--- a/.github/workflows/Lib edFi.ods.api manual.yml
+++ b/.github/workflows/Lib edFi.ods.api manual.yml
@@ -7,6 +7,8 @@ name: Lib EdFi.Ods.Api Manually triggered build
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [main, 'ODS-*']  
 
 env:
   INFORMATIONAL_VERSION: "7.0"
@@ -32,21 +34,11 @@ jobs:
       with:
         repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
         path: Ed-Fi-ODS/
-    - name: Checkout Ed-Fi-ODS-Implementation
-      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
-      with:
-        repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation
-        path: Ed-Fi-ODS-Implementation/
-    - name: Is pull request branch exists in Ed-Fi-ODS-Implementation
-      working-directory: ./Ed-Fi-ODS/
-      shell: pwsh
-      run: |
-        ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"  
     - name: Cache Nuget packages       
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages
@@ -66,7 +58,6 @@ jobs:
         .\build.githubactions.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Application/EdFi.Ods.Api/EdFi.Ods.Api.sln" -ProjectFile "Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj" -PackageName  "EdFi.Suite3.Ods.Api"
       shell: pwsh
     - name: Install-credential-handler
-      working-directory: ./Ed-Fi-ODS/
       run: |
         .\build.githubactions.ps1 InstallCredentialHandler
       shell: pwsh

--- a/.github/workflows/Lib edFi.ods.api manual.yml
+++ b/.github/workflows/Lib edFi.ods.api manual.yml
@@ -41,7 +41,18 @@ jobs:
       working-directory: ./Ed-Fi-ODS/
       shell: pwsh
       run: |
-        ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"        
+        ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"  
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      run: |
+        .\build.githubactions.ps1 restore -Solution "Application/EdFi.Ods.Api/EdFi.Ods.Api.sln"
+      shell: pwsh
     - name: build
       run: |
         .\build.githubactions.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Application/EdFi.Ods.Api/EdFi.Ods.Api.sln" -ProjectFile "Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj"

--- a/.github/workflows/Lib edFi.ods.api manual.yml
+++ b/.github/workflows/Lib edFi.ods.api manual.yml
@@ -7,8 +7,6 @@ name: Lib EdFi.Ods.Api Manually triggered build
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [main, 'ODS-*']  
 
 env:
   INFORMATIONAL_VERSION: "7.0"

--- a/.github/workflows/Lib edFi.ods.api pullrequest .yml
+++ b/.github/workflows/Lib edFi.ods.api pullrequest .yml
@@ -19,6 +19,17 @@ jobs:
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
       with:
         dotnet-version: 6.0.x
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      run: |
+        .\build.githubactions.ps1 restore -Solution "Application/EdFi.Ods.Api/EdFi.Ods.Api.sln"
+      shell: pwsh        
     - name: build
       run: |
         .\build.githubactions.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -Solution "Application/EdFi.Ods.Api/EdFi.Ods.Api.sln" -ProjectFile "Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj"

--- a/.github/workflows/Lib edFi.ods.api pullrequest .yml
+++ b/.github/workflows/Lib edFi.ods.api pullrequest .yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages

--- a/.github/workflows/Lib edFi.ods.common manual.yml
+++ b/.github/workflows/Lib edFi.ods.common manual.yml
@@ -42,6 +42,17 @@ jobs:
       shell: pwsh
       run: |
         ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      run: |
+        .\build.githubactions.ps1 restore -Solution "Application/EdFi.Ods.Common/EdFi.Ods.Common.sln"
+      shell: pwsh        
     - name: build
       run: |
         .\build.githubactions.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Application/EdFi.Ods.Common/EdFi.Ods.Common.sln" -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"

--- a/.github/workflows/Lib edFi.ods.common manual.yml
+++ b/.github/workflows/Lib edFi.ods.common manual.yml
@@ -7,8 +7,6 @@ name: Lib EdFi.Ods.Common Manually triggered build
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [main, 'ODS-*']  
 
 env:
   INFORMATIONAL_VERSION: "7.0"

--- a/.github/workflows/Lib edFi.ods.common manual.yml
+++ b/.github/workflows/Lib edFi.ods.common manual.yml
@@ -7,6 +7,8 @@ name: Lib EdFi.Ods.Common Manually triggered build
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [main, 'ODS-*']  
 
 env:
   INFORMATIONAL_VERSION: "7.0"
@@ -32,21 +34,11 @@ jobs:
       with:
         repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
         path: Ed-Fi-ODS/
-    - name: Checkout Ed-Fi-ODS-Implementation
-      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
-      with:
-        repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation
-        path: Ed-Fi-ODS-Implementation/
-    - name: Is pull request branch exists in Ed-Fi-ODS-Implementation
-      working-directory: ./Ed-Fi-ODS/
-      shell: pwsh
-      run: |
-        ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"
     - name: Cache Nuget packages       
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages
@@ -66,7 +58,6 @@ jobs:
         .\build.githubactions.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Application/EdFi.Ods.Common/EdFi.Ods.Common.sln" -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj" -PackageName "EdFi.Suite3.Ods.Common"
       shell: pwsh
     - name: Install-credential-handler
-      working-directory: ./Ed-Fi-ODS/
       run: |
         .\build.githubactions.ps1 InstallCredentialHandler
       shell: pwsh

--- a/.github/workflows/Lib edFi.ods.common pullrequest.yml
+++ b/.github/workflows/Lib edFi.ods.common pullrequest.yml
@@ -19,6 +19,17 @@ jobs:
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
       with:
         dotnet-version: 6.0.x
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      run: |
+        .\build.githubactions.ps1 restore -Solution "Application/EdFi.Ods.Common/EdFi.Ods.Common.sln"
+      shell: pwsh        
     - name: build
       run: |
         .\build.githubactions.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -Solution "Application/EdFi.Ods.Common/EdFi.Ods.Common.sln" -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"

--- a/.github/workflows/Lib edFi.ods.common pullrequest.yml
+++ b/.github/workflows/Lib edFi.ods.common pullrequest.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages

--- a/.github/workflows/Lib edFi.ods.standard manual.yml
+++ b/.github/workflows/Lib edFi.ods.standard manual.yml
@@ -48,7 +48,7 @@ jobs:
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages

--- a/.github/workflows/Lib edFi.ods.standard manual.yml
+++ b/.github/workflows/Lib edFi.ods.standard manual.yml
@@ -44,6 +44,18 @@ jobs:
       shell: pwsh
       run: |
         ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      working-directory: ./Ed-Fi-ODS/
+      run: |
+        .\build.githubactions.ps1 restore -ProjectFile "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Application/EdFi.Ods.Standard/EdFi.Ods.Standard.csproj"
+      shell: pwsh        
     - name: CodeGen
       shell: pwsh
       run: |

--- a/.github/workflows/Lib edFi.ods.standard pullrequest.yml
+++ b/.github/workflows/Lib edFi.ods.standard pullrequest.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages

--- a/.github/workflows/Lib edFi.ods.standard pullrequest.yml
+++ b/.github/workflows/Lib edFi.ods.standard pullrequest.yml
@@ -31,6 +31,18 @@ jobs:
       shell: pwsh
       run: |
         ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      working-directory: ./Ed-Fi-ODS/
+      run: |
+        .\build.githubactions.ps1 restore -ProjectFile "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Application/EdFi.Ods.Standard/EdFi.Ods.Standard.csproj"
+      shell: pwsh        
     - name: CodeGen    
       working-directory: ./Ed-Fi-ODS/
       shell: pwsh

--- a/.github/workflows/Lib edFi.security.dataaccess manual.yml
+++ b/.github/workflows/Lib edFi.security.dataaccess manual.yml
@@ -7,8 +7,6 @@ name: Lib EdFi.Security.DataAccess Manually triggered build
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [main, 'ODS-*']  
 
 env:
   INFORMATIONAL_VERSION: "7.0"

--- a/.github/workflows/Lib edFi.security.dataaccess manual.yml
+++ b/.github/workflows/Lib edFi.security.dataaccess manual.yml
@@ -7,6 +7,8 @@ name: Lib EdFi.Security.DataAccess Manually triggered build
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [main, 'ODS-*']  
 
 env:
   INFORMATIONAL_VERSION: "7.0"
@@ -32,21 +34,11 @@ jobs:
       with:
         repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
         path: Ed-Fi-ODS/
-    - name: Checkout Ed-Fi-ODS-Implementation
-      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
-      with:
-        repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation
-        path: Ed-Fi-ODS-Implementation/
-    - name: Is pull request branch exists in Ed-Fi-ODS-Implementation
-      working-directory: ./Ed-Fi-ODS/
-      shell: pwsh
-      run: |
-        ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"  
     - name: Cache Nuget packages       
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages
@@ -66,7 +58,6 @@ jobs:
         .\build.githubactions.ps1 pack -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.sln" -ProjectFile "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj" -PackageName  "EdFi.Suite3.Security.DataAccess"
       shell: pwsh
     - name: Install-credential-handler
-      working-directory: ./Ed-Fi-ODS/
       run: |
         .\build.githubactions.ps1 InstallCredentialHandler
       shell: pwsh

--- a/.github/workflows/Lib edFi.security.dataaccess manual.yml
+++ b/.github/workflows/Lib edFi.security.dataaccess manual.yml
@@ -41,7 +41,18 @@ jobs:
       working-directory: ./Ed-Fi-ODS/
       shell: pwsh
       run: |
-        ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"        
+        ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"  
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      run: |
+        .\build.githubactions.ps1 restore -Solution "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.sln"
+      shell: pwsh        
     - name: build
       run: |
         .\build.githubactions.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.sln" -ProjectFile "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj"

--- a/.github/workflows/Lib edFi.security.dataaccess pullrequest.yml
+++ b/.github/workflows/Lib edFi.security.dataaccess pullrequest.yml
@@ -20,6 +20,17 @@ jobs:
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
       with:
         dotnet-version: 6.0.x
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      run: |
+        .\build.githubactions.ps1 restore -Solution "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.sln"
+      shell: pwsh        
     - name: build
       run: |
         .\build.githubactions.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.sln" -ProjectFile "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj"

--- a/.github/workflows/Lib edFi.security.dataaccess pullrequest.yml
+++ b/.github/workflows/Lib edFi.security.dataaccess pullrequest.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages

--- a/.github/workflows/Pkg EdFi.Ods.CodeGen.yml
+++ b/.github/workflows/Pkg EdFi.Ods.CodeGen.yml
@@ -66,7 +66,7 @@ jobs:
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages
@@ -84,7 +84,7 @@ jobs:
       run: |
         $ErrorActionPreference = 'Stop'
         $solution = "$env:GITHUB_WORKSPACE\Ed-Fi-ODS\Utilities\CodeGeneration\EdFi.Ods.CodeGen.sln"
-        $reports = "$env:GITHUB_WORKSPACE\Ed-Fi-ODS-Implementation\reports\"
+        $reports = "$env:GITHUB_WORKSPACE\Ed-Fi-ODS\reports\"
         if (Test-Path $reports) {
             Remove-Item -Path $reports -Force -Recurse | Out-Null
         }

--- a/.github/workflows/Pkg EdFi.Ods.CodeGen.yml
+++ b/.github/workflows/Pkg EdFi.Ods.CodeGen.yml
@@ -62,6 +62,18 @@ jobs:
       shell: pwsh
       run: |
         ./build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-Extensions"
+    - name: Cache Nuget packages   
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      working-directory: ./Ed-Fi-ODS/
+      run: |
+        .\build.githubactions.ps1 restore -Solution "Utilities/CodeGeneration/EdFi.Ods.CodeGen.sln"
+      shell: pwsh        
     - name: build
       working-directory: ./Ed-Fi-ODS/
       run: |

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
@@ -9,8 +9,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches: [main, 'ODS-*']      
   workflow_dispatch:
     inputs:
       distinct_id:

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
@@ -86,7 +86,7 @@ jobs:
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches: [main, 'ODS-*']      
   workflow_dispatch:
     inputs:
       distinct_id:
@@ -82,6 +84,18 @@ jobs:
       shell: pwsh
       run: |
         .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      working-directory: ./Ed-Fi-ODS/
+      run: |
+        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
+      shell: pwsh                
     - name: Initialize-DevelopmentEnvironment
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
@@ -89,7 +103,7 @@ jobs:
         [Environment]::SetEnvironmentVariable('msbuild_buildConfiguration', '${{ env.CONFIGURATION }}')
         $PSVersionTable
           . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Initialize-PowershellForDevelopment.ps1
-        Initialize-DevelopmentEnvironment -NoCredentials -NoDeploy -Engine PostgreSQL
+        Initialize-DevelopmentEnvironment -NoCredentials -NoDeploy -Engine PostgreSQL -NoRestore
       shell: pwsh
     - name: Remove Plug-Ins
       working-directory: ./Ed-Fi-ODS-Implementation/

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.PostgreSQL.yml
@@ -9,8 +9,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches: [main, 'ODS-*']       
   workflow_dispatch:
     inputs:
       distinct_id:

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.PostgreSQL.yml
@@ -96,7 +96,7 @@ jobs:
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.PostgreSQL.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches: [main, 'ODS-*']       
   workflow_dispatch:
     inputs:
       distinct_id:
@@ -92,6 +94,18 @@ jobs:
       shell: pwsh
       run: |
         .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      working-directory: ./Ed-Fi-ODS/
+      run: |
+        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
+      shell: pwsh                
     - name: Initialize-DevelopmentEnvironment
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
@@ -101,7 +115,7 @@ jobs:
         $PSVersionTable
           . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Initialize-PowershellForDevelopment.ps1
 
-        Initialize-DevelopmentEnvironment -UsePlugins -NoDeploy -Engine PostgreSQL
+        Initialize-DevelopmentEnvironment -UsePlugins -NoDeploy -Engine PostgreSQL -NoRestore
       shell: pwsh
     - name: Create Database Template (no extensions)
       working-directory: ./

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.yml
@@ -9,8 +9,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches: [main, 'ODS-*']       
   workflow_dispatch:
     inputs:
       distinct_id:

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.yml
@@ -87,7 +87,7 @@ jobs:
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches: [main, 'ODS-*']       
   workflow_dispatch:
     inputs:
       distinct_id:
@@ -83,13 +85,25 @@ jobs:
       run: |
           choco install sql-server-2019  -y --params "'/IGNOREPENDINGREBOOT /IACCEPTSQLSERVERLICENSETERMS /Q /ACTION=install /INSTANCEID=MSSQLSERVER /INSTANCENAME=MSSQLSERVER /TCPENABLED=1 /UPDATEENABLED=FALSE /FEATURES=SQL,Tools'" --execution-timeout=$installTimeout
           choco install sqlpackage
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      working-directory: ./Ed-Fi-ODS/
+      run: |
+        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
+      shell: pwsh                
     - name: Initialize-DevelopmentEnvironment
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
         $ErrorActionPreference = 'Stop'
         $PSVersionTable
           . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Initialize-PowershellForDevelopment.ps1
-        Initialize-DevelopmentEnvironment -UsePlugins -NoDeploy
+        Initialize-DevelopmentEnvironment -UsePlugins -NoDeploy -NoRestore
       shell: powershell
     - name: Create Database Template (no extensions)
       working-directory: ./

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.yml
@@ -9,8 +9,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches: [main, 'ODS-*']       
   workflow_dispatch:
     inputs:
       distinct_id:

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches: [main, 'ODS-*']       
   workflow_dispatch:
     inputs:
       distinct_id:
@@ -75,6 +77,18 @@ jobs:
       run: |
           choco install sql-server-2019  -y --params "'/IGNOREPENDINGREBOOT /IACCEPTSQLSERVERLICENSETERMS /Q /ACTION=install /INSTANCEID=MSSQLSERVER /INSTANCENAME=MSSQLSERVER /TCPENABLED=1 /UPDATEENABLED=FALSE /FEATURES=SQL,Tools'" --execution-timeout=$installTimeout
           choco install sqlpackage
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      working-directory: ./Ed-Fi-ODS/
+      run: |
+        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
+      shell: pwsh                
     - name: Initialize-DevelopmentEnvironment
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
@@ -82,7 +96,7 @@ jobs:
         [Environment]::SetEnvironmentVariable('msbuild_buildConfiguration', '${{ env.CONFIGURATION }}')
         $PSVersionTable
           . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Initialize-PowershellForDevelopment.ps1
-        Initialize-DevelopmentEnvironment -NoCredentials -NoDeploy
+        Initialize-DevelopmentEnvironment -NoCredentials -NoDeploy -NoRestore
       shell: powershell
     - name: Remove Plug-Ins
       working-directory: ./Ed-Fi-ODS-Implementation/

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.yml
@@ -79,7 +79,7 @@ jobs:
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
@@ -9,8 +9,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches: [main, 'ODS-*']       
   workflow_dispatch:
     inputs:
       distinct_id:

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches: [main, 'ODS-*']       
   workflow_dispatch:
     inputs:
       distinct_id:
@@ -82,6 +84,18 @@ jobs:
       shell: pwsh
       run: |
         .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      working-directory: ./Ed-Fi-ODS/
+      run: |
+        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
+      shell: pwsh                
     - name: Initialize-DevelopmentEnvironment
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
@@ -89,7 +103,7 @@ jobs:
         [Environment]::SetEnvironmentVariable('msbuild_buildConfiguration', '${{ env.CONFIGURATION }}')
         $PSVersionTable
           . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Initialize-PowershellForDevelopment.ps1
-        Initialize-DevelopmentEnvironment -NoCredentials -NoDeploy -Engine PostgreSQL
+        Initialize-DevelopmentEnvironment -NoCredentials -NoDeploy -Engine PostgreSQL -NoRestore
       shell: pwsh
     - name: Remove Plug-Ins
       working-directory: ./Ed-Fi-ODS-Implementation/

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
@@ -86,7 +86,7 @@ jobs:
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.PostgreSQL.yml
@@ -9,9 +9,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches: [main, 'ODS-*']       
-
   workflow_dispatch:
     inputs:
       distinct_id:

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.PostgreSQL.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches: [main, 'ODS-*']       
 
   workflow_dispatch:
     inputs:
@@ -93,6 +95,18 @@ jobs:
       shell: pwsh
       run: |
         .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS-Implementation"
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      working-directory: ./Ed-Fi-ODS/
+      run: |
+        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
+      shell: pwsh                
     - name: Initialize-DevelopmentEnvironment
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
@@ -100,7 +114,7 @@ jobs:
         [Environment]::SetEnvironmentVariable('msbuild_buildConfiguration', '${{ env.CONFIGURATION }}')
         $PSVersionTable
         . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Initialize-PowershellForDevelopment.ps1
-        Initialize-DevelopmentEnvironment -UsePlugins -NoDeploy -Engine PostgreSQL
+        Initialize-DevelopmentEnvironment -UsePlugins -NoDeploy -Engine PostgreSQL -NoRestore
       shell: pwsh
     - name: Create Database Template (no extensions)
       run: |

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.PostgreSQL.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+
   workflow_dispatch:
     inputs:
       distinct_id:

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.PostgreSQL.yml
@@ -96,7 +96,7 @@ jobs:
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.yml
@@ -9,8 +9,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches: [main, 'ODS-*']       
   workflow_dispatch:
     inputs:
       distinct_id:

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches: [main, 'ODS-*']       
   workflow_dispatch:
     inputs:
       distinct_id:
@@ -85,13 +87,25 @@ jobs:
       run: |
           choco install sql-server-2019  -y --params "'/IGNOREPENDINGREBOOT /IACCEPTSQLSERVERLICENSETERMS /Q /ACTION=install /INSTANCEID=MSSQLSERVER /INSTANCENAME=MSSQLSERVER /TCPENABLED=1 /UPDATEENABLED=FALSE /FEATURES=SQL,Tools'" --execution-timeout=$installTimeout
           choco install sqlpackage
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      working-directory: ./Ed-Fi-ODS/
+      run: |
+        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
+      shell: pwsh                
     - name: Initialize-DevelopmentEnvironment
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
         $ErrorActionPreference = 'Stop'
         $PSVersionTable
           . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Initialize-PowershellForDevelopment.ps1
-        Initialize-DevelopmentEnvironment -UsePlugins -NoDeploy
+        Initialize-DevelopmentEnvironment -UsePlugins -NoDeploy  -NoRestore
       shell: powershell
     - name: Create Database Template (no extensions)
       working-directory: ./

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.yml
@@ -89,7 +89,7 @@ jobs:
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.yml
@@ -9,8 +9,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches: [main, 'ODS-*']       
   workflow_dispatch:
     inputs:
       distinct_id:

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches: [main, 'ODS-*']       
   workflow_dispatch:
     inputs:
       distinct_id:
@@ -74,6 +76,18 @@ jobs:
       run: |
           choco install sql-server-2019  -y --params "'/IGNOREPENDINGREBOOT /IACCEPTSQLSERVERLICENSETERMS /Q /ACTION=install /INSTANCEID=MSSQLSERVER /INSTANCENAME=MSSQLSERVER /TCPENABLED=1 /UPDATEENABLED=FALSE /FEATURES=SQL,Tools'" --execution-timeout=$installTimeout
           choco install sqlpackage
+    - name: Cache Nuget packages       
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      working-directory: ./Ed-Fi-ODS/
+      run: |
+        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
+      shell: pwsh                
     - name: Initialize-DevelopmentEnvironment
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
@@ -83,7 +97,7 @@ jobs:
         $PSVersionTable
           . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Initialize-PowershellForDevelopment.ps1
         
-        Initialize-DevelopmentEnvironment -NoCredentials -NoDeploy
+        Initialize-DevelopmentEnvironment -NoCredentials -NoDeploy  -NoRestore
       shell: powershell
     - name: Remove Plug-Ins
       working-directory: ./Ed-Fi-ODS-Implementation/

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.yml
@@ -78,7 +78,7 @@ jobs:
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/*.sln', '**/configuration.packages.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Restore NuGet packages

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -7,7 +7,7 @@
 param(
     # Command to execute, defaults to "Build".
     [string]
-    [ValidateSet("DotnetClean", "Build", "Test", "Pack", "Publish", "CheckoutBranch", "InstallCredentialHandler")]
+    [ValidateSet("DotnetClean", "Restore", "Build", "Test", "Pack", "Publish", "CheckoutBranch", "InstallCredentialHandler")]
     $Command = "Build",
 
     [switch] $SelfContained,
@@ -119,17 +119,21 @@ function DotnetClean {
     Invoke-Execute { dotnet clean $Solution -c $Configuration --nologo -v minimal }
 }
 
+function Restore {
+    Invoke-Execute { dotnet restore  $Solution --verbosity:normal }
+}
+
 function Compile {
     Invoke-Execute {
         dotnet --info
-        dotnet build $Solution -c $Configuration --version-suffix $version
+        dotnet build $Solution -c $Configuration --version-suffix $version --no-restore
     }
 }
 
 function Pack {
     if ([string]::IsNullOrWhiteSpace($PackageName) -and [string]::IsNullOrWhiteSpace($NuspecFilePath)){
         Invoke-Execute {
-            dotnet pack $ProjectFile -c $Configuration --output $packageOutput --no-build --verbosity normal -p:VersionPrefix=$version -p:NoWarn=NU5123
+            dotnet pack $ProjectFile -c $Configuration --output $packageOutput --no-build --no-restore --verbosity normal -p:VersionPrefix=$version -p:NoWarn=NU5123
         }
     }
     if ($NuspecFilePath -Like "*.nuspec" -and $PackageName -ne $null){
@@ -137,7 +141,7 @@ function Pack {
     }
     if ([string]::IsNullOrWhiteSpace($NuspecFilePath) -and $PackageName -ne $null){
         Invoke-Execute {
-            dotnet pack $ProjectFile -c $Configuration --output $packageOutput --no-build --verbosity normal -p:VersionPrefix=$version -p:NoWarn=NU5123 -p:PackageId=$PackageName
+            dotnet pack $ProjectFile -c $Configuration --output $packageOutput --no-build --no-restore --verbosity normal -p:VersionPrefix=$version -p:NoWarn=NU5123 -p:PackageId=$PackageName
         }
     }
 }
@@ -165,9 +169,9 @@ function Publish {
 
 function Test {
     if(-not $TestFilter) {
-        Invoke-Execute { dotnet test $solution  -c $Configuration --no-build -v normal }
+        Invoke-Execute { dotnet test $solution  -c $Configuration --no-build --no-restore -v normal }
     } else {
-        Invoke-Execute { dotnet test $solution  -c $Configuration --no-build -v normal --filter TestCategory!~"$TestFilter" }
+        Invoke-Execute { dotnet test $solution  -c $Configuration --no-build --no-restore -v normal --filter TestCategory!~"$TestFilter" }
     }
 }
 
@@ -245,6 +249,10 @@ function Invoke-DotnetClean {
     Invoke-Step { DotnetClean }
 }
 
+function Invoke-Restore {
+    Invoke-Step { Restore }
+}
+
 function Invoke-Publish {
     Invoke-Step { Publish }
 }
@@ -268,6 +276,7 @@ function Invoke-InstallCredentialHandler {
 Invoke-Main {
     switch ($Command) {
         DotnetClean { Invoke-DotnetClean }
+        Restore { Invoke-Restore }
         Build { Invoke-Build }
         Test { Invoke-Tests }
         Pack { Invoke-Pack }

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -211,8 +211,23 @@ function CheckoutBranch {
     }
 }
 
+function Get-IsWindows {
+    <#
+    .SYNOPSIS
+        Checks to see if the current machine is a Windows machine.
+    .EXAMPLE
+        Get-IsWindows returns $True
+    #>
+    if ($null -eq $IsWindows) {
+        # This section will only trigger when the automatic $IsWindows variable is not detected.
+        # Every version of PS released on Linux contains this variable so it will always exist.
+        # $IsWindows does not exist pre PS 6.
+        return $true
+    }
+    return $IsWindows
+}
+
 function InstallCredentialHandler {
-    Import-Module -Force -Scope Global "$PSScriptRoot/../Ed-Fi-ODS-Implementation/logistics/scripts/modules/utility/cross-platform.psm1"
     if (Get-IsWindows -and -not Get-InstalledModule | Where-Object -Property Name -eq "7Zip4Powershell") {
          Install-Module -Force -Scope CurrentUser -Name 7Zip4Powershell
     }


### PR DESCRIPTION
Added function Get-IsWindows in build.githubactions.ps1 to remove ODS Implementation reference for InstallCredentialHandler  method and also remove ODS Implementation checkout from below workflows

1. Lib edFi.admin.dataaccess manual.yml 
2. Lib edFi.common manual.yml
3. Lib edFi.loadtools manual.yml
4. Lib edFi.ods.api manual.yml
5. Lib edFi.ods.common manual.yml
6. Lib edFi.loadtools manual.yml
7. Lib edFi.ods.api manual.yml
8. Lib edFi.ods.common manual.yml
9. Lib edFi.security.dataaccess manual.yml

Above workflows of manual & similar Pull request build and test all workflows uses only ODS repo ,so cache key created based on all nuget package exists all cs projects in ODS repo

Known fact that all 8 Database Templates  needs ODS Implementation repo which executes Ed-Fi-ODS-Implementation/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
internally invokes  Invoke-RebuildSolution to build  the  Ed-Fi-ODS solution which has projects in both repos
example :Pkg EdFi.Ods.Minimal.Template ,  so another  cache key created based on all nuget package exists all cs projects in ODS repo & ODS Implementation repo 