### PR TITLE
[ODS-5329] Track the details of failed API calls

### DIFF
--- a/Application/EdFi.Ods.Api/Container/Modules/ApplicationModule.cs
+++ b/Application/EdFi.Ods.Api/Container/Modules/ApplicationModule.cs
@@ -377,8 +377,8 @@ namespace EdFi.Ods.Api.Container.Modules
                     .As<IMiddleware>()
                     .WithParameter(
                         new ResolvedParameter(
-                            (p, c) => p.Name == "logRequestResponseContentForSeconds",
-                            (p, c) => c.Resolve<ApiSettings>().LogRequestResponseContentForSeconds))
+                            (p, c) => p.Name == "logRequestResponseContentForMinutes",
+                            (p, c) => c.Resolve<ApiSettings>().LogRequestResponseContentForMinutes))
                     .WithParameter(
                         new ResolvedParameter(
                         (p, c) => p.ParameterType == typeof(ReverseProxySettings),

--- a/Application/EdFi.Ods.Api/Container/Modules/ApplicationModule.cs
+++ b/Application/EdFi.Ods.Api/Container/Modules/ApplicationModule.cs
@@ -375,6 +375,14 @@ namespace EdFi.Ods.Api.Container.Modules
             {
                 builder.RegisterType<RequestResponseDetailsLoggerMiddleware>()
                     .As<IMiddleware>()
+                    .WithParameter(
+                        new ResolvedParameter(
+                            (p, c) => p.Name == "logRequestResponseContentForSeconds",
+                            (p, c) => c.Resolve<ApiSettings>().LogRequestResponseContentForSeconds))
+                    .WithParameter(
+                        new ResolvedParameter(
+                        (p, c) => p.ParameterType == typeof(ReverseProxySettings),
+                        (p, c) => c.Resolve<ApiSettings>().GetReverseProxySettings()))
                     .AsSelf()
                     .SingleInstance();
 

--- a/Application/EdFi.Ods.Api/Middleware/RequestResponseDetailsLoggerMiddleware.cs
+++ b/Application/EdFi.Ods.Api/Middleware/RequestResponseDetailsLoggerMiddleware.cs
@@ -4,13 +4,16 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using EdFi.Ods.Api.ExceptionHandling;
 using EdFi.Ods.Api.Extensions;
 using EdFi.Ods.Common.Configuration;
+using EdFi.Ods.Common.Database;
 using log4net;
+using log4net.Appender;
 using Microsoft.AspNetCore.Http;
 
 namespace EdFi.Ods.Api.Middleware
@@ -19,30 +22,106 @@ namespace EdFi.Ods.Api.Middleware
     {
         private readonly ReverseProxySettings _reverseProxySettings;
         private readonly IRESTErrorProvider _restErrorProvider;
+        private readonly IOdsDatabaseConnectionStringProvider _connectionStringProvider;
+        private readonly DateTime _logRequestResponseContentUntil;
+        private bool _logRequestResponseContent;
         private ILog _requestResponseDetailsLogger;
+        private ILog _requestResponseContentLogger;
 
-        public RequestResponseDetailsLoggerMiddleware(ApiSettings apiSettings, IRESTErrorProvider restErrorProvider)
+        public RequestResponseDetailsLoggerMiddleware(ApiSettings apiSettings, IRESTErrorProvider restErrorProvider, IOdsDatabaseConnectionStringProvider connectionStringProvider)
         {
             _reverseProxySettings = apiSettings.GetReverseProxySettings();
             _restErrorProvider = restErrorProvider;
+            _connectionStringProvider = connectionStringProvider;
+            _logRequestResponseContent = apiSettings.LogRequestResponseContentForSeconds > 0 && RequestResponseContentDatabaseAppenderExists();
+
+            if(_logRequestResponseContent)
+                _logRequestResponseContentUntil = DateTime.UtcNow.AddSeconds(apiSettings.LogRequestResponseContentForSeconds);
         }
 
         public async Task InvokeAsync(HttpContext context, RequestDelegate next)
         {
-            await next(context);
+            if (_logRequestResponseContent && DateTime.UtcNow > _logRequestResponseContentUntil)
+            {
+                _logRequestResponseContent = false;
+            }
+
+            if (_logRequestResponseContent)
+            {
+                SetDatabaseAppenderConnectionString();
+
+                context.Request.EnableBuffering();
+                string requestBodyContent = await GetRequestBodyContent();
+
+                var originalResponseBodyStream = context.Response.Body;
+                context.Response.Body = new MemoryStream();
+                
+                await next(context);
+
+                string responseBodyContent = await GetResponseBodyContent(originalResponseBodyStream);
+
+                AddLoggerDetailProperties(context.Request.Method, context.Response.StatusCode, context);
+                AddLoggerContentProperties(requestBodyContent, responseBodyContent, context);
+
+                switch (context.Response.StatusCode)
+                {
+                    case StatusCodes.Status500InternalServerError:
+                        if (context.Items["Exception"] is Exception exception)
+                            LogRequestResponseContentOnException(exception);
+                        break;
+                    default:
+                        LogRequestResponseContentInfo(context);
+                        break;
+                }
+            }
+            else
+            {
+                await next(context);
+                AddLoggerDetailProperties(context.Request.Method, context.Response.StatusCode, context);
+            }
 
             switch (context.Response.StatusCode)
             {
                 case StatusCodes.Status500InternalServerError:
                     if(context.Items["Exception"] is Exception exception) 
-                        LogRequestResponseDetailsOnException(context, exception);
-                    break;
-                case StatusCodes.Status201Created:
-                    LogRequestResponseDetailsInfo(context, (context.Items["createdResourceUri"] as string) ?? "Created resource URI missing");
+                        LogRequestResponseDetailsOnException(exception);
                     break;
                 default:
                     LogRequestResponseDetailsInfo(context);
                     break;
+            }
+            
+            void SetDatabaseAppenderConnectionString()
+            {
+                var requestResponseAppenders = ((log4net.Repository.Hierarchy.Logger)LogManager.GetAllRepositories().FirstOrDefault()?.GetLogger("RequestResponseContentLogger"))?.Appenders;
+
+                if (requestResponseAppenders?.Count != 1 || requestResponseAppenders.OfType<AdoNetAppender>().Count() != 1)
+                    return;
+
+                var adoNetAppender = (AdoNetAppender)requestResponseAppenders[0];
+                adoNetAppender.ConnectionString = _connectionStringProvider.GetConnectionString();
+                adoNetAppender.ActivateOptions();
+            }
+
+            async Task<string> GetRequestBodyContent()
+            {
+                context.Request.Body.Position = 0;
+                var requestBody = await new StreamReader(context.Request.Body).ReadToEndAsync();
+                context.Request.Body.Position = 0;
+
+                return requestBody;
+            }
+
+            async Task<string> GetResponseBodyContent(Stream originalBodyStream)
+            {
+                context.Response.Body.Position = 0;
+                var responseBody = await new StreamReader(context.Response.Body).ReadToEndAsync();
+                context.Response.Body.Position = 0;
+
+                await context.Response.Body.CopyToAsync(originalBodyStream);
+                context.Response.Body = originalBodyStream;
+
+                return responseBody;
             }
         }
 
@@ -55,26 +134,34 @@ namespace EdFi.Ods.Api.Middleware
                 : "Unknown";
         }
 
-        private void LogRequestResponseDetailsInfo(HttpContext context, string responseMessage = "Ok")
+        private void LogRequestResponseContentInfo(HttpContext context)
+        {
+            RequestResponseContentLogger.Info(TryGetStatusCodeDescription(context.Response.StatusCode));
+        }
+
+        private void LogRequestResponseContentOnException(Exception exception)
+        {
+            var restError = _restErrorProvider.GetRestErrorFromException(exception);
+
+            RequestResponseContentLogger.Error(restError.Message);
+        }
+
+        private void LogRequestResponseDetailsInfo(HttpContext context)
         {
             // Check the Appender exists to avoid duplicated log messages on both controller(root) and detailed loggers
             if (!RequestResponseDetailsFileAppenderExists())
                 return;
 
-            AddLoggerProperties(context.Request.Method, context.Response.StatusCode, context);
-
             RequestResponseDetailsLogger.Info(TryGetStatusCodeDescription(context.Response.StatusCode));
         }
 
-        private void LogRequestResponseDetailsOnException(HttpContext context, Exception exception)
+        private void LogRequestResponseDetailsOnException(Exception exception)
         {
             // Check the Appender exists to avoid duplicated log messages on both controller(root) and detailed loggers
             if (!RequestResponseDetailsFileAppenderExists())
                 return;
 
             var restError = _restErrorProvider.GetRestErrorFromException(exception);
-
-            AddLoggerProperties(context.Request.Method, restError.Code, context);
 
             RequestResponseDetailsLogger.Error(restError.Message);
         }
@@ -84,15 +171,29 @@ namespace EdFi.Ods.Api.Middleware
             get => _requestResponseDetailsLogger ??= LogManager.GetLogger("RequestResponseDetailsLogger");
         }
 
-        private void AddLoggerProperties(string requestMethod, int responseCode, HttpContext context)
+        protected ILog RequestResponseContentLogger
+        {
+            get => _requestResponseContentLogger ??= LogManager.GetLogger("RequestResponseContentLogger");
+        }
+
+        private void AddLoggerDetailProperties(string requestMethod, int responseCode, HttpContext context)
         {
             LogicalThreadContext.Properties["RequestUrl"] = context.Request.ResourceUri(_reverseProxySettings);
             LogicalThreadContext.Properties["RequestMethod"] = requestMethod;
             LogicalThreadContext.Properties["ResponseCode"] = responseCode;
         }
 
+        private void AddLoggerContentProperties(string requestBodyContent, string responseBodyContent, HttpContext context)
+        {
+            LogicalThreadContext.Properties["RequestUrlWithQueryString"] = $"{context.Request.ResourceUri(_reverseProxySettings)}{context.Request.QueryString}";
+            LogicalThreadContext.Properties["RequestBody"] = requestBodyContent;
+            LogicalThreadContext.Properties["ResponseBody"] = responseBodyContent;
+        }
+
         private bool RequestResponseDetailsFileAppenderExists() => 
             RequestResponseDetailsLogger.Logger.Repository.GetAppenders().Any(x => x.Name == "RequestResponseDetailsFileAppender");
 
+        private bool RequestResponseContentDatabaseAppenderExists() =>
+            RequestResponseContentLogger.Logger.Repository.GetAppenders().Any(x => x.Name == "RequestResponseContentAppender");
     }
 }

--- a/Application/EdFi.Ods.Api/Middleware/RequestResponseDetailsLoggerMiddleware.cs
+++ b/Application/EdFi.Ods.Api/Middleware/RequestResponseDetailsLoggerMiddleware.cs
@@ -28,15 +28,15 @@ namespace EdFi.Ods.Api.Middleware
         private ILog _requestResponseDetailsLogger;
         private ILog _requestResponseContentLogger;
 
-        public RequestResponseDetailsLoggerMiddleware(ReverseProxySettings reverseProxySettings, int logRequestResponseContentForSeconds,IRESTErrorProvider restErrorProvider, IOdsDatabaseConnectionStringProvider connectionStringProvider)
+        public RequestResponseDetailsLoggerMiddleware(ReverseProxySettings reverseProxySettings, int logRequestResponseContentForMinutes,IRESTErrorProvider restErrorProvider, IOdsDatabaseConnectionStringProvider connectionStringProvider)
         {
             _reverseProxySettings = reverseProxySettings;
             _restErrorProvider = restErrorProvider;
             _connectionStringProvider = connectionStringProvider;
-            _logRequestResponseContent = logRequestResponseContentForSeconds > 0 && RequestResponseContentDatabaseAppenderExists();
+            _logRequestResponseContent = logRequestResponseContentForMinutes > 0 && RequestResponseContentDatabaseAppenderExists();
 
             if(_logRequestResponseContent)
-                _logRequestResponseContentUntil = DateTime.UtcNow.AddSeconds(logRequestResponseContentForSeconds);
+                _logRequestResponseContentUntil = DateTime.UtcNow.AddMinutes(logRequestResponseContentForMinutes);
         }
 
         public async Task InvokeAsync(HttpContext context, RequestDelegate next)

--- a/Application/EdFi.Ods.Api/Middleware/RequestResponseDetailsLoggerMiddleware.cs
+++ b/Application/EdFi.Ods.Api/Middleware/RequestResponseDetailsLoggerMiddleware.cs
@@ -143,7 +143,7 @@ namespace EdFi.Ods.Api.Middleware
         {
             var restError = _restErrorProvider.GetRestErrorFromException(exception);
 
-            RequestResponseContentLogger.Error(restError.Message);
+            RequestResponseContentLogger.Error(restError.Message, exception);
         }
 
         private void LogRequestResponseDetailsInfo(HttpContext context)
@@ -163,7 +163,7 @@ namespace EdFi.Ods.Api.Middleware
 
             var restError = _restErrorProvider.GetRestErrorFromException(exception);
 
-            RequestResponseDetailsLogger.Error(restError.Message);
+            RequestResponseDetailsLogger.Error(restError.Message, exception);
         }
 
         protected ILog RequestResponseDetailsLogger

--- a/Application/EdFi.Ods.Api/Middleware/RequestResponseDetailsLoggerMiddleware.cs
+++ b/Application/EdFi.Ods.Api/Middleware/RequestResponseDetailsLoggerMiddleware.cs
@@ -28,15 +28,15 @@ namespace EdFi.Ods.Api.Middleware
         private ILog _requestResponseDetailsLogger;
         private ILog _requestResponseContentLogger;
 
-        public RequestResponseDetailsLoggerMiddleware(ApiSettings apiSettings, IRESTErrorProvider restErrorProvider, IOdsDatabaseConnectionStringProvider connectionStringProvider)
+        public RequestResponseDetailsLoggerMiddleware(ReverseProxySettings reverseProxySettings, int logRequestResponseContentForSeconds,IRESTErrorProvider restErrorProvider, IOdsDatabaseConnectionStringProvider connectionStringProvider)
         {
-            _reverseProxySettings = apiSettings.GetReverseProxySettings();
+            _reverseProxySettings = reverseProxySettings;
             _restErrorProvider = restErrorProvider;
             _connectionStringProvider = connectionStringProvider;
-            _logRequestResponseContent = apiSettings.LogRequestResponseContentForSeconds > 0 && RequestResponseContentDatabaseAppenderExists();
+            _logRequestResponseContent = logRequestResponseContentForSeconds > 0 && RequestResponseContentDatabaseAppenderExists();
 
             if(_logRequestResponseContent)
-                _logRequestResponseContentUntil = DateTime.UtcNow.AddSeconds(apiSettings.LogRequestResponseContentForSeconds);
+                _logRequestResponseContentUntil = DateTime.UtcNow.AddSeconds(logRequestResponseContentForSeconds);
         }
 
         public async Task InvokeAsync(HttpContext context, RequestDelegate next)

--- a/Application/EdFi.Ods.Common/Configuration/ApiSettings.cs
+++ b/Application/EdFi.Ods.Common/Configuration/ApiSettings.cs
@@ -24,6 +24,8 @@ namespace EdFi.Ods.Common.Configuration
 
         public int DefaultPageSizeLimit { get; set; } = 500;
 
+        public int LogRequestResponseContentForSeconds { get; set; } = 0;
+
         public string Engine { get; set; }
 
         public bool PlainTextSecrets { get; set; }

--- a/Application/EdFi.Ods.Common/Configuration/ApiSettings.cs
+++ b/Application/EdFi.Ods.Common/Configuration/ApiSettings.cs
@@ -24,7 +24,7 @@ namespace EdFi.Ods.Common.Configuration
 
         public int DefaultPageSizeLimit { get; set; } = 500;
 
-        public int LogRequestResponseContentForSeconds { get; set; } = 0;
+        public int LogRequestResponseContentForMinutes { get; set; } = 0;
 
         public string Engine { get; set; }
 


### PR DESCRIPTION
### Steps to enabling request/response content logging:

- Take the steps necessary to create a new ODS instance. Then, add a request/response logging table to the ODS database by running one of the following create table scripts (the one matching the database engine in use):

_For an MS SQL database:_
```
IF (EXISTS (SELECT 1 
                 FROM INFORMATION_SCHEMA.TABLES 
                 WHERE TABLE_SCHEMA = 'dbo' 
                 AND  TABLE_NAME = 'RequestResponseContentLog'))
BEGIN
	DROP TABLE [dbo].[RequestResponseContentLog];
END

CREATE TABLE [dbo].[RequestResponseContentLog] (
    [Id] [int] IDENTITY (1, 1) NOT NULL,
    [Date] [datetime] NOT NULL,
	[Thread] [varchar] (255) NOT NULL,
    [ApiClientId] [varchar] (255) NULL,
    [Level] [varchar] (50) NULL,
	[RequestUrl] [varchar] (255) NULL,
	[RequestMethod] [varchar] (10) NULL,
	[ProfilesHeader] [varchar] (255) NULL,
	[RequestBody] [nvarchar] (max) NULL,
	[ResponseBody] [nvarchar] (max) NULL,
    [ResponseMessage] [varchar] (255) NULL,
    [Exception] [varchar] (2000) NULL
)
```

_For a PostgreSQL database:_
```
CREATE TABLE edfi.RequestResponseContentLog (
    Id  SERIAL PRIMARY KEY NOT NULL,
    Date  TIMESTAMP  NOT NULL,
	Thread  varchar  (255) NOT NULL,
    ApiClientId  varchar  (255) NULL,
    Level  varchar  (50) NULL,
	RequestUrl  varchar  (255) NULL,
	RequestMethod  varchar  (10) NULL,
	ProfilesHeader  varchar  (255) NULL,
	RequestBody  varchar   NULL,
	ResponseBody  varchar   NULL,
    ResponseMessage  varchar  (255) NULL,
    Exception varchar  (2000) NULL
)
```

- Next, add one of the following configurations (the ones matching the database engine in use) logger and database appender to the active log4net configuration:

_For logging into an MS SQL database:_
```
  <logger name="RequestResponseContentLogger" additivity="false">
	<level value="ERROR" />
	<appender-ref ref="RequestResponseContentAppender" />
  </logger>
  <appender name="RequestResponseContentAppender" type="log4net.Appender.AdoNetAppender">
    <bufferSize value="0" />
    <threshold value="ERROR" />
    <connectionType value="System.Data.SqlClient.SqlConnection, System.Data, Version=1.0.3300.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
    <commandText value="INSERT INTO RequestResponseContentLog ([Date],[Thread],[ApiClientId],[Level],[RequestUrl],[RequestMethod],[ProfilesHeader],[RequestBody],[ResponseBody],[ResponseMessage],[Exception]) VALUES (@log_date, @thread, @api_client_id, @log_level, @request_url, @request_method, @profiles_header, @request_body, @response_body, @response_message, @exception)" />
    <parameter>
        <parameterName value="@log_date" />
        <dbType value="DateTime" />
        <layout type="log4net.Layout.RawTimeStampLayout" />
    </parameter>
    <parameter>
        <parameterName value="@thread" />
        <dbType value="String" />
        <size value="255" />
        <layout type="log4net.Layout.PatternLayout">
            <conversionPattern value="%thread" />
        </layout>
    </parameter>
    <parameter>
	    <parameterName value="@api_client_id" />
	    <dbType value="String" />
	    <size value="255" />
	    <layout type="log4net.Layout.PatternLayout">
		    <conversionPattern value="%property{ApiClientId}" />
	    </layout>
    </parameter>
    <parameter>
        <parameterName value="@log_level" />
        <dbType value="String" />
        <size value="50" />
        <layout type="log4net.Layout.PatternLayout">
            <conversionPattern value="%level" />
        </layout>
    </parameter>
    <parameter>
	    <parameterName value="@request_url" />
	    <dbType value="String" />
	    <size value="255" />
	    <layout type="log4net.Layout.PatternLayout">
		    <conversionPattern value="%property{RequestUrlWithQueryString}" />
	    </layout>
    </parameter>
    <parameter>
	    <parameterName value="@request_method" />
	    <dbType value="String" />
	    <size value="10" />
	    <layout type="log4net.Layout.PatternLayout">
		    <conversionPattern value="%property{RequestMethod}" />
	    </layout>
    </parameter>
    <parameter>
	    <parameterName value="@profiles_header" />
	    <dbType value="String" />
	    <size value="255" />
	    <layout type="log4net.Layout.PatternLayout">
		    <conversionPattern value="%property{ProfilesHeader}" />
	    </layout>
    </parameter>
    <parameter>
        <parameterName value="@request_body" />
        <dbType value="String" />
        <size value="-1" />
        <layout type="log4net.Layout.PatternLayout">
            <conversionPattern value="%property{RequestBody}" />
        </layout>
    </parameter>
    <parameter>
	    <parameterName value="@response_body" />
	    <dbType value="String" />
	    <size value="-1" />
	    <layout type="log4net.Layout.PatternLayout">
		    <conversionPattern value="%property{ResponseBody}" />
	    </layout>
    </parameter>
    <parameter>
        <parameterName value="@response_message" />
        <dbType value="String" />
        <size value="255" />
        <layout type="log4net.Layout.PatternLayout">
            <conversionPattern value="%message" />
        </layout>
    </parameter>
    <parameter>
        <parameterName value="@exception" />
        <dbType value="String" />
        <size value="2000" />
        <layout type="log4net.Layout.ExceptionLayout" />
    </parameter>
  </appender>
  
```
_For logging into a PostgreSQL database:_
```
  <logger name="RequestResponseContentLogger" additivity="false">
	<level value="ERROR" />
	<appender-ref ref="RequestResponseContentAppender" />
  </logger>
  <appender name="RequestResponseContentAppender" type="log4net.Appender.AdoNetAppender">
    <bufferSize value="0" />
    <threshold value="ERROR" />
     <connectionType value="Npgsql.NpgsqlConnection, Npgsql" />
    <commandText value="INSERT INTO edfi.RequestResponseContentLog (date,thread,apiclientid,level,requesturl,requestmethod,profilesheader,requestbody,responsebody,responsemessage,exception) VALUES (@log_date, @thread, @api_client_id, @log_level, @request_url, @request_method, @profiles_header, @request_body, @response_body, @response_message, @exception)" />
    <parameter>
        <parameterName value="@log_date" />
        <dbType value="DateTime" />
        <layout type="log4net.Layout.RawTimeStampLayout" />
    </parameter>
    <parameter>
        <parameterName value="@thread" />
        <dbType value="String" />
        <size value="255" />
        <layout type="log4net.Layout.PatternLayout">
            <conversionPattern value="%thread" />
        </layout>
    </parameter>
    <parameter>
	    <parameterName value="@api_client_id" />
	    <dbType value="String" />
	    <size value="255" />
	    <layout type="log4net.Layout.PatternLayout">
		    <conversionPattern value="%property{ApiClientId}" />
	    </layout>
    </parameter>
    <parameter>
        <parameterName value="@log_level" />
        <dbType value="String" />
        <size value="50" />
        <layout type="log4net.Layout.PatternLayout">
            <conversionPattern value="%level" />
        </layout>
    </parameter>
    <parameter>
	    <parameterName value="@request_url" />
	    <dbType value="String" />
	    <size value="255" />
	    <layout type="log4net.Layout.PatternLayout">
		    <conversionPattern value="%property{RequestUrlWithQueryString}" />
	    </layout>
    </parameter>
    <parameter>
	    <parameterName value="@request_method" />
	    <dbType value="String" />
	    <size value="10" />
	    <layout type="log4net.Layout.PatternLayout">
		    <conversionPattern value="%property{RequestMethod}" />
	    </layout>
    </parameter>
    <parameter>
	    <parameterName value="@profiles_header" />
	    <dbType value="String" />
	    <size value="255" />
	    <layout type="log4net.Layout.PatternLayout">
		    <conversionPattern value="%property{ProfilesHeader}" />
	    </layout>
    </parameter>
    <parameter>
        <parameterName value="@request_body" />
        <dbType value="String" />
        <size value="-1" />
        <layout type="log4net.Layout.PatternLayout">
            <conversionPattern value="%property{RequestBody}" />
        </layout>
    </parameter>
    <parameter>
	    <parameterName value="@response_body" />
	    <dbType value="String" />
	    <size value="-1" />
	    <layout type="log4net.Layout.PatternLayout">
		    <conversionPattern value="%property{ResponseBody}" />
	    </layout>
    </parameter>
    <parameter>
        <parameterName value="@response_message" />
        <dbType value="String" />
        <size value="255" />
        <layout type="log4net.Layout.PatternLayout">
            <conversionPattern value="%message" />
        </layout>
    </parameter>
    <parameter>
        <parameterName value="@exception" />
        <dbType value="String" />
        <size value="2000" />
        <layout type="log4net.Layout.ExceptionLayout" />
    </parameter>
  </appender>
  
```

- Finally, set LogRequestResponseContentForSeconds in appsettings.json to a reasonable value greater than zero, such as 1200.

```
"DefaultPageSizeLimit": 500,
    "LogRequestResponseContentForSeconds": 1200,
    "Features": [
```

### To test request/response content logging:
- Initialize a development environment with multiple ODS databases and follow the steps above. Be sure to create a logging table in each ODS database.
- To test logging on exception: use the above configuration and manually cause an exception to be thrown in the API pipeline when processing an API request. One way to do this is to add `result.Exception = new BadHttpRequestException("TEST EXCEPTION");` on line 81 in \Ed-Fi-ODS\Application\EdFi.Ods.Api\Infrastructure\Pipelines\PipelineBase.cs.
- To test logging of all requests: change  `<level value="ERROR" />` to `<level value="INFO" />` in the two places it appears in the log4net configuration above
- Check that the expected log entries appear in the RequestResponseContentLog table and that the entries get logged to the correct ODS database
