### PR TITLE
[ODS-5743] Unit test is incorrectly passing in OpenApiMetadataDefinitionsFactoryTests 

### DIFF
--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Features/OpenApiMetadata/Factories/OpenApiMetadataDefinitionsFactoryTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Features/OpenApiMetadata/Factories/OpenApiMetadataDefinitionsFactoryTests.cs
@@ -87,7 +87,8 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Features.OpenApiMetadata.Factories
 
                 // link definitions are excluded here and tested in a separate assertion.
                 _actualExtendableEdfiResourceDefinitions = _resources.Where(r => r.IsEdFiStandardResource && !r.Entity.IsDescriptorEntity)
-                    .Select(r => $"{r.SchemaProperCaseName.ToCamelCase()}_{r.Name.ToCamelCase()}").Where(_actualDefinitions.ContainsKey).Select(r => _actualDefinitions[r])
+                    .Select(r => $"{r.SchemaProperCaseName.ToCamelCase()}_{r.Name.ToCamelCase()}")
+                    .Where(_actualDefinitions.ContainsKey).Select(r => _actualDefinitions[r])
                     .ToList();
 
                 _actualPropertyNamesByDefinitionName = _actualDefinitions.Where(d => d.Key != "link").Select(
@@ -417,7 +418,9 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Features.OpenApiMetadata.Factories
                 AssertHelper.All(
                     definitionReferences.Select(
                         r => (Action) (() => Assert.That(
-                            r.EndsWith($"_{ContentTypeUsage.Readable}", StringComparison.OrdinalIgnoreCase) || r.EndsWith($"_{ContentTypeUsage.Writable}", StringComparison.OrdinalIgnoreCase ), Is.True,
+                            r.EndsWith($"_{ContentTypeUsage.Readable}", StringComparison.OrdinalIgnoreCase) 
+                                || r.EndsWith($"_{ContentTypeUsage.Writable}", StringComparison.OrdinalIgnoreCase), 
+                            Is.True,
                             $@"Definition reference {r} does not end with a content type usage"))).ToArray());
             }
 

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Features/OpenApiMetadata/Factories/OpenApiMetadataDefinitionsFactoryTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Features/OpenApiMetadata/Factories/OpenApiMetadataDefinitionsFactoryTests.cs
@@ -87,7 +87,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Features.OpenApiMetadata.Factories
 
                 // link definitions are excluded here and tested in a separate assertion.
                 _actualExtendableEdfiResourceDefinitions = _resources.Where(r => r.IsEdFiStandardResource && !r.Entity.IsDescriptorEntity)
-                    .Select(r => r.Name.ToCamelCase()).Where(_actualDefinitions.ContainsKey).Select(r => _actualDefinitions[r])
+                    .Select(r => $"{r.SchemaProperCaseName.ToCamelCase()}_{r.Name.ToCamelCase()}").Where(_actualDefinitions.ContainsKey).Select(r => _actualDefinitions[r])
                     .ToList();
 
                 _actualPropertyNamesByDefinitionName = _actualDefinitions.Where(d => d.Key != "link").Select(
@@ -409,12 +409,15 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Features.OpenApiMetadata.Factories
             [Assert]
             public void Should_return_filtered_profile_resource_definitions_with_correctly_named_definition_references()
             {
-                var definitionReferences = _actualDefinitions.Values.Where(v => v.items != null).Select(v => v.items.@ref);
-
+                var definitionReferences = _actualDefinitions
+                    .SelectMany(d => d.Value.properties
+                        .Where(p => p.Value.items != null))
+                    .Select(p => p.Value.items.@ref);
+                
                 AssertHelper.All(
                     definitionReferences.Select(
                         r => (Action) (() => Assert.That(
-                            r.EndsWith($"_{ContentTypeUsage.Readable}") || r.EndsWith($"_{ContentTypeUsage.Writable}"), Is.True,
+                            r.EndsWith($"_{ContentTypeUsage.Readable}", StringComparison.OrdinalIgnoreCase) || r.EndsWith($"_{ContentTypeUsage.Writable}", StringComparison.OrdinalIgnoreCase ), Is.True,
                             $@"Definition reference {r} does not end with a content type usage"))).ToArray());
             }
 

--- a/Application/Test.Common/AssertHelper.cs
+++ b/Application/Test.Common/AssertHelper.cs
@@ -19,6 +19,11 @@ namespace Test.Common
         /// <param name="asserts">Asserts to invoke</param>
         public static void All(params Action[] asserts)
         {
+            if (asserts == null || asserts.Length == 0)
+            {
+                Assert.Fail($"No asserts were provided for invocation");
+            }
+            
             var errorMessages = new List<Exception>();
 
             foreach (var assert in asserts)


### PR DESCRIPTION
This updates two unit tests to align with changes elsewhere in the solution and function as initially intended.