### PR TITLE
[ODS-5794] Enhance Request-Response logging with profile header information

### DIFF
--- a/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
+++ b/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
@@ -65,10 +65,6 @@ namespace EdFi.Ods.Api.Startup
     {
         private const string CorsPolicyName = "_development_";
 
-        private const string EmptyClientId = "";
-
-        private const string EmptyProfilesContentTypeHeader = "";
-
         private readonly ILog _logger = LogManager.GetLogger(typeof(OdsStartupBase));
 
         public OdsStartupBase(IWebHostEnvironment env, IConfiguration configuration)
@@ -83,9 +79,9 @@ namespace EdFi.Ods.Api.Startup
 
             Configuration.Bind("Plugin", Plugin);
 
-            GlobalContext.Properties["ApiClientId"] = EmptyClientId;
+            GlobalContext.Properties["ApiClientId"] = null;
 
-            GlobalContext.Properties["ProfilesHeader"] = EmptyProfilesContentTypeHeader;
+            GlobalContext.Properties["ProfilesHeader"] = null;
 
             _logger.Debug($"built configuration = {Configuration}");
         }

--- a/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
+++ b/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
@@ -67,6 +67,8 @@ namespace EdFi.Ods.Api.Startup
 
         private const string EmptyClientId = "";
 
+        private const string EmptyProfilesContentTypeHeader = "";
+
         private readonly ILog _logger = LogManager.GetLogger(typeof(OdsStartupBase));
 
         public OdsStartupBase(IWebHostEnvironment env, IConfiguration configuration)
@@ -82,6 +84,8 @@ namespace EdFi.Ods.Api.Startup
             Configuration.Bind("Plugin", Plugin);
 
             GlobalContext.Properties["ApiClientId"] = EmptyClientId;
+
+            GlobalContext.Properties["ProfilesHeader"] = EmptyProfilesContentTypeHeader;
 
             _logger.Debug($"built configuration = {Configuration}");
         }

--- a/Application/EdFi.Ods.Features/Profiles/ProfileContentTypeContextMiddleware.cs
+++ b/Application/EdFi.Ods.Features/Profiles/ProfileContentTypeContextMiddleware.cs
@@ -11,6 +11,7 @@ using EdFi.Ods.Common.Context;
 using EdFi.Ods.Common.Metadata.Profiles;
 using EdFi.Ods.Common.Profiles;
 using EdFi.Ods.Common.Utils.Profiles;
+using log4net;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
@@ -55,6 +56,7 @@ public class ProfileContentTypeContextMiddleware
 
             if (profileContentType != null)
             {
+                LogicalThreadContext.Properties["ProfilesHeader"] = profileContentType;
                 var (continueInvocation, profileContentTypeContext) = await TryProcessProfileContentTypeAsync(
                     "Accept",
                     profileContentType,
@@ -76,6 +78,8 @@ public class ProfileContentTypeContextMiddleware
 
             if (profileContentType?.StartsWith(ProfileContentTypePrefix) ?? false)
             {
+                LogicalThreadContext.Properties["ProfilesHeader"] = profileContentType;
+
                 var (continueInvocation, profileContentTypeContext) = await TryProcessProfileContentTypeAsync(
                     "Content-Type",
                     profileContentType,


### PR DESCRIPTION
Include any profiles header (content-type header starting with "application/vnd.ed-fi." ) sent by an API client in the RequestResponseDetails log messages. The field is left blank in the log message if the client does not provide a profiles header in the request.
Example of log message including a profiles header:
`2023-04-19 19:19:16,898 [64] INFO  ClientId:43 RequestUrl:http://localhost:8765/data/v3/ed-fi/schools RequestMethod:POST ProfilesHeader:application/vnd.ed-fi.school.Test-Profile-Resource-WriteOnly.writable+json ResponseCode:403 ResponseMessage:Forbidden` 