### PR TITLE
[ODS-5772] Code owners file for Ed-Fi-ODS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+.github/**/*    @Ed-Fi-Alliance-OSS/ods-platform-automation-owners
+build.githubactions.ps1   @Ed-Fi-Alliance-OSS/ods-platform-automation-owners


### PR DESCRIPTION
This change makes it so that changes to the GitHub Actions yml files and to the main build script must be reviewed by a member of the new team, @Ed-Fi-Alliance-OSS/ods-platform-automation-owners. At this time, members are @semalaiappan @vimayya and @stephenfuqua.

This is the first change as we institute a policy of having tighter review on automation, as recommended by our security consultants.