### PR TITLE
[ODS-5791] Fix Postman integration test harness

### DIFF
--- a/Application/EdFi.Ods.Api/Container/Modules/ApplicationModule.cs
+++ b/Application/EdFi.Ods.Api/Container/Modules/ApplicationModule.cs
@@ -157,7 +157,6 @@ namespace EdFi.Ods.Api.Container.Modules
 
             builder.RegisterType<FeatureDisabledProfileResourceModelProvider>()
                 .As<IProfileResourceModelProvider>()
-                .EnableInterfaceInterceptors()
                 .PreserveExistingDefaults()
                 .SingleInstance();
 


### PR DESCRIPTION
With Profiles disabled, the registration of the "disabled feature" implementation with Autofac incorrectly using interface interceptors, which results in Autofac requiring interceptor registration (which is only registered by the Profiles module, which isn't run when feature is disabled).