### PR TITLE
[ODS-5766] Add the Standard version to the minimal and populated templates

### DIFF
--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - 'ODS-*'
   workflow_dispatch:
     inputs:
       distinct_id:
@@ -19,7 +20,6 @@ on:
     types: [triggered-from-datastandard-repo]
 
 env:
-  EDFI_STANDARD_REFERENCE: "v4.0.0"
   INFORMATIONAL_VERSION: "7.0"
   BUILD_INCREMENTER: "400"
   AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
@@ -31,10 +31,34 @@ env:
   REF_NAME:  ${{ GITHUB.REF_NAME }}
 
 jobs:
-  build:
 
+  FindStandardVersions:
+     runs-on: ubuntu-latest    
+     outputs:
+       StandardVersions: ${{ steps.Set_StandardVersions.outputs.StandardVersions }}
+     steps:
+     - name: Checkout Ed-Fi-ODS
+       uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
+       with:
+           repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
+           path: Ed-Fi-ODS/   
+     - name: Set StandardVersions
+       id: Set_StandardVersions
+       working-directory: ./Ed-Fi-ODS/
+       run: |
+         $output = .\build.githubactions.ps1 StandardVersions -ProjectFile "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Application/EdFi.Ods.Standard/EdFi.Ods.Standard.csproj"
+         echo "StandardVersions=$output" >> $env:GITHUB_OUTPUT
+         Write-host "StandardVersions is  $output"
+       shell: pwsh
+
+  build:
+    if: ${{ always() }}
+    needs: FindStandardVersions
     runs-on: ubuntu-latest
-    
+    strategy:
+      matrix:
+        StandardVersion: ${{ fromJson(needs.FindStandardVersions.outputs.StandardVersions) }}
+    name: build (Standard Version ${{ matrix.StandardVersion }})
     services:
       postgres:
         image: postgres:13
@@ -66,6 +90,13 @@ jobs:
       with:
           repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation
           path: Ed-Fi-ODS-Implementation/
+    - name: Set Ed-Fi-Standard Reference
+      working-directory: ./Ed-Fi-ODS/
+      run: |
+        $standardTag = .\build.githubactions.ps1 StandardTag -standardVersion ${{ matrix.StandardVersion }} -ProjectFile "./Application/EdFi.Ods.Standard/EdFi.Ods.Standard.csproj"
+        echo "EDFI_STANDARD_REFERENCE=$standardTag">> $env:GITHUB_ENV
+        Write-host "Ed-Fi-Standard Tag is  $standardTag"
+      shell: pwsh
     - name: Checkout Ed-Fi-ODS-Standard
       uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
       with:
@@ -76,7 +107,7 @@ jobs:
       working-directory: ./Ed-Fi-ODS/
       shell: pwsh
       run: |
-        .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-Standard"          
+        .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-Standard"
     - name: Is pull request branch exists in Ed-Fi-ODS-Implementation
       working-directory: ./Ed-Fi-ODS/
       shell: pwsh
@@ -93,7 +124,7 @@ jobs:
       working-directory: ./Ed-Fi-ODS/
       run: |
         .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
-      shell: pwsh                
+      shell: pwsh
     - name: Initialize-DevelopmentEnvironment
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
@@ -101,7 +132,7 @@ jobs:
         [Environment]::SetEnvironmentVariable('msbuild_buildConfiguration', '${{ env.CONFIGURATION }}')
         $PSVersionTable
           . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Initialize-PowershellForDevelopment.ps1
-        Initialize-DevelopmentEnvironment -NoCredentials -NoDeploy -Engine PostgreSQL -NoRestore
+        Initialize-DevelopmentEnvironment -NoCredentials -NoDeploy -Engine PostgreSQL -NoRestore -StandardVersion ${{ matrix.StandardVersion }}
       shell: pwsh
     - name: Remove Plug-Ins
       working-directory: ./Ed-Fi-ODS-Implementation/
@@ -115,12 +146,12 @@ jobs:
         $ErrorActionPreference = 'Stop'
         [Environment]::SetEnvironmentVariable('msbuild_buildConfiguration', '${{ env.CONFIGURATION }}')
         Import-Module -Force -Scope Global "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/DatabaseTemplate/Modules/create-minimal-template.psm1"
-        Initialize-MinimalTemplate -samplePath "./Ed-Fi-Standard/Descriptors" -noExtensions -Engine PostgreSQL
+        Initialize-MinimalTemplate -samplePath "./Ed-Fi-Standard/Descriptors" -noExtensions -Engine PostgreSQL -standardVersion ${{ matrix.StandardVersion }}
       shell: pwsh
     - name: pack
       working-directory: ./Ed-Fi-ODS/
       run: |
-        .\build.githubactions.ps1 pack -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuspecFilePath "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/DatabaseTemplate/Database/EdFi.Ods.Minimal.Template.PostgreSQL.nuspec" -PackageName "EdFi.Suite3.Ods.Minimal.Template.PostgreSQL"
+        .\build.githubactions.ps1 pack -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuspecFilePath "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/DatabaseTemplate/Database/EdFi.Ods.Minimal.Template.PostgreSQL.Standard.${{ matrix.StandardVersion }}.nuspec" -PackageName "EdFi.Suite3.Ods.Minimal.Template.PostgreSQL.Standard.${{ matrix.StandardVersion }}"
       shell: pwsh
     - name: Install-credential-handler
       working-directory: ./Ed-Fi-ODS/
@@ -130,7 +161,7 @@ jobs:
     - name: publish 
       working-directory: ./Ed-Fi-ODS/
       run: |
-        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Suite3.Ods.Minimal.Template.PostgreSQL"
+        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Suite3.Ods.Minimal.Template.PostgreSQL.Standard.${{ matrix.StandardVersion }}"
       shell: pwsh
     - name: Upload EdFi.Ods.Minimal.Template Artifacts
       if: success() || failure()

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - main
-      - 'ODS-*'
   workflow_dispatch:
     inputs:
       distinct_id:
@@ -33,7 +32,7 @@ env:
 jobs:
 
   FindStandardVersions:
-     runs-on: ubuntu-latest    
+     runs-on: ubuntu-latest
      outputs:
        StandardVersions: ${{ steps.Set_StandardVersions.outputs.StandardVersions }}
      steps:

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - main
-      - 'ODS-*'
   workflow_dispatch:
     inputs:
       distinct_id:

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.yml
@@ -33,7 +33,7 @@ env:
 jobs:
 
   FindStandardVersions:
-     runs-on: ubuntu-latest    
+     runs-on: ubuntu-latest
      outputs:
        StandardVersions: ${{ steps.Set_StandardVersions.outputs.StandardVersions }}
      steps:
@@ -66,8 +66,8 @@ jobs:
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
       with:
         dotnet-version: 6.0.x
-     - name: Support longpaths
-       run: git config --system core.longpaths true
+    - name: Support longpaths
+      run: git config --system core.longpaths true
     - name: Checkout Ed-Fi-ODS
       uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
       with:

--- a/.github/workflows/Pkg EdFi.Ods.Minimal.Template.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Minimal.Template.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - 'ODS-*'
   workflow_dispatch:
     inputs:
       distinct_id:
@@ -19,7 +20,6 @@ on:
     types: [triggered-from-datastandard-repo]
 
 env:
-  EDFI_STANDARD_REFERENCE: "v4.0.0"
   INFORMATIONAL_VERSION: "7.0"
   BUILD_INCREMENTER: "499"
   AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
@@ -31,10 +31,34 @@ env:
   REF_NAME:  ${{ GITHUB.REF_NAME }}
 
 jobs:
+
+  FindStandardVersions:
+     runs-on: ubuntu-latest    
+     outputs:
+       StandardVersions: ${{ steps.Set_StandardVersions.outputs.StandardVersions }}
+     steps:
+     - name: Checkout Ed-Fi-ODS
+       uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
+       with:
+           repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
+           path: Ed-Fi-ODS/ 
+     - name: Set StandardVersions
+       id: Set_StandardVersions
+       working-directory: ./Ed-Fi-ODS/
+       run: |
+         $output = .\build.githubactions.ps1 StandardVersions -ProjectFile "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Application/EdFi.Ods.Standard/EdFi.Ods.Standard.csproj"
+         echo "StandardVersions=$output" >> $env:GITHUB_OUTPUT
+         Write-host "StandardVersions is  $output"
+       shell: pwsh
+
   build:
-
+    if: ${{ always() }}
+    needs: FindStandardVersions
     runs-on: windows-latest
-
+    strategy:
+      matrix:
+        StandardVersion: ${{ fromJson(needs.FindStandardVersions.outputs.StandardVersions) }}
+    name: build (Standard Version ${{ matrix.StandardVersion }})
     steps:
     - name: echo distinct ID ${{ github.event.inputs.distinct_id }}
       run:  echo "${{ github.event.inputs.distinct_id }}"
@@ -42,8 +66,8 @@ jobs:
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # 2.1.0
       with:
         dotnet-version: 6.0.x
-    - name: Support longpaths
-      run: git config --system core.longpaths true
+     - name: Support longpaths
+       run: git config --system core.longpaths true
     - name: Checkout Ed-Fi-ODS
       uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
       with:
@@ -54,12 +78,19 @@ jobs:
       with:
           repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation
           path: Ed-Fi-ODS-Implementation/
+    - name: Set Ed-Fi-Standard Reference
+      working-directory: ./Ed-Fi-ODS/
+      run: |
+        $standardTag = .\build.githubactions.ps1 StandardTag -standardVersion ${{ matrix.StandardVersion }} -ProjectFile "./Application/EdFi.Ods.Standard/EdFi.Ods.Standard.csproj"
+        echo "EDFI_STANDARD_REFERENCE=$standardTag">> $env:GITHUB_ENV
+        Write-host "Ed-Fi-Standard Tag is  $standardTag"
+      shell: pwsh
     - name: Checkout Ed-Fi-ODS-Standard
       uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
       with:
           repository: Ed-Fi-Alliance-OSS/Ed-Fi-Standard
           path: Ed-Fi-Standard/
-          ref: ${{ env.EDFI_STANDARD_REFERENCE }}          
+          ref: ${{ env.EDFI_STANDARD_REFERENCE }}
     - name: Is pull request branch exists in Ed-Fi-Standard
       working-directory: ./Ed-Fi-ODS/
       shell: powershell
@@ -75,7 +106,7 @@ jobs:
       run: |
           choco install sql-server-2019  -y --params "'/IGNOREPENDINGREBOOT /IACCEPTSQLSERVERLICENSETERMS /Q /ACTION=install /INSTANCEID=MSSQLSERVER /INSTANCENAME=MSSQLSERVER /TCPENABLED=1 /UPDATEENABLED=FALSE /FEATURES=SQL,Tools'" --execution-timeout=$installTimeout
           choco install sqlpackage
-    - name: Cache Nuget packages       
+    - name: Cache Nuget packages
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
@@ -94,7 +125,7 @@ jobs:
         [Environment]::SetEnvironmentVariable('msbuild_buildConfiguration', '${{ env.CONFIGURATION }}')
         $PSVersionTable
           . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Initialize-PowershellForDevelopment.ps1
-        Initialize-DevelopmentEnvironment -NoCredentials -NoDeploy -NoRestore
+        Initialize-DevelopmentEnvironment -NoCredentials -NoDeploy -NoRestore -StandardVersion ${{ matrix.StandardVersion }}
       shell: powershell
     - name: Remove Plug-Ins
       working-directory: ./Ed-Fi-ODS-Implementation/
@@ -107,13 +138,13 @@ jobs:
       run: |
         $ErrorActionPreference = 'Stop'
         [Environment]::SetEnvironmentVariable('msbuild_buildConfiguration', '${{ env.CONFIGURATION }}')
-        Import-Module -Force -Scope Global "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/DatabaseTemplate/Modules/create-minimal-template.psm1"      
-        Initialize-MinimalTemplate -samplePath './Ed-Fi-Standard/Descriptors' -noExtensions
+        Import-Module -Force -Scope Global "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/DatabaseTemplate/Modules/create-minimal-template.psm1"
+        Initialize-MinimalTemplate -samplePath './Ed-Fi-Standard/Descriptors' -noExtensions -standardVersion ${{ matrix.StandardVersion }}
       shell: powershell
     - name: pack
       working-directory: ./Ed-Fi-ODS/
       run: |
-        .\build.githubactions.ps1 pack -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuspecFilePath "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/DatabaseTemplate/Database/EdFi.Ods.Minimal.Template.nuspec" -PackageName  "EdFi.Suite3.Ods.Minimal.Template" 
+        .\build.githubactions.ps1 pack -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuspecFilePath "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/DatabaseTemplate/Database/EdFi.Ods.Minimal.Template.Standard.${{ matrix.StandardVersion }}.nuspec" -PackageName  "EdFi.Suite3.Ods.Minimal.Template.Standard.${{ matrix.StandardVersion }}" 
       shell: powershell
     - name: Install-credential-handler
       working-directory: ./Ed-Fi-ODS-Implementation/
@@ -150,7 +181,7 @@ jobs:
     - name: publish 
       working-directory: ./Ed-Fi-ODS/
       run: |
-        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Suite3.Ods.Minimal.Template"
+        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Suite3.Ods.Minimal.Template.Standard.${{ matrix.StandardVersion }}"
       shell: powershell      
     - name: Upload EdFi.Ods.Minimal.Template Artifacts
       if: success() || failure()

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - main
-      - 'ODS-*'
   workflow_dispatch:
     inputs:
       distinct_id:

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - 'ODS-*'
   workflow_dispatch:
     inputs:
       distinct_id:
@@ -19,7 +20,6 @@ on:
     types: [triggered-from-datastandard-repo]
 
 env:
-  EDFI_STANDARD_REFERENCE: "v4.0.0"
   INFORMATIONAL_VERSION: "7.0"
   BUILD_INCREMENTER: "391"
   AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
@@ -31,10 +31,34 @@ env:
   REF_NAME:  ${{ GITHUB.REF_NAME }}
 
 jobs:
+
+  FindStandardVersions:
+     runs-on: ubuntu-latest    
+     outputs:
+       StandardVersions: ${{ steps.Set_StandardVersions.outputs.StandardVersions }}
+     steps:
+     - name: Checkout Ed-Fi-ODS
+       uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
+       with:
+           repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
+           path: Ed-Fi-ODS/   
+     - name: Set StandardVersions
+       id: Set_StandardVersions
+       working-directory: ./Ed-Fi-ODS/
+       run: |
+         $output = .\build.githubactions.ps1 StandardVersions -ProjectFile "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Application/EdFi.Ods.Standard/EdFi.Ods.Standard.csproj"
+         echo "StandardVersions=$output" >> $env:GITHUB_OUTPUT
+         Write-host "StandardVersions is  $output"
+       shell: pwsh
+
   build:
-
+    if: ${{ always() }}
+    needs: FindStandardVersions
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        StandardVersion: ${{ fromJson(needs.FindStandardVersions.outputs.StandardVersions) }}
+    name: build (Standard Version ${{ matrix.StandardVersion }})
     services:
       postgres:
         image: postgres:13
@@ -66,17 +90,24 @@ jobs:
       with:
           repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation
           path: Ed-Fi-ODS-Implementation/
+    - name: Set Ed-Fi-Standard Reference
+      working-directory: ./Ed-Fi-ODS/
+      run: |
+        $standardTag = .\build.githubactions.ps1 StandardTag -standardVersion ${{ matrix.StandardVersion }} -ProjectFile "./Application/EdFi.Ods.Standard/EdFi.Ods.Standard.csproj"
+        echo "EDFI_STANDARD_REFERENCE=$standardTag">> $env:GITHUB_ENV
+        Write-host "Ed-Fi-Standard Tag is  $standardTag"
+      shell: pwsh
     - name: Checkout Ed-Fi-ODS-Standard
       uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
       with:
           repository: Ed-Fi-Alliance-OSS/Ed-Fi-Standard
           path: Ed-Fi-Standard/
-          ref: ${{ env.EDFI_STANDARD_REFERENCE }}          
+          ref: ${{ env.EDFI_STANDARD_REFERENCE }}
     - name: Is pull request branch exists in Ed-Fi-Standard
       working-directory: ./Ed-Fi-ODS/
       shell: pwsh
       run: |
-        .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-Standard"          
+        .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-Standard"
     - name: Is pull request branch exists in Ed-Fi-ODS-Implementation
       working-directory: ./Ed-Fi-ODS/
       shell: pwsh
@@ -93,7 +124,7 @@ jobs:
       working-directory: ./Ed-Fi-ODS/
       run: |
         .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
-      shell: pwsh                
+      shell: pwsh
     - name: Initialize-DevelopmentEnvironment
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
@@ -101,7 +132,7 @@ jobs:
         [Environment]::SetEnvironmentVariable('msbuild_buildConfiguration', '${{ env.CONFIGURATION }}')
         $PSVersionTable
           . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Initialize-PowershellForDevelopment.ps1
-        Initialize-DevelopmentEnvironment -NoCredentials -NoDeploy -Engine PostgreSQL -NoRestore
+        Initialize-DevelopmentEnvironment -NoCredentials -NoDeploy -Engine PostgreSQL -NoRestore -StandardVersion ${{ matrix.StandardVersion }}
       shell: pwsh
     - name: Remove Plug-Ins
       working-directory: ./Ed-Fi-ODS-Implementation/
@@ -115,12 +146,12 @@ jobs:
         $ErrorActionPreference = 'Stop'
         [Environment]::SetEnvironmentVariable('msbuild_buildConfiguration', '${{ env.CONFIGURATION }}')
         Import-Module -Force -Scope Global "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/DatabaseTemplate/Modules/create-populated-template.psm1"
-        Initialize-PopulatedTemplate -samplePath "./Ed-Fi-Standard/" -noExtensions -Engine PostgreSQL
+        Initialize-PopulatedTemplate -samplePath "./Ed-Fi-Standard/" -noExtensions -Engine PostgreSQL -standardVersion ${{ matrix.StandardVersion }}
       shell: pwsh
     - name: pack
       working-directory: ./Ed-Fi-ODS/
       run: |
-        .\build.githubactions.ps1 pack -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuspecFilePath "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/DatabaseTemplate/Database/EdFi.Ods.Populated.Template.PostgreSQL.nuspec" -PackageName "EdFi.Suite3.Ods.Populated.Template.PostgreSQL"
+        .\build.githubactions.ps1 pack -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuspecFilePath "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/DatabaseTemplate/Database/EdFi.Ods.Populated.Template.PostgreSQL.Standard.${{ matrix.StandardVersion }}.nuspec" -PackageName "EdFi.Suite3.Ods.Populated.Template.PostgreSQL.Standard.${{ matrix.StandardVersion }}"
       shell: pwsh
     - name: Install-credential-handler
       working-directory: ./Ed-Fi-ODS/
@@ -130,7 +161,7 @@ jobs:
     - name: publish 
       working-directory: ./Ed-Fi-ODS/
       run: |
-        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Suite3.Ods.Populated.Template.PostgreSQL"
+        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Suite3.Ods.Populated.Template.PostgreSQL.Standard.${{ matrix.StandardVersion }}"
       shell: pwsh
     - name: Upload EdFi.Ods.Populated.Template Artifacts
       if: success() || failure()

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - main
-      - 'ODS-*'
   workflow_dispatch:
     inputs:
       distinct_id:

--- a/.github/workflows/Pkg EdFi.Ods.Populated.Template.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Populated.Template.yml
@@ -9,17 +9,17 @@ on:
   push:
     branches:
       - main
+      - 'ODS-*'
   workflow_dispatch:
     inputs:
       distinct_id:
         description: 'distinct ID for Rebuild Database Templates workflow'
         required: false
         default: 'distinct_id'
-
   repository_dispatch:
     types: [triggered-from-datastandard-repo]
+
 env:
-  EDFI_STANDARD_REFERENCE: "v4.0.0"
   INFORMATIONAL_VERSION: "7.0"
   BUILD_INCREMENTER: "470"
   AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
@@ -29,11 +29,36 @@ env:
   REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
   HEAD_REF:  ${{ GITHUB.HEAD_REF }}
   REF_NAME:  ${{ GITHUB.REF_NAME }}
+
 jobs:
+
+  FindStandardVersions:
+     runs-on: ubuntu-latest
+     outputs:
+       StandardVersions: ${{ steps.Set_StandardVersions.outputs.StandardVersions }}
+     steps:
+     - name: Checkout Ed-Fi-ODS
+       uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
+       with:
+           repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
+           path: Ed-Fi-ODS/   
+     - name: Set StandardVersions
+       id: Set_StandardVersions
+       working-directory: ./Ed-Fi-ODS/
+       run: |
+         $output = .\build.githubactions.ps1 StandardVersions -ProjectFile "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Application/EdFi.Ods.Standard/EdFi.Ods.Standard.csproj"
+         echo "StandardVersions=$output" >> $env:GITHUB_OUTPUT
+         Write-host "StandardVersions is  $output"
+       shell: pwsh
+
   build:
-
+    if: ${{ always() }}
+    needs: FindStandardVersions
     runs-on: windows-latest
-
+    strategy:
+      matrix:
+        StandardVersion: ${{ fromJson(needs.FindStandardVersions.outputs.StandardVersions) }}
+    name: build (Standard Version ${{ matrix.StandardVersion }})
     steps:
     - name: echo distinct ID ${{ github.event.inputs.distinct_id }}
       run:  echo "${{ github.event.inputs.distinct_id }}"
@@ -53,17 +78,24 @@ jobs:
       with:
           repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation
           path: Ed-Fi-ODS-Implementation/
+    - name: Set Ed-Fi-Standard Reference
+      working-directory: ./Ed-Fi-ODS/
+      run: |
+        $standardTag = .\build.githubactions.ps1 StandardTag -standardVersion ${{ matrix.StandardVersion }} -ProjectFile "./Application/EdFi.Ods.Standard/EdFi.Ods.Standard.csproj"
+        echo "EDFI_STANDARD_REFERENCE=$standardTag">> $env:GITHUB_ENV
+        Write-host "Ed-Fi-Standard Tag is  $standardTag"
+      shell: pwsh
     - name: Checkout Ed-Fi-ODS-Standard
       uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
       with:
           repository: Ed-Fi-Alliance-OSS/Ed-Fi-Standard
           path: Ed-Fi-Standard/
-          ref: ${{ env.EDFI_STANDARD_REFERENCE }}          
+          ref: ${{ env.EDFI_STANDARD_REFERENCE }}
     - name: Is pull request branch exists in Ed-Fi-Standard
       working-directory: ./Ed-Fi-ODS/
       shell: powershell
       run: |
-        .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-Standard"          
+        .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-Standard"
     - name: Is pull request branch exists in Ed-Fi-ODS-Implementation
       working-directory: ./Ed-Fi-ODS/
       shell: powershell
@@ -74,7 +106,7 @@ jobs:
       run: |
           choco install sql-server-2019  -y --params "'/IGNOREPENDINGREBOOT /IACCEPTSQLSERVERLICENSETERMS /Q /ACTION=install /INSTANCEID=MSSQLSERVER /INSTANCENAME=MSSQLSERVER /TCPENABLED=1 /UPDATEENABLED=FALSE /FEATURES=SQL,Tools'" --execution-timeout=$installTimeout
           choco install sqlpackage
-    - name: Cache Nuget packages       
+    - name: Cache Nuget packages
       uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
       with:
         path: ~/.nuget/packages
@@ -85,17 +117,15 @@ jobs:
       working-directory: ./Ed-Fi-ODS/
       run: |
         .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
-      shell: pwsh                
+      shell: pwsh
     - name: Initialize-DevelopmentEnvironment
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
         $ErrorActionPreference = 'Stop'
         [Environment]::SetEnvironmentVariable('msbuild_buildConfiguration', '${{ env.CONFIGURATION }}')
-
         $PSVersionTable
           . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Initialize-PowershellForDevelopment.ps1
-        
-        Initialize-DevelopmentEnvironment -NoCredentials -NoDeploy  -NoRestore
+        Initialize-DevelopmentEnvironment -NoCredentials -NoDeploy  -NoRestore  -StandardVersion ${{ matrix.StandardVersion }}
       shell: powershell
     - name: Remove Plug-Ins
       working-directory: ./Ed-Fi-ODS-Implementation/
@@ -108,13 +138,13 @@ jobs:
       run: |
         $ErrorActionPreference = 'Stop'
         [Environment]::SetEnvironmentVariable('msbuild_buildConfiguration', '${{ env.CONFIGURATION }}')
-        Import-Module -Force -Scope Global "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/DatabaseTemplate/Modules/create-populated-template.psm1"      
-        Initialize-PopulatedTemplate -samplePath './Ed-Fi-Standard/' -noExtensions
+        Import-Module -Force -Scope Global "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/DatabaseTemplate/Modules/create-populated-template.psm1"
+        Initialize-PopulatedTemplate -samplePath './Ed-Fi-Standard/' -noExtensions -standardVersion ${{ matrix.StandardVersion }}
       shell: powershell
     - name: pack
       working-directory: ./Ed-Fi-ODS/
       run: |
-        .\build.githubactions.ps1 pack -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuspecFilePath "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/DatabaseTemplate/Database/EdFi.Ods.Populated.Template.nuspec" -PackageName  "EdFi.Suite3.Ods.Populated.Template" 
+        .\build.githubactions.ps1 pack -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuspecFilePath "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/DatabaseTemplate/Database/EdFi.Ods.Populated.Template.Standard.${{ matrix.StandardVersion }}.nuspec" -PackageName  "EdFi.Suite3.Ods.Populated.Template.Standard.${{ matrix.StandardVersion }}" 
       shell: powershell
     - name: Install-credential-handler
       working-directory: ./Ed-Fi-ODS-Implementation/
@@ -151,7 +181,7 @@ jobs:
     - name: publish 
       working-directory: ./Ed-Fi-ODS/
       run: |
-        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Suite3.Ods.Populated.Template"
+        .\build.githubactions.ps1 publish -InformationalVersion ${{ env.INFORMATIONAL_VERSION }} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }} -EdFiNuGetFeed ${{env.AZURE_ARTIFACT_URL}} -PackageName  "EdFi.Suite3.Ods.Populated.Template.Standard.${{ matrix.StandardVersion }}"
       shell: powershell      
     - name: Upload EdFi.Ods.Populated.Template Artifacts
       if: success() || failure()

--- a/Application/EdFi.Ods.Standard/version.utils.ps1
+++ b/Application/EdFi.Ods.Standard/version.utils.ps1
@@ -6,21 +6,12 @@
 [CmdLetBinding()]
 param(
     [string]
-    [ValidateSet("Get-StandardTag", "Get-TpdmTag")]
-    $Command = "Get-StandardTag",
+    [ValidateSet("Get-TpdmTag")]
+    $Command = "Get-TpdmTag",
 
     [string]
     $StandardVersion
 )
-
-function Get-StandardTag {
-    param (
-        [string]
-        $StandardVersion
-    )
-
-    (Get-Content versionmap.json | ConvertFrom-Json).'Ed-Fi-Standard'.$StandardVersion
-}
 
 function Get-TpdmTag {
     param (
@@ -33,7 +24,6 @@ function Get-TpdmTag {
 
 try {
     switch ($Command) {
-        Get-StandardTag { Get-StandardTag($standardversion) }
         Get-TpdmTag { Get-TpdmTag($standardversion) }
     }
     exit 0


### PR DESCRIPTION
Created ODS-5766 branch in Ed-Fi-Extensions to have CodeGen build passing

Application/EdFi.Ods.Standard/version.utils.ps1 will be totally removed in https://tracker.ed-fi.org/browse/ODS-5767