### PR TITLE
[ODS-5799] CodeFix for Logical Name issue with Log Type Data File

### DIFF
--- a/Application/EdFi.Ods.Sandbox/Provisioners/SqlServerSandboxProvisioner.cs
+++ b/Application/EdFi.Ods.Sandbox/Provisioners/SqlServerSandboxProvisioner.cs
@@ -120,7 +120,7 @@ namespace EdFi.Ods.Sandbox.Provisioners
                         using (var reader = await conn.ExecuteReaderAsync($@"RESTORE FILELISTONLY FROM DISK = '{backup}';", commandTimeout: CommandTimeout)
                             .ConfigureAwait(false))
                         {
-                            while (reader.Read())
+                            while (await reader.ReadAsync().ConfigureAwait(false))
                             {
                                 string logicalName = reader.GetString(0);  
                                 string PhyiscalName = reader.GetString(1);     


### PR DESCRIPTION
![image](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/assets/34613894/d5d6af09-1a68-4a7d-92c1-f2a2c1b5e59c)
Problem is existing code is  taking logical name for first row and using it for 2nd row just appending with _log .  then it comes EdFi_Ods_Minimal_Template_Data_Log which is not available in this case .  Code fix which takes 2nd row value for Log Data File

Steps to Reproduce 
1.  Run InitDev with YearSpecific 
2.  Create .bacpac file from EdFi_Ods_2024 database  with EdFi_Ods_Minimal_Template Name - Use Task Export Data -tier Application option
3.  Create .bacpac file from EdFi_Ods_2024 database  with EdFi_Ods_Populate_Template Name - Use Task Export Data -tier Application option
4. Run InitDev with Sandbox Mode
5.  Use Databases -> Import Data Tier Application to restore both  .bacpac file  
6.  Finally Run your Sandbox Admin from your local to see the error ERROR EdFi.Ods.Sandbox.Admin.Initialization.InitializationEngine - MESSAGE: Microsoft.Data.SqlClient.SqlException (0x80131904): Logical file 'EdFi_Ods_Minimal_Template_Data_log' is not part of database 'EdFi_Ods_Sandbox_RIByqTN2x0PJioz91lp4f'. Use RESTORE FILELISTONLY to list the logical file names.