### PR TITLE
[ODS-5775] Allow GitHub actions to run in forked repositories without secrets

### DIFF
--- a/.github/workflows/Cleanup Caches by a branch.yml
+++ b/.github/workflows/Cleanup Caches by a branch.yml
@@ -10,7 +10,7 @@ on:
     types: [ closed ]
   
 env:
-  EDFI_ODS_IMP_TOKEN: ${{ secrets.REPO_DISPATCH_TOKEN }}
+  GH_TOKEN: ${{ secrets.REPO_DISPATCH_TOKEN }}
   REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
 
 jobs:
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for Repo Dispatch Token
-        if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.EDFI_ODS_IMP_TOKEN == '' }}
+        if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.GH_TOKEN == '' }}
         run: | 
-          echo "Missing GitHub Token" 
+          echo "::error::Missing GitHub Token"
           exit 1 
       - name: Check out code
-        if: ${{ env.EDFI_ODS_IMP_TOKEN != '' }}
+        if: ${{ env.GH_TOKEN != '' }}
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3.0.2
       - name: Cleanup
         run: |

--- a/.github/workflows/Cleanup Caches by a branch.yml
+++ b/.github/workflows/Cleanup Caches by a branch.yml
@@ -8,12 +8,22 @@ on:
   pull_request:
     branches: [main, 'ODS-*']
     types: [ closed ]
+  
+env:
+  EDFI_ODS_IMP_TOKEN: ${{ secrets.REPO_DISPATCH_TOKEN }}
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
+      - name: Check for Repo Dispatch Token
+        if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.EDFI_ODS_IMP_TOKEN == '' }}
+        run: | 
+          echo "Missing GitHub Token" 
+          exit 1 
       - name: Check out code
+        if: ${{ env.EDFI_ODS_IMP_TOKEN != '' }}
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3.0.2
       - name: Cleanup
         run: |
@@ -42,5 +52,3 @@ jobs:
               gh actions-cache delete $cacheKey -R $REPO -B $WORKINGBRANCH --confirm
           done          
           echo "Done"
-        env:
-          GH_TOKEN: ${{ secrets.REPO_DISPATCH_TOKEN }}

--- a/.github/workflows/Lib edFi.admin.dataaccess manual.yml
+++ b/.github/workflows/Lib edFi.admin.dataaccess manual.yml
@@ -15,6 +15,7 @@ env:
   AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
   AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
   VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
 
 jobs:
   build:
@@ -22,6 +23,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Check for Azure token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
+      run: | 
+        echo "Missing Azure Access Token" 
+        exit 1 
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
@@ -60,6 +66,7 @@ jobs:
         .\build.githubactions.ps1 InstallCredentialHandler
       shell: pwsh 
     - name: publish
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       run: |
         .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -Solution "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.sln" -ProjectFile "Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj" -PackageName  "EdFi.Suite3.Admin.DataAccess"
       shell: pwsh      

--- a/.github/workflows/Lib edFi.admin.dataaccess manual.yml
+++ b/.github/workflows/Lib edFi.admin.dataaccess manual.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Check for Azure token
       if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
       run: | 
-        echo "Missing Azure Access Token" 
+        echo "::error::Missing Azure Token" 
         exit 1 
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET

--- a/.github/workflows/Lib edFi.common manual.yml
+++ b/.github/workflows/Lib edFi.common manual.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Check for Azure token
       if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
       run: | 
-        echo "Missing Azure Access Token" 
+        echo "::error::Missing Azure Token"
         exit 1 
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET

--- a/.github/workflows/Lib edFi.common manual.yml
+++ b/.github/workflows/Lib edFi.common manual.yml
@@ -15,6 +15,7 @@ env:
   AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
   AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
   VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
 
 jobs:
   build:
@@ -22,6 +23,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Check for Azure token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
+      run: | 
+        echo "Missing Azure Access Token" 
+        exit 1 
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
@@ -59,7 +65,8 @@ jobs:
       run: |
         .\build.githubactions.ps1 InstallCredentialHandler
       shell: pwsh
-    - name: publish 
+    - name: publish
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       run: |
         .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -Solution "Application/EdFi.Common/EdFi.Common.sln" -ProjectFile "Application/EdFi.Common/EdFi.Common.csproj" -PackageName  "EdFi.Suite3.Common"
       shell: pwsh      

--- a/.github/workflows/Lib edFi.loadtools manual.yml
+++ b/.github/workflows/Lib edFi.loadtools manual.yml
@@ -15,6 +15,7 @@ env:
   AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
   AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
   VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
 
 jobs:
   build:
@@ -22,6 +23,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Check for Azure token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
+      run: | 
+        echo "Missing Azure Access Token" 
+        exit 1 
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
@@ -68,14 +74,17 @@ jobs:
         .\build.githubactions.ps1 InstallCredentialHandler
       shell: pwsh
     - name: publish load tools
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       run: |
         .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -Solution "Utilities/DataLoading/LoadTools.sln" -ProjectFile "Ed-Fi-ODS/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj"  -PackageName "EdFi.Suite3.LoadTools"
       shell: pwsh      
     - name: publish bulk load client
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       run: |
         .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -Solution "Utilities/DataLoading/LoadTools.sln" -ProjectFile "Ed-Fi-ODS/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj" -PackageName "EdFi.Suite3.BulkLoadClient.Console"
       shell: pwsh
     - name: publish smoke test console
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       run: |
         .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -Solution "Utilities/DataLoading/LoadTools.sln" -ProjectFile "Ed-Fi-ODS/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj" -PackageName "EdFi.Suite3.SmokeTest.Console"
       shell: pwsh

--- a/.github/workflows/Lib edFi.loadtools manual.yml
+++ b/.github/workflows/Lib edFi.loadtools manual.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Check for Azure token
       if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
       run: | 
-        echo "Missing Azure Access Token" 
+        echo "::error::Missing Azure Token" 
         exit 1 
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET

--- a/.github/workflows/Lib edFi.ods.api manual.yml
+++ b/.github/workflows/Lib edFi.ods.api manual.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Check for Azure token
       if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
       run: | 
-        echo "Missing Azure Access Token" 
+        echo "::error::Missing Azure Token"
         exit 1 
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET

--- a/.github/workflows/Lib edFi.ods.api manual.yml
+++ b/.github/workflows/Lib edFi.ods.api manual.yml
@@ -15,6 +15,7 @@ env:
   AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
   AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
   VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
 
 jobs:
   build:
@@ -22,6 +23,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Check for Azure token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
+      run: | 
+        echo "Missing Azure Access Token" 
+        exit 1 
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
@@ -59,7 +65,8 @@ jobs:
       run: |
         .\build.githubactions.ps1 InstallCredentialHandler
       shell: pwsh
-    - name: publish 
+    - name: publish
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       run: |
         .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -Solution "Application/EdFi.Ods.Api/EdFi.Ods.Api.sln" -ProjectFile "Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj" -PackageName  "EdFi.Suite3.Ods.Api"
       shell: pwsh

--- a/.github/workflows/Lib edFi.ods.common manual.yml
+++ b/.github/workflows/Lib edFi.ods.common manual.yml
@@ -15,6 +15,7 @@ env:
   AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
   AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
   VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
 
 jobs:
   build:
@@ -22,6 +23,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Check for Azure token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
+      run: | 
+        echo "Missing Azure Access Token" 
+        exit 1 
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
@@ -60,6 +66,7 @@ jobs:
         .\build.githubactions.ps1 InstallCredentialHandler
       shell: pwsh
     - name: publish
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       run: |
         .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -Solution "Application/EdFi.Ods.Common/EdFi.Ods.Common.sln" -ProjectFile "Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj"  -PackageName "EdFi.Suite3.Ods.Common"
       shell: pwsh

--- a/.github/workflows/Lib edFi.ods.common manual.yml
+++ b/.github/workflows/Lib edFi.ods.common manual.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Check for Azure token
       if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
       run: | 
-        echo "Missing Azure Access Token" 
+        echo "::error::Missing Azure Token" 
         exit 1 
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET

--- a/.github/workflows/Lib edFi.ods.standard manual.yml
+++ b/.github/workflows/Lib edFi.ods.standard manual.yml
@@ -17,7 +17,8 @@ env:
   VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
   HEAD_REF:  ${{ GITHUB.HEAD_REF }}
   REF_NAME:  ${{ GITHUB.REF_NAME }}
-  REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}  
+  REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
 
 jobs:
   build:
@@ -25,6 +26,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Check for Azure token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
+      run: | 
+        echo "Missing Azure Access Token" 
+        exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # v2.1.0
       with:
@@ -83,7 +89,8 @@ jobs:
       run: |
         .\build.githubactions.ps1 InstallCredentialHandler
       shell: pwsh
-    - name: publish 
+    - name: publish
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       working-directory: ./Ed-Fi-ODS/
       run: |
         ./build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -ProjectFile "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Application/EdFi.Ods.Standard/EdFi.Ods.Standard.csproj" -PackageName  "EdFi.Suite3.Ods.Standard"

--- a/.github/workflows/Lib edFi.ods.standard manual.yml
+++ b/.github/workflows/Lib edFi.ods.standard manual.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Check for Azure token
       if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
       run: | 
-        echo "Missing Azure Access Token" 
+        echo "::error::Missing Azure Token"
         exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # v2.1.0

--- a/.github/workflows/Lib edFi.security.dataaccess manual.yml
+++ b/.github/workflows/Lib edFi.security.dataaccess manual.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Check for Azure token
       if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
       run: | 
-        echo "Missing Azure Access Token" 
+        echo "::error::Missing Azure Token"
         exit 1 
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET

--- a/.github/workflows/Lib edFi.security.dataaccess manual.yml
+++ b/.github/workflows/Lib edFi.security.dataaccess manual.yml
@@ -15,6 +15,7 @@ env:
   AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
   AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
   VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
 
 jobs:
   build:
@@ -22,6 +23,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Check for Azure token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
+      run: | 
+        echo "Missing Azure Access Token" 
+        exit 1 
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
@@ -59,7 +65,8 @@ jobs:
       run: |
         .\build.githubactions.ps1 InstallCredentialHandler
       shell: pwsh
-    - name: publish 
+    - name: publish
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       run: |
         .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -Solution "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.sln" -ProjectFile "Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj" -PackageName  "EdFi.Suite3.Security.DataAccess"
       shell: pwsh      

--- a/.github/workflows/Pkg EdFi.Database.Admin.yml
+++ b/.github/workflows/Pkg EdFi.Database.Admin.yml
@@ -27,6 +27,7 @@ env:
   HEAD_REF:  ${{ GITHUB.HEAD_REF }}
   REF_NAME:  ${{ GITHUB.REF_NAME }}
   REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
 
 jobs:
   build:
@@ -34,6 +35,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
+    - name: Check for Azure token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
+      run: exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # v2.1.0
       with:
@@ -97,6 +101,7 @@ jobs:
       run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
       shell: pwsh
     - name: Publish Nuget package
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       working-directory: ./Ed-Fi-ODS/
       run: |
         ./build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Admin"

--- a/.github/workflows/Pkg EdFi.Database.Security.yml
+++ b/.github/workflows/Pkg EdFi.Database.Security.yml
@@ -27,6 +27,7 @@ env:
   HEAD_REF:  ${{ GITHUB.HEAD_REF }}
   REF_NAME:  ${{ GITHUB.REF_NAME }}
   REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
 
 jobs:
   build:
@@ -34,6 +35,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
+    - name: Check for Azure token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
+      run: | 
+        echo "Missing Azure Access Token" 
+        exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # v2.1.0
       with:
@@ -98,6 +104,7 @@ jobs:
       shell: pwsh
     - name: Publish Nuget package
       working-directory: ./Ed-Fi-ODS-Implementation/
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       run: |
         ./build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Security"
         ./build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Database.Security.BACPAC"

--- a/.github/workflows/Pkg EdFi.Database.Security.yml
+++ b/.github/workflows/Pkg EdFi.Database.Security.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Check for Azure token
       if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
       run: | 
-        echo "Missing Azure Access Token" 
+        echo "::error::Missing Azure Token"
         exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # v2.1.0

--- a/.github/workflows/Pkg EdFi.Ods.CodeGen.yml
+++ b/.github/workflows/Pkg EdFi.Ods.CodeGen.yml
@@ -23,6 +23,7 @@ env:
   REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
   HEAD_REF:  ${{ GITHUB.HEAD_REF }}
   REF_NAME:  ${{ GITHUB.REF_NAME }}
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
 
 jobs:
   build:
@@ -32,6 +33,11 @@ jobs:
     steps:
     - name: echo distinct ID ${{ github.event.inputs.distinct_id }}
       run:  echo "${{ github.event.inputs.distinct_id }}"
+    - name: Check for Azure token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
+      run: | 
+        echo "Missing Azure Access Token" 
+        exit 1 
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
@@ -103,7 +109,8 @@ jobs:
         .\build.githubactions.ps1 InstallCredentialHandler
       shell: pwsh    
     - name: publish codegen
-      working-directory: ./Ed-Fi-ODS/    
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
+      working-directory: ./Ed-Fi-ODS/
       run: |
         .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -ProjectFile "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/CodeGeneration/EdFi.Ods.CodeGen/EdFi.Ods.CodeGen.csproj" -PackageName "EdFi.Suite3.Ods.CodeGen"
       shell: pwsh

--- a/.github/workflows/Pkg EdFi.Ods.CodeGen.yml
+++ b/.github/workflows/Pkg EdFi.Ods.CodeGen.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Check for Azure token
       if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
       run: | 
-        echo "Missing Azure Access Token" 
+        echo "::error::Missing Azure Token"
         exit 1 
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: Setup .NET

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Check for Azure token
       if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
       run: | 
-        echo "Missing Azure Access Token" 
+        echo "::error::Missing Azure Token" 
         exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
@@ -29,6 +29,7 @@ env:
   REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
   HEAD_REF:  ${{ GITHUB.HEAD_REF }}
   REF_NAME:  ${{ GITHUB.REF_NAME }}
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
 
 jobs:
   build:
@@ -52,6 +53,11 @@ jobs:
     steps:
     - name: echo distinct ID ${{ github.event.inputs.distinct_id }}
       run:  echo "${{ github.event.inputs.distinct_id }}"
+    - name: Check for Azure token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
+      run: | 
+        echo "Missing Azure Access Token" 
+        exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
       with:
@@ -129,6 +135,7 @@ jobs:
       shell: pwsh     
     - name: publish 
       working-directory: ./Ed-Fi-ODS/
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       run: |
         .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Suite3.Ods.Minimal.Template.PostgreSQL"
       shell: pwsh

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.PostgreSQL.yml
@@ -29,6 +29,7 @@ env:
   REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
   HEAD_REF:  ${{ GITHUB.HEAD_REF }}
   REF_NAME:  ${{ GITHUB.REF_NAME }}
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
 
 jobs:
   build:
@@ -52,6 +53,11 @@ jobs:
     steps:
     - name: echo distinct ID ${{ github.event.inputs.distinct_id }}
       run:  echo "${{ github.event.inputs.distinct_id }}"
+    - name: Check for Azure token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
+      run: | 
+        echo "Missing Azure Access Token" 
+        exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
       with:
@@ -135,6 +141,7 @@ jobs:
       shell: pwsh     
     - name: publish 
       working-directory: ./Ed-Fi-ODS/
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       run: |
         .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Suite3.Ods.Minimal.Template.TPDM.Core.PostgreSQL"
       shell: pwsh

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.PostgreSQL.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Check for Azure token
       if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
       run: | 
-        echo "Missing Azure Access Token" 
+        echo "::error::Missing Azure Token"
         exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Check for Azure token
       if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
       run: | 
-        echo "Missing Azure Access Token" 
+        echo "::error::Missing Azure Token"
         exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.TPDM.yml
@@ -28,6 +28,8 @@ env:
   REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
   HEAD_REF:  ${{ GITHUB.HEAD_REF }}
   REF_NAME:  ${{ GITHUB.REF_NAME }}
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
+
 jobs:
   build:
 
@@ -36,6 +38,11 @@ jobs:
     steps:
     - name: echo distinct ID ${{ github.event.inputs.distinct_id }}
       run:  echo "${{ github.event.inputs.distinct_id }}"
+    - name: Check for Azure token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
+      run: | 
+        echo "Missing Azure Access Token" 
+        exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
       with:
@@ -149,6 +156,7 @@ jobs:
       shell: pwsh
     - name: publish 
       working-directory: ./Ed-Fi-ODS/
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       run: |
         .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Suite3.Ods.Minimal.Template.TPDM.Core"
       shell: powershell      

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Check for Azure token
       if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
       run: | 
-        echo "Missing Azure Access Token" 
+        echo "::error::Missing Azure Token"
         exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.yml
@@ -29,6 +29,7 @@ env:
   REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
   HEAD_REF:  ${{ GITHUB.HEAD_REF }}
   REF_NAME:  ${{ GITHUB.REF_NAME }}
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
 
 jobs:
   build:
@@ -38,6 +39,11 @@ jobs:
     steps:
     - name: echo distinct ID ${{ github.event.inputs.distinct_id }}
       run:  echo "${{ github.event.inputs.distinct_id }}"
+    - name: Check for Azure token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
+      run: | 
+        echo "Missing Azure Access Token" 
+        exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
       with:
@@ -149,6 +155,7 @@ jobs:
       shell: pwsh
     - name: publish 
       working-directory: ./Ed-Fi-ODS/
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       run: |
         .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Suite3.Ods.Minimal.Template"
       shell: powershell      

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
@@ -29,6 +29,7 @@ env:
   REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
   HEAD_REF:  ${{ GITHUB.HEAD_REF }}
   REF_NAME:  ${{ GITHUB.REF_NAME }}
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
 
 jobs:
   build:
@@ -52,6 +53,11 @@ jobs:
     steps:
     - name: echo distinct ID ${{ github.event.inputs.distinct_id }}
       run:  echo "${{ github.event.inputs.distinct_id }}"
+    - name: Check for Azure token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
+      run: | 
+        echo "Missing Azure Access Token" 
+        exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
       with:
@@ -127,7 +133,8 @@ jobs:
       run: |
         .\build.githubactions.ps1 InstallCredentialHandler
       shell: pwsh    
-    - name: publish 
+    - name: publish
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       working-directory: ./Ed-Fi-ODS/
       run: |
         .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Suite3.Ods.Populated.Template.PostgreSQL"

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Check for Azure token
       if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
       run: | 
-        echo "Missing Azure Access Token" 
+        echo "::error::Missing Azure Token"
         exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.PostgreSQL.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Check for Azure token
       if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
       run: | 
-        echo "Missing Azure Access Token" 
+        echo "::error::Missing Azure Token"
         exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.PostgreSQL.yml
@@ -30,6 +30,7 @@ env:
   REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
   HEAD_REF:  ${{ GITHUB.HEAD_REF }}
   REF_NAME:  ${{ GITHUB.REF_NAME }}
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
 
 jobs:
   build:
@@ -53,6 +54,11 @@ jobs:
     steps:
     - name: echo distinct ID ${{ github.event.inputs.distinct_id }}
       run:  echo "${{ github.event.inputs.distinct_id }}"
+    - name: Check for Azure token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
+      run: | 
+        echo "Missing Azure Access Token" 
+        exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
       with:
@@ -131,7 +137,8 @@ jobs:
       run: |
         .\build.githubactions.ps1 InstallCredentialHandler
       shell: pwsh     
-    - name: publish 
+    - name: publish
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       working-directory: ./Ed-Fi-ODS/
       run: |
         .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Suite3.Ods.Populated.Template.TPDM.Core.PostgreSQL"

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Check for Azure token
       if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
       run: | 
-        echo "Missing Azure Access Token" 
+        echo "::error::Missing Azure Token"
         exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.TPDM.yml
@@ -30,6 +30,8 @@ env:
   REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
   HEAD_REF:  ${{ GITHUB.HEAD_REF }}
   REF_NAME:  ${{ GITHUB.REF_NAME }}
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
+
 jobs:
   build:
 
@@ -38,6 +40,11 @@ jobs:
     steps:
     - name: echo distinct ID ${{ github.event.inputs.distinct_id }}
       run:  echo "${{ github.event.inputs.distinct_id }}"
+    - name: Check for Azure token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
+      run: | 
+        echo "Missing Azure Access Token" 
+        exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
       with:
@@ -149,7 +156,8 @@ jobs:
               Write-Host "Extracted to: $env:UserProfile\.nuget\plugins\" -ForegroundColor Green
           }
       shell: pwsh
-    - name: publish 
+    - name: publish
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       working-directory: ./Ed-Fi-ODS/
       run: |
         .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Suite3.Ods.Populated.Template.TPDM.Core"

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Check for Azure token
       if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
       run: | 
-        echo "Missing Azure Access Token" 
+        echo "::error::Missing Azure Token"
         exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.yml
@@ -29,6 +29,8 @@ env:
   REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
   HEAD_REF:  ${{ GITHUB.HEAD_REF }}
   REF_NAME:  ${{ GITHUB.REF_NAME }}
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
+
 jobs:
   build:
 
@@ -37,6 +39,11 @@ jobs:
     steps:
     - name: echo distinct ID ${{ github.event.inputs.distinct_id }}
       run:  echo "${{ github.event.inputs.distinct_id }}"
+    - name: Check for Azure token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.AZURE_ARTIFACT_NUGET_KEY == '' }}
+      run: | 
+        echo "Missing Azure Access Token" 
+        exit 1 
     - name: Setup .NET
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
       with:
@@ -149,6 +156,7 @@ jobs:
           }
       shell: pwsh
     - name: publish 
+      if: ${{ env.AZURE_ARTIFACT_NUGET_KEY != '' }}
       working-directory: ./Ed-Fi-ODS/
       run: |
         .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Suite3.Ods.Populated.Template"

--- a/.github/workflows/Trgr InitDev workflows in Implementation repo.yml
+++ b/.github/workflows/Trgr InitDev workflows in Implementation repo.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   EDFI_ODS_IMP_TOKEN: ${{ secrets.REPO_DISPATCH_TOKEN }}
+  REPOSITORY_OWNER: ${{ GITHUB.REPOSITORY_OWNER }}
 
 jobs:
   build:
@@ -14,7 +15,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Check for Repo Dispatch Token
+      if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.EDFI_ODS_IMP_TOKEN == '' }}
+      run: | 
+        echo "Missing GitHub Token" 
+        exit 1
     - name: Dispatch to Implementation repo
+      if: ${{ env.EDFI_ODS_IMP_TOKEN != '' }}
       uses: peter-evans/repository-dispatch@11ba7d3f32dc7cc919d1c43f1fec1c05260c26b5 # v2
       with:
         token: ${{ env.EDFI_ODS_IMP_TOKEN }}

--- a/.github/workflows/Trgr InitDev workflows in Implementation repo.yml
+++ b/.github/workflows/Trgr InitDev workflows in Implementation repo.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Check for Repo Dispatch Token
       if: ${{ env.REPOSITORY_OWNER == 'Ed-Fi-Alliance-OSS' && env.EDFI_ODS_IMP_TOKEN == '' }}
       run: | 
-        echo "Missing GitHub Token" 
+        echo "::error::Missing GitHub Token"
         exit 1
     - name: Dispatch to Implementation repo
       if: ${{ env.EDFI_ODS_IMP_TOKEN != '' }}


### PR DESCRIPTION
Forked repositories need the ability to run actions without necessarily uploading artifacts to Azure or using GitHub secrets. This PR causes those actions to still fail in the Ed-Fi-Alliance-OSS repository if the secrets are missing, but pass in other repositories, skipping the steps that use the tokens. 