### PR TITLE
[ODS-5933] Multitenancy Identities endpoint returns full stack message when feature is disabled

### DIFF
--- a/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
+++ b/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
@@ -184,10 +184,11 @@ namespace EdFi.Ods.Api.Startup
             services.AddApplicationInsightsTelemetry(
                 options => { options.ApplicationVersion = ApiVersionConstants.Version; });
 
-            if (_apiSettings.IsFeatureEnabled(ApiFeature.IdentityManagement.GetConfigKeyName()))
-            {
-                services.AddAuthorization(
-                    options =>
+            
+            services.AddAuthorization(
+                options =>
+                {
+                    if (_apiSettings.IsFeatureEnabled(ApiFeature.IdentityManagement.GetConfigKeyName()))
                     {
                         options.AddPolicy(
                             "IdentityManagement",
@@ -198,19 +199,13 @@ namespace EdFi.Ods.Api.Startup
                                         .HasClaim(c => c.Type == _identityManagementClaimType);
                                 }
                             ));
-                    });
-            }
-            else
-            {
-                services.AddAuthorization(
-                    options =>
+                    }
+                    else
                     {
                         options.AddPolicy(
-                            "IdentityManagement",
-                            policy => policy.RequireAssertion(_ => false)
-                            );
-                    });
-            }
+                            "IdentityManagement", policy => policy.RequireAssertion(_ => false));
+                    }
+                });
 
             if (_apiSettings.UseReverseProxyHeaders.HasValue && _apiSettings.UseReverseProxyHeaders.Value)
             {

--- a/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
+++ b/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
@@ -192,8 +192,23 @@ namespace EdFi.Ods.Api.Startup
                         options.AddPolicy(
                             "IdentityManagement",
                             policy => policy.RequireAssertion(
-                                context => context.User
-                                    .HasClaim(c => c.Type == _identityManagementClaimType)));
+                                context =>
+                                {
+                                    return context.User
+                                        .HasClaim(c => c.Type == _identityManagementClaimType);
+                                }
+                            ));
+                    });
+            }
+            else
+            {
+                services.AddAuthorization(
+                    options =>
+                    {
+                        options.AddPolicy(
+                            "IdentityManagement",
+                            policy => policy.RequireAssertion(_ => false)
+                            );
                     });
             }
 


### PR DESCRIPTION
The immediate cause of the 500 error was the `IdentitiesController` trying to use the "IdentityManagement" authorization policy, which did not exist if the Identity Management feature was disabled. This change resolves the 500 error when the Identity Management feature is turned off by adding an "IdentityManagement" authorization policy that always causes an unauthorized result in that situation. The expected behavior is for requests to the identities endpoints to return a 401 unauthorized response if the Identity Management feature is disabled rather than a 500 error with a stack trace.

