### PR TITLE
[ODS-6039] Descriptors in key not compared using case-insensitive comparison in PUT requests

### DIFF
--- a/Postman Test Suite/Ed-Fi ODS-API Integration Test Suite.postman_collection.json
+++ b/Postman Test Suite/Ed-Fi ODS-API Integration Test Suite.postman_collection.json
@@ -9948,6 +9948,151 @@
 					]
 				}
 			]
+		},
+		{
+			"name": "Case-insensitive descriptor comparison in key change check",
+			"item": [
+				{
+					"name": "Setup",
+					"item": [
+						{
+							"name": "Identify staff association",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response is 200\", () => {\r",
+											"  pm.expect(pm.response.code).to.equal(200);\r",
+											"});\r",
+											"\r",
+											"const item = pm.response.json()[0];\r",
+											"\r",
+											"pm.environment.set('known:staffEdOrgAssociation:id', item.id);\r",
+											"pm.environment.set('known:staffEdOrgAssociation:educationOrganizationId', item.educationOrganizationReference.educationOrganizationId);\r",
+											"pm.environment.set('known:staffEdOrgAssociation:staffUniqueId', item.staffReference.staffUniqueId);\r",
+											"pm.environment.set('known:staffEdOrgAssociation:beginDate', item.beginDate);\r",
+											"pm.environment.set('known:staffEdOrgAssociation:positionTitle', item.positionTitle);\r",
+											"pm.environment.set('known:staffEdOrgAssociation:staffClassificationDescriptor', item.staffClassificationDescriptor);\r",
+											"pm.environment.set('known:staffEdOrgAssociation:staffClassificationDescriptor:lower', item.staffClassificationDescriptor.toLowerCase());\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "limit",
+										"value": "1",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/staffEducationOrganizationAssignmentAssociations",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"staffEducationOrganizationAssignmentAssociations"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Perform Update",
+					"item": [
+						{
+							"name": "PUT with case-mismatch on descriptor URI in key",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 204\", () => {\r",
+											"  pm.expect(pm.response.code).to.equal(204);\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"staffClassificationDescriptor\": \"{{known:staffEdOrgAssociation:staffClassificationDescriptor:lower}}\",\r\n  \"educationOrganizationReference\": {\r\n    \"educationOrganizationId\": {{known:staffEdOrgAssociation:educationOrganizationId}}\r\n  },\r\n  \"staffReference\": {\r\n    \"staffUniqueId\": \"{{known:staffEdOrgAssociation:staffUniqueId}}\"\r\n  },\r\n  \"beginDate\": \"{{known:staffEdOrgAssociation:beginDate}}\",\r\n  \"positionTitle\": \"{{known:staffEdOrgAssociation:positionTitle}} ABCD\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/staffEducationOrganizationAssignmentAssociations/{{known:staffEdOrgAssociation:id}}",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"staffEducationOrganizationAssignmentAssociations",
+										"{{known:staffEdOrgAssociation:id}}"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Teardown",
+					"item": [
+						{
+							"name": "Clean up Environment Variables",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"// Remove all environment variables that start with \"known:\" or \"supplied:\"\r",
+											"_.chain(_.keys(pm.environment.toObject()))\r",
+											"  .filter(x => _.startsWith(x, 'known:') || _.startsWith(x, 'supplied:'))\r",
+											"  .each(k => pm.environment.unset(k)).value();"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{ApiBaseUrl}}",
+									"host": [
+										"{{ApiBaseUrl}}"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
 		}
 	],
 	"auth": {

--- a/Postman Test Suite/Ed-Fi ODS-API Integration Test Suite.postman_collection.json
+++ b/Postman Test Suite/Ed-Fi ODS-API Integration Test Suite.postman_collection.json
@@ -8,7 +8,7 @@
 	},
 	"item": [
 		{
-			"name": "Authenicate API Client Key/Secret",
+			"name": "Authenticate API Client Key/Secret",
 			"item": [
 				{
 					"name": "Valid Key/Secret Request",
@@ -2692,281 +2692,850 @@
 			"name": "Limit/Offset/Total Count",
 			"item": [
 				{
-					"name": "Include total count in Get request without search condition",
-					"event": [
+					"name": "Courses",
+					"item": [
 						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
-									"    pm.expect(pm.response.code).to.equal(200);",
-									"});",
-									"",
-									"pm.test(\"Total-Count header is present\", () => {",
-									"    pm.response.to.have.header(\"Total-Count\");",
-									"});",
-									"const __ = require('lodash');",
-									"const responseItems = pm.response.json();",
-									"pm.test(\"Should return the DefaultPageSizeLimit items in response\", () => {",
-									"     pm.expect(responseItems.length).to.be.at.least(1).and.at.most(500);",
-									"});",
-									"pm.environment.set('known:courseCode', __.first(responseItems).courseCode);",
-									"pm.environment.set('known:totalCount', postman.getResponseHeader(\"Total-Count\"));"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/courses?totalCount=true",
-							"host": [
-								"{{ApiBaseUrl}}"
-							],
-							"path": [
-								"data",
-								"v3",
-								"ed-fi",
-								"courses"
-							],
-							"query": [
+							"name": "Include total count in Get request without search condition",
+							"event": [
 								{
-									"key": "totalCount",
-									"value": "true"
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", () => {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});",
+											"",
+											"pm.test(\"Total-Count header is present\", () => {",
+											"    pm.response.to.have.header(\"Total-Count\");",
+											"});",
+											"const __ = require('lodash');",
+											"const responseItems = pm.response.json();",
+											"pm.test(\"Should return the DefaultPageSizeLimit items in response\", () => {",
+											"     pm.expect(responseItems.length).to.be.at.least(1).and.at.most(500);",
+											"});",
+											"pm.environment.set('known:courseCode', __.first(responseItems).courseCode);",
+											"pm.environment.set('known:totalCount', postman.getResponseHeader(\"Total-Count\"));"
+										],
+										"type": "text/javascript"
+									}
 								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Include total count in Get request ,Set limit to 100",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
-									"    pm.expect(pm.response.code).to.equal(200);",
-									"});",
-									"const __ = require('lodash');",
-									"const responseItems = pm.response.json();",
-									"pm.test(\"Should return less than or equal to 100  item in response\", () => {",
-									"     pm.expect(responseItems.length).to.be.at.most(100);",
-									"});",
-									"const courses = __.takeRight(responseItems, 25);",
-									"const courseCodes = __.map(courses, course => course.courseCode);",
-									"console.log(courseCodes);",
-									"pm.environment.set(\"known:courseCodes\",courseCodes);    ",
-									"  "
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/courses?limit=100",
-							"host": [
-								"{{ApiBaseUrl}}"
 							],
-							"path": [
-								"data",
-								"v3",
-								"ed-fi",
-								"courses"
-							],
-							"query": [
-								{
-									"key": "limit",
-									"value": "100"
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/courses?totalCount=true",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"courses"
+									],
+									"query": [
+										{
+											"key": "totalCount",
+											"value": "true"
+										}
+									]
 								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Include total count in Get request and a search parameter like course code is passed",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
-									"    pm.expect(pm.response.code).to.equal(200);",
-									"});",
-									"",
-									"pm.test(\"Total-Count header is present\", () => {",
-									"    pm.response.to.have.header(\"Total-Count\");",
-									"});",
-									"",
-									"pm.test(\"Total-Count header has correct value\", () => {",
-									"    pm.expect(pm.response.headers.get(\"Total-Count\")).to.eql(\"1\");",
-									"});",
-									"",
-									"const __ = require('lodash');",
-									"const responseItems = pm.response.json();",
-									"pm.test(\"Should return 1 item in response\", () => {",
-									"     pm.expect(responseItems).to.have.lengthOf(1);",
-									"    });",
-									"    "
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/courses?totalCount=true&courseCode={{known:courseCode}}",
-							"host": [
-								"{{ApiBaseUrl}}"
-							],
-							"path": [
-								"data",
-								"v3",
-								"ed-fi",
-								"courses"
-							],
-							"query": [
-								{
-									"key": "totalCount",
-									"value": "true"
-								},
-								{
-									"key": "courseCode",
-									"value": "{{known:courseCode}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Include total count in Get request , Set offset equal to totalcount minus one",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
-									"    pm.expect(pm.response.code).to.equal(200);",
-									"});",
-									"const __ = require('lodash');",
-									"const responseItems = pm.response.json();",
-									"pm.test(\"Should return 1 item in response\", () => {",
-									"     pm.expect(responseItems).to.have.lengthOf(1);",
-									"});",
-									"    "
-								],
-								"type": "text/javascript"
-							}
+							},
+							"response": []
 						},
 						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									"const totalCount =pm.environment.get(\"known:totalCount\");",
-									"pm.environment.set(\"known:offset\", Number(totalCount) -1);"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/courses?offset={{known:offset}}",
-							"host": [
-								"{{ApiBaseUrl}}"
-							],
-							"path": [
-								"data",
-								"v3",
-								"ed-fi",
-								"courses"
-							],
-							"query": [
+							"name": "Include total count in Get request ,Set limit to 100",
+							"event": [
 								{
-									"key": "offset",
-									"value": "{{known:offset}}"
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", () => {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});",
+											"const __ = require('lodash');",
+											"const responseItems = pm.response.json();",
+											"pm.test(\"Should return less than or equal to 100  item in response\", () => {",
+											"     pm.expect(responseItems.length).to.be.at.most(100);",
+											"});",
+											"const courses = __.takeRight(responseItems, 25);",
+											"const courseCodes = __.map(courses, course => course.courseCode);",
+											"console.log(courseCodes);",
+											"pm.environment.set(\"known:courseCodes\",courseCodes);    ",
+											"  "
+										],
+										"type": "text/javascript"
+									}
 								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Include total count in Get request , Set offset equal to totalcount minus 25 and limit is 25",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
-									"    pm.expect(pm.response.code).to.equal(200);",
-									"});",
-									"const __ = require('lodash');",
-									"const responseItems = pm.response.json();",
-									"pm.test(\"Should return 25 item in response\", () => {",
-									"     pm.expect(responseItems).to.have.lengthOf(25);",
-									"});",
-									"",
-									"pm.test(\"Should match with each  item course  in response\", () => {",
-									"    const courseCodes= pm.environment.get(\"known:courseCodes\");",
-									"     \t__.each(responseItems, responseItem => {",
-									"        \t      pm.expect(__.includes(courseCodes, responseItem.courseCode)).to.equal(true);",
-									"        });",
-									"});"
-								],
-								"type": "text/javascript"
-							}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/courses?limit=100",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"courses"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "100"
+										}
+									]
+								}
+							},
+							"response": []
 						},
 						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									"const totalCount =pm.environment.get(\"known:totalCount\");",
-									"pm.environment.set(\"known:offset\", Number(totalCount) -25);"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/courses?offset={{known:offset}}&limit=25",
-							"host": [
-								"{{ApiBaseUrl}}"
-							],
-							"path": [
-								"data",
-								"v3",
-								"ed-fi",
-								"courses"
-							],
-							"query": [
+							"name": "Include total count in Get request and a search parameter like course code is passed",
+							"event": [
 								{
-									"key": "offset",
-									"value": "{{known:offset}}"
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", () => {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});",
+											"",
+											"pm.test(\"Total-Count header is present\", () => {",
+											"    pm.response.to.have.header(\"Total-Count\");",
+											"});",
+											"",
+											"pm.test(\"Total-Count header has correct value\", () => {",
+											"    pm.expect(pm.response.headers.get(\"Total-Count\")).to.eql(\"1\");",
+											"});",
+											"",
+											"const __ = require('lodash');",
+											"const responseItems = pm.response.json();",
+											"pm.test(\"Should return 1 item in response\", () => {",
+											"     pm.expect(responseItems).to.have.lengthOf(1);",
+											"    });",
+											"    "
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/courses?totalCount=true&courseCode={{known:courseCode}}",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"courses"
+									],
+									"query": [
+										{
+											"key": "totalCount",
+											"value": "true"
+										},
+										{
+											"key": "courseCode",
+											"value": "{{known:courseCode}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Include total count in Get request , Set offset equal to totalcount minus one",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", () => {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});",
+											"const __ = require('lodash');",
+											"const responseItems = pm.response.json();",
+											"pm.test(\"Should return 1 item in response\", () => {",
+											"     pm.expect(responseItems).to.have.lengthOf(1);",
+											"});",
+											"    "
+										],
+										"type": "text/javascript"
+									}
 								},
 								{
-									"key": "limit",
-									"value": "25"
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const totalCount =pm.environment.get(\"known:totalCount\");",
+											"pm.environment.set(\"known:offset\", Number(totalCount) -1);"
+										],
+										"type": "text/javascript"
+									}
 								}
-							]
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/courses?offset={{known:offset}}",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"courses"
+									],
+									"query": [
+										{
+											"key": "offset",
+											"value": "{{known:offset}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Include total count in Get request , Set offset equal to totalcount minus 25 and limit is 25",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", () => {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});",
+											"const __ = require('lodash');",
+											"const responseItems = pm.response.json();",
+											"pm.test(\"Should return 25 item in response\", () => {",
+											"     pm.expect(responseItems).to.have.lengthOf(25);",
+											"});",
+											"",
+											"pm.test(\"Should match with each  item course  in response\", () => {",
+											"    const courseCodes= pm.environment.get(\"known:courseCodes\");",
+											"     \t__.each(responseItems, responseItem => {",
+											"        \t      pm.expect(__.includes(courseCodes, responseItem.courseCode)).to.equal(true);",
+											"        });",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const totalCount =pm.environment.get(\"known:totalCount\");",
+											"pm.environment.set(\"known:offset\", Number(totalCount) -25);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/courses?offset={{known:offset}}&limit=25",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"courses"
+									],
+									"query": [
+										{
+											"key": "offset",
+											"value": "{{known:offset}}"
+										},
+										{
+											"key": "limit",
+											"value": "25"
+										}
+									]
+								}
+							},
+							"response": []
 						}
-					},
-					"response": []
+					]
+				},
+				{
+					"name": "Student",
+					"item": [
+						{
+							"name": "Include total count in Get request without search condition",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", () => {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});",
+											"",
+											"pm.test(\"Total-Count header is present\", () => {",
+											"    pm.response.to.have.header(\"Total-Count\");",
+											"});",
+											"const __ = require('lodash');",
+											"const responseItems = pm.response.json();",
+											"pm.test(\"Should return the DefaultPageSizeLimit items in response\", () => {",
+											"     pm.expect(responseItems.length).to.equal(500);",
+											"});",
+											"pm.environment.set('known:studentUniqueId', __.first(responseItems).studentUniqueId);",
+											"pm.environment.set('known:studentTotalCount', postman.getResponseHeader(\"Total-Count\"));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/students?totalCount=true",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"students"
+									],
+									"query": [
+										{
+											"key": "totalCount",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Include total count in Get request ,Set limit to 100",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", () => {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});",
+											"const __ = require('lodash');",
+											"const responseItems = pm.response.json();",
+											"pm.test(\"Should return less than or equal to 100  item in response\", () => {",
+											"     pm.expect(responseItems.length).to.be.at.most(100);",
+											"});",
+											"const students = __.takeRight(responseItems, 25);",
+											"const studentUniqueIds = __.map(students, student => student.studentUniqueId);",
+											"console.log(studentUniqueIds);",
+											"pm.environment.set(\"known:studentUniqueIds\",studentUniqueIds);    ",
+											"  "
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/students?limit=100",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"students"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "100"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Include total count in Get request and a search parameter like Student Unique Id is passed",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", () => {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});",
+											"",
+											"pm.test(\"Total-Count header is present\", () => {",
+											"    pm.response.to.have.header(\"Total-Count\");",
+											"});",
+											"",
+											"pm.test(\"Total-Count header has correct value\", () => {",
+											"    pm.expect(pm.response.headers.get(\"Total-Count\")).to.eql(\"1\");",
+											"});",
+											"",
+											"const __ = require('lodash');",
+											"const responseItems = pm.response.json();",
+											"pm.test(\"Should return 1 item in response\", () => {",
+											"     pm.expect(responseItems).to.have.lengthOf(1);",
+											"    });",
+											"    "
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/students?totalCount=true&studentUniqueId={{known:studentUniqueId}}",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"students"
+									],
+									"query": [
+										{
+											"key": "totalCount",
+											"value": "true"
+										},
+										{
+											"key": "studentUniqueId",
+											"value": "{{known:studentUniqueId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Include total count in Get request , Set offset equal to totalcount minus one",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", () => {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});",
+											"const __ = require('lodash');",
+											"const responseItems = pm.response.json();",
+											"pm.test(\"Should return 1 item in response\", () => {",
+											"     pm.expect(responseItems).to.have.lengthOf(1);",
+											"});",
+											"    "
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const totalCount =pm.environment.get(\"known:studentTotalCount\");",
+											"pm.environment.set(\"known:studentOffset\", Number(totalCount) -1);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/students?offset={{known:studentOffset}}",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"students"
+									],
+									"query": [
+										{
+											"key": "offset",
+											"value": "{{known:studentOffset}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Include total count in Get request , Set offset equal to totalcount minus 25 and limit is 25",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", () => {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});",
+											"const __ = require('lodash');",
+											"const responseItems = pm.response.json();",
+											"pm.test(\"Should return 25 item in response\", () => {",
+											"     pm.expect(responseItems).to.have.lengthOf(25);",
+											"});",
+											"",
+											"pm.test(\"Should match with each  item course  in response\", () => {",
+											"    const studentUniqueIds= pm.environment.get(\"known:studentUniqueIds\");",
+											"     \t__.each(responseItems, responseItem => {",
+											"        \t      pm.expect(__.includes(studentUniqueIds, responseItem.studentUniqueId)).to.equal(true);",
+											"        });",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const totalCount =pm.environment.get(\"known:studentTotalCount\");",
+											"pm.environment.set(\"known:studentOffset\", 100 - 25);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/students?offset={{known:studentOffset}}&limit=25",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"students"
+									],
+									"query": [
+										{
+											"key": "offset",
+											"value": "{{known:studentOffset}}"
+										},
+										{
+											"key": "limit",
+											"value": "25"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Staff",
+					"item": [
+						{
+							"name": "Include total count in Get request without search condition",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", () => {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});",
+											"",
+											"pm.test(\"Total-Count header is present\", () => {",
+											"    pm.response.to.have.header(\"Total-Count\");",
+											"});",
+											"const __ = require('lodash');",
+											"const responseItems = pm.response.json();",
+											"pm.test(\"Should return the DefaultPageSizeLimit items in response\", () => {",
+											"     pm.expect(responseItems.length).to.be.at.least(1).and.at.most(500);",
+											"});",
+											"pm.environment.set('known:staffUniqueId', __.first(responseItems).staffUniqueId);",
+											"pm.environment.set('known:staffTotalCount', postman.getResponseHeader(\"Total-Count\"));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/staffs?totalCount=true",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"staffs"
+									],
+									"query": [
+										{
+											"key": "totalCount",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Include total count in Get request ,Set limit to 100",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", () => {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});",
+											"const __ = require('lodash');",
+											"const responseItems = pm.response.json();",
+											"pm.test(\"Should return less than or equal to 100  item in response\", () => {",
+											"     pm.expect(responseItems.length).to.be.at.most(100);",
+											"});",
+											"const staffs = __.takeRight(responseItems, 25);",
+											"const staffUniqueIds = __.map(staffs, staff => staff.staffUniqueId);",
+											"console.log(staffUniqueIds);",
+											"pm.environment.set(\"known:staffUniqueIds\",staffUniqueIds);    ",
+											"  "
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/staffs?limit=100",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"staffs"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "100"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Include total count in Get request and a search parameter like Staff Unique Id is passed",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", () => {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});",
+											"",
+											"pm.test(\"Total-Count header is present\", () => {",
+											"    pm.response.to.have.header(\"Total-Count\");",
+											"});",
+											"",
+											"pm.test(\"Total-Count header has correct value\", () => {",
+											"    pm.expect(pm.response.headers.get(\"Total-Count\")).to.eql(\"1\");",
+											"});",
+											"",
+											"const __ = require('lodash');",
+											"const responseItems = pm.response.json();",
+											"pm.test(\"Should return 1 item in response\", () => {",
+											"     pm.expect(responseItems).to.have.lengthOf(1);",
+											"    });",
+											"    "
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/staffs?totalCount=true&staffUniqueId={{known:staffUniqueId}}",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"staffs"
+									],
+									"query": [
+										{
+											"key": "totalCount",
+											"value": "true"
+										},
+										{
+											"key": "staffUniqueId",
+											"value": "{{known:staffUniqueId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Include total count in Get request , Set offset equal to totalcount minus one",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", () => {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});",
+											"const __ = require('lodash');",
+											"const responseItems = pm.response.json();",
+											"pm.test(\"Should return 1 item in response\", () => {",
+											"     pm.expect(responseItems).to.have.lengthOf(1);",
+											"});",
+											"    "
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const totalCount =pm.environment.get(\"known:staffTotalCount\");",
+											"pm.environment.set(\"known:staffOffset\", Number(totalCount) -1);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/staffs?offset={{known:staffOffset}}",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"staffs"
+									],
+									"query": [
+										{
+											"key": "offset",
+											"value": "{{known:staffOffset}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Include total count in Get request , Set offset equal to totalcount minus 25 and limit is 25",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", () => {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});",
+											"const __ = require('lodash');",
+											"const responseItems = pm.response.json();",
+											"pm.test(\"Should return 25 item in response\", () => {",
+											"     pm.expect(responseItems).to.have.lengthOf(25);",
+											"});",
+											"",
+											"pm.test(\"Should match with each  item course  in response\", () => {",
+											"    const staffUniqueIds= pm.environment.get(\"known:staffUniqueIds\");",
+											"     \t__.each(responseItems, responseItem => {",
+											"        \t      pm.expect(__.includes(staffUniqueIds, responseItem.staffUniqueId)).to.equal(true);",
+											"        });",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const totalCount =pm.environment.get(\"known:staffTotalCount\");",
+											"pm.environment.set(\"known:staffOffset\", Number(totalCount) -25);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/staffs?offset={{known:staffOffset}}&limit=25",
+									"host": [
+										"{{ApiBaseUrl}}"
+									],
+									"path": [
+										"data",
+										"v3",
+										"ed-fi",
+										"staffs"
+									],
+									"query": [
+										{
+											"key": "offset",
+											"value": "{{known:staffOffset}}"
+										},
+										{
+											"key": "limit",
+											"value": "25"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
 				}
 			]
 		},
@@ -5245,570 +5814,6 @@
 							}
 						}
 					]
-				}
-			]
-		},
-		{
-			"name": "Limit/Offset/Total Count - Student",
-			"item": [
-				{
-					"name": "Include total count in Get request without search condition",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
-									"    pm.expect(pm.response.code).to.equal(200);",
-									"});",
-									"",
-									"pm.test(\"Total-Count header is present\", () => {",
-									"    pm.response.to.have.header(\"Total-Count\");",
-									"});",
-									"const __ = require('lodash');",
-									"const responseItems = pm.response.json();",
-									"pm.test(\"Should return the DefaultPageSizeLimit items in response\", () => {",
-									"     pm.expect(responseItems.length).to.equal(500);",
-									"});",
-									"pm.environment.set('known:studentUniqueId', __.first(responseItems).studentUniqueId);",
-									"pm.environment.set('known:studentTotalCount', postman.getResponseHeader(\"Total-Count\"));"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/students?totalCount=true",
-							"host": [
-								"{{ApiBaseUrl}}"
-							],
-							"path": [
-								"data",
-								"v3",
-								"ed-fi",
-								"students"
-							],
-							"query": [
-								{
-									"key": "totalCount",
-									"value": "true"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Include total count in Get request ,Set limit to 100",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
-									"    pm.expect(pm.response.code).to.equal(200);",
-									"});",
-									"const __ = require('lodash');",
-									"const responseItems = pm.response.json();",
-									"pm.test(\"Should return less than or equal to 100  item in response\", () => {",
-									"     pm.expect(responseItems.length).to.be.at.most(100);",
-									"});",
-									"const students = __.takeRight(responseItems, 25);",
-									"const studentUniqueIds = __.map(students, student => student.studentUniqueId);",
-									"console.log(studentUniqueIds);",
-									"pm.environment.set(\"known:studentUniqueIds\",studentUniqueIds);    ",
-									"  "
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/students?limit=100",
-							"host": [
-								"{{ApiBaseUrl}}"
-							],
-							"path": [
-								"data",
-								"v3",
-								"ed-fi",
-								"students"
-							],
-							"query": [
-								{
-									"key": "limit",
-									"value": "100"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Include total count in Get request and a search parameter like Student Unique Id is passed",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
-									"    pm.expect(pm.response.code).to.equal(200);",
-									"});",
-									"",
-									"pm.test(\"Total-Count header is present\", () => {",
-									"    pm.response.to.have.header(\"Total-Count\");",
-									"});",
-									"",
-									"pm.test(\"Total-Count header has correct value\", () => {",
-									"    pm.expect(pm.response.headers.get(\"Total-Count\")).to.eql(\"1\");",
-									"});",
-									"",
-									"const __ = require('lodash');",
-									"const responseItems = pm.response.json();",
-									"pm.test(\"Should return 1 item in response\", () => {",
-									"     pm.expect(responseItems).to.have.lengthOf(1);",
-									"    });",
-									"    "
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/students?totalCount=true&studentUniqueId={{known:studentUniqueId}}",
-							"host": [
-								"{{ApiBaseUrl}}"
-							],
-							"path": [
-								"data",
-								"v3",
-								"ed-fi",
-								"students"
-							],
-							"query": [
-								{
-									"key": "totalCount",
-									"value": "true"
-								},
-								{
-									"key": "studentUniqueId",
-									"value": "{{known:studentUniqueId}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Include total count in Get request , Set offset equal to totalcount minus one",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
-									"    pm.expect(pm.response.code).to.equal(200);",
-									"});",
-									"const __ = require('lodash');",
-									"const responseItems = pm.response.json();",
-									"pm.test(\"Should return 1 item in response\", () => {",
-									"     pm.expect(responseItems).to.have.lengthOf(1);",
-									"});",
-									"    "
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									"const totalCount =pm.environment.get(\"known:studentTotalCount\");",
-									"pm.environment.set(\"known:studentOffset\", Number(totalCount) -1);"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/students?offset={{known:studentOffset}}",
-							"host": [
-								"{{ApiBaseUrl}}"
-							],
-							"path": [
-								"data",
-								"v3",
-								"ed-fi",
-								"students"
-							],
-							"query": [
-								{
-									"key": "offset",
-									"value": "{{known:studentOffset}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Include total count in Get request , Set offset equal to totalcount minus 25 and limit is 25",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
-									"    pm.expect(pm.response.code).to.equal(200);",
-									"});",
-									"const __ = require('lodash');",
-									"const responseItems = pm.response.json();",
-									"pm.test(\"Should return 25 item in response\", () => {",
-									"     pm.expect(responseItems).to.have.lengthOf(25);",
-									"});",
-									"",
-									"pm.test(\"Should match with each  item course  in response\", () => {",
-									"    const studentUniqueIds= pm.environment.get(\"known:studentUniqueIds\");",
-									"     \t__.each(responseItems, responseItem => {",
-									"        \t      pm.expect(__.includes(studentUniqueIds, responseItem.studentUniqueId)).to.equal(true);",
-									"        });",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									"const totalCount =pm.environment.get(\"known:studentTotalCount\");",
-									"pm.environment.set(\"known:studentOffset\", 100 - 25);"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/students?offset={{known:studentOffset}}&limit=25",
-							"host": [
-								"{{ApiBaseUrl}}"
-							],
-							"path": [
-								"data",
-								"v3",
-								"ed-fi",
-								"students"
-							],
-							"query": [
-								{
-									"key": "offset",
-									"value": "{{known:studentOffset}}"
-								},
-								{
-									"key": "limit",
-									"value": "25"
-								}
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Limit/Offset/Total Count - Staff",
-			"item": [
-				{
-					"name": "Include total count in Get request without search condition",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
-									"    pm.expect(pm.response.code).to.equal(200);",
-									"});",
-									"",
-									"pm.test(\"Total-Count header is present\", () => {",
-									"    pm.response.to.have.header(\"Total-Count\");",
-									"});",
-									"const __ = require('lodash');",
-									"const responseItems = pm.response.json();",
-									"pm.test(\"Should return the DefaultPageSizeLimit items in response\", () => {",
-									"     pm.expect(responseItems.length).to.be.at.least(1).and.at.most(500);",
-									"});",
-									"pm.environment.set('known:staffUniqueId', __.first(responseItems).staffUniqueId);",
-									"pm.environment.set('known:staffTotalCount', postman.getResponseHeader(\"Total-Count\"));"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/staffs?totalCount=true",
-							"host": [
-								"{{ApiBaseUrl}}"
-							],
-							"path": [
-								"data",
-								"v3",
-								"ed-fi",
-								"staffs"
-							],
-							"query": [
-								{
-									"key": "totalCount",
-									"value": "true"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Include total count in Get request ,Set limit to 100",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
-									"    pm.expect(pm.response.code).to.equal(200);",
-									"});",
-									"const __ = require('lodash');",
-									"const responseItems = pm.response.json();",
-									"pm.test(\"Should return less than or equal to 100  item in response\", () => {",
-									"     pm.expect(responseItems.length).to.be.at.most(100);",
-									"});",
-									"const staffs = __.takeRight(responseItems, 25);",
-									"const staffUniqueIds = __.map(staffs, staff => staff.staffUniqueId);",
-									"console.log(staffUniqueIds);",
-									"pm.environment.set(\"known:staffUniqueIds\",staffUniqueIds);    ",
-									"  "
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/staffs?limit=100",
-							"host": [
-								"{{ApiBaseUrl}}"
-							],
-							"path": [
-								"data",
-								"v3",
-								"ed-fi",
-								"staffs"
-							],
-							"query": [
-								{
-									"key": "limit",
-									"value": "100"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Include total count in Get request and a search parameter like Staff Unique Id is passed",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
-									"    pm.expect(pm.response.code).to.equal(200);",
-									"});",
-									"",
-									"pm.test(\"Total-Count header is present\", () => {",
-									"    pm.response.to.have.header(\"Total-Count\");",
-									"});",
-									"",
-									"pm.test(\"Total-Count header has correct value\", () => {",
-									"    pm.expect(pm.response.headers.get(\"Total-Count\")).to.eql(\"1\");",
-									"});",
-									"",
-									"const __ = require('lodash');",
-									"const responseItems = pm.response.json();",
-									"pm.test(\"Should return 1 item in response\", () => {",
-									"     pm.expect(responseItems).to.have.lengthOf(1);",
-									"    });",
-									"    "
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/staffs?totalCount=true&staffUniqueId={{known:staffUniqueId}}",
-							"host": [
-								"{{ApiBaseUrl}}"
-							],
-							"path": [
-								"data",
-								"v3",
-								"ed-fi",
-								"staffs"
-							],
-							"query": [
-								{
-									"key": "totalCount",
-									"value": "true"
-								},
-								{
-									"key": "staffUniqueId",
-									"value": "{{known:staffUniqueId}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Include total count in Get request , Set offset equal to totalcount minus one",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
-									"    pm.expect(pm.response.code).to.equal(200);",
-									"});",
-									"const __ = require('lodash');",
-									"const responseItems = pm.response.json();",
-									"pm.test(\"Should return 1 item in response\", () => {",
-									"     pm.expect(responseItems).to.have.lengthOf(1);",
-									"});",
-									"    "
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									"const totalCount =pm.environment.get(\"known:staffTotalCount\");",
-									"pm.environment.set(\"known:staffOffset\", Number(totalCount) -1);"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/staffs?offset={{known:staffOffset}}",
-							"host": [
-								"{{ApiBaseUrl}}"
-							],
-							"path": [
-								"data",
-								"v3",
-								"ed-fi",
-								"staffs"
-							],
-							"query": [
-								{
-									"key": "offset",
-									"value": "{{known:staffOffset}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Include total count in Get request , Set offset equal to totalcount minus 25 and limit is 25",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
-									"    pm.expect(pm.response.code).to.equal(200);",
-									"});",
-									"const __ = require('lodash');",
-									"const responseItems = pm.response.json();",
-									"pm.test(\"Should return 25 item in response\", () => {",
-									"     pm.expect(responseItems).to.have.lengthOf(25);",
-									"});",
-									"",
-									"pm.test(\"Should match with each  item course  in response\", () => {",
-									"    const staffUniqueIds= pm.environment.get(\"known:staffUniqueIds\");",
-									"     \t__.each(responseItems, responseItem => {",
-									"        \t      pm.expect(__.includes(staffUniqueIds, responseItem.staffUniqueId)).to.equal(true);",
-									"        });",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									"const totalCount =pm.environment.get(\"known:staffTotalCount\");",
-									"pm.environment.set(\"known:staffOffset\", Number(totalCount) -25);"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{ApiBaseUrl}}/data/v3/ed-fi/staffs?offset={{known:staffOffset}}&limit=25",
-							"host": [
-								"{{ApiBaseUrl}}"
-							],
-							"path": [
-								"data",
-								"v3",
-								"ed-fi",
-								"staffs"
-							],
-							"query": [
-								{
-									"key": "offset",
-									"value": "{{known:staffOffset}}"
-								},
-								{
-									"key": "limit",
-									"value": "25"
-								}
-							]
-						}
-					},
-					"response": []
 				}
 			]
 		},

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/4.0.0/DataStandard_400_ApprovalTests.Verify.Extensions.Sample.1.0.0_Std_4.0.0_Models_Mappers_EntityMapper.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/4.0.0/DataStandard_400_ApprovalTests.Verify.Extensions.Sample.1.0.0_Std_4.0.0_Models_Mappers_EntityMapper.generated.approved.cs
@@ -3708,7 +3708,7 @@ namespace EdFi.Ods.Entities.Common.Sample //.StudentArtProgramAssociationAggrega
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentArtProgramAssociation
@@ -5000,7 +5000,7 @@ namespace EdFi.Ods.Entities.Common.Sample //.StudentGraduationPlanAssociationAgg
             // Detect primary key changes
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
-                || (target.GraduationPlanTypeDescriptor != source.GraduationPlanTypeDescriptor)
+                || !string.Equals(target.GraduationPlanTypeDescriptor, source.GraduationPlanTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.GraduationSchoolYear != source.GraduationSchoolYear)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/4.0.0/DataStandard_400_ApprovalTests.Verify.Extensions.TPDM.1.1.0_Std_4.0.0_Models_Mappers_EntityMapper.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/4.0.0/DataStandard_400_ApprovalTests.Verify.Extensions.TPDM.1.1.0_Std_4.0.0_Models_Mappers_EntityMapper.generated.approved.cs
@@ -1891,7 +1891,7 @@ namespace EdFi.Ods.Entities.Common.TPDM //.CandidateEducatorPreparationProgramAs
                 || (!keyStringComparer.Equals(target.CandidateIdentifier, source.CandidateIdentifier))
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor))
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on CandidateEducatorPreparationProgramAssociation
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -2959,7 +2959,7 @@ namespace EdFi.Ods.Entities.Common.TPDM //.EducatorPreparationProgramAggregate
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor))
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on EducatorPreparationProgram
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -3639,12 +3639,12 @@ namespace EdFi.Ods.Entities.Common.TPDM //.EvaluationAggregate
             // Detect primary key changes
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
-                || (target.EvaluationPeriodDescriptor != source.EvaluationPeriodDescriptor)
+                || !string.Equals(target.EvaluationPeriodDescriptor, source.EvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.EvaluationTitle, source.EvaluationTitle))
                 || (!keyStringComparer.Equals(target.PerformanceEvaluationTitle, source.PerformanceEvaluationTitle))
-                || (target.PerformanceEvaluationTypeDescriptor != source.PerformanceEvaluationTypeDescriptor)
+                || !string.Equals(target.PerformanceEvaluationTypeDescriptor, source.PerformanceEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.SchoolYear != source.SchoolYear)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on Evaluation
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -3897,12 +3897,12 @@ namespace EdFi.Ods.Entities.Common.TPDM //.EvaluationElementAggregate
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.EvaluationElementTitle, source.EvaluationElementTitle))
                 || (!keyStringComparer.Equals(target.EvaluationObjectiveTitle, source.EvaluationObjectiveTitle))
-                || (target.EvaluationPeriodDescriptor != source.EvaluationPeriodDescriptor)
+                || !string.Equals(target.EvaluationPeriodDescriptor, source.EvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.EvaluationTitle, source.EvaluationTitle))
                 || (!keyStringComparer.Equals(target.PerformanceEvaluationTitle, source.PerformanceEvaluationTitle))
-                || (target.PerformanceEvaluationTypeDescriptor != source.PerformanceEvaluationTypeDescriptor)
+                || !string.Equals(target.PerformanceEvaluationTypeDescriptor, source.PerformanceEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.SchoolYear != source.SchoolYear)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on EvaluationElement
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -4148,14 +4148,14 @@ namespace EdFi.Ods.Entities.Common.TPDM //.EvaluationElementRatingAggregate
                 || (target.EvaluationDate != source.EvaluationDate)
                 || (!keyStringComparer.Equals(target.EvaluationElementTitle, source.EvaluationElementTitle))
                 || (!keyStringComparer.Equals(target.EvaluationObjectiveTitle, source.EvaluationObjectiveTitle))
-                || (target.EvaluationPeriodDescriptor != source.EvaluationPeriodDescriptor)
+                || !string.Equals(target.EvaluationPeriodDescriptor, source.EvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.EvaluationTitle, source.EvaluationTitle))
                 || (!keyStringComparer.Equals(target.PerformanceEvaluationTitle, source.PerformanceEvaluationTitle))
-                || (target.PerformanceEvaluationTypeDescriptor != source.PerformanceEvaluationTypeDescriptor)
+                || !string.Equals(target.PerformanceEvaluationTypeDescriptor, source.PerformanceEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.PersonId, source.PersonId))
                 || (target.SchoolYear != source.SchoolYear)
-                || (target.SourceSystemDescriptor != source.SourceSystemDescriptor)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.SourceSystemDescriptor, source.SourceSystemDescriptor, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on EvaluationElementRating
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -4566,12 +4566,12 @@ namespace EdFi.Ods.Entities.Common.TPDM //.EvaluationObjectiveAggregate
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.EvaluationObjectiveTitle, source.EvaluationObjectiveTitle))
-                || (target.EvaluationPeriodDescriptor != source.EvaluationPeriodDescriptor)
+                || !string.Equals(target.EvaluationPeriodDescriptor, source.EvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.EvaluationTitle, source.EvaluationTitle))
                 || (!keyStringComparer.Equals(target.PerformanceEvaluationTitle, source.PerformanceEvaluationTitle))
-                || (target.PerformanceEvaluationTypeDescriptor != source.PerformanceEvaluationTypeDescriptor)
+                || !string.Equals(target.PerformanceEvaluationTypeDescriptor, source.PerformanceEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.SchoolYear != source.SchoolYear)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on EvaluationObjective
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -4825,14 +4825,14 @@ namespace EdFi.Ods.Entities.Common.TPDM //.EvaluationObjectiveRatingAggregate
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.EvaluationDate != source.EvaluationDate)
                 || (!keyStringComparer.Equals(target.EvaluationObjectiveTitle, source.EvaluationObjectiveTitle))
-                || (target.EvaluationPeriodDescriptor != source.EvaluationPeriodDescriptor)
+                || !string.Equals(target.EvaluationPeriodDescriptor, source.EvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.EvaluationTitle, source.EvaluationTitle))
                 || (!keyStringComparer.Equals(target.PerformanceEvaluationTitle, source.PerformanceEvaluationTitle))
-                || (target.PerformanceEvaluationTypeDescriptor != source.PerformanceEvaluationTypeDescriptor)
+                || !string.Equals(target.PerformanceEvaluationTypeDescriptor, source.PerformanceEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.PersonId, source.PersonId))
                 || (target.SchoolYear != source.SchoolYear)
-                || (target.SourceSystemDescriptor != source.SourceSystemDescriptor)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.SourceSystemDescriptor, source.SourceSystemDescriptor, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on EvaluationObjectiveRating
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -5212,14 +5212,14 @@ namespace EdFi.Ods.Entities.Common.TPDM //.EvaluationRatingAggregate
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.EvaluationDate != source.EvaluationDate)
-                || (target.EvaluationPeriodDescriptor != source.EvaluationPeriodDescriptor)
+                || !string.Equals(target.EvaluationPeriodDescriptor, source.EvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.EvaluationTitle, source.EvaluationTitle))
                 || (!keyStringComparer.Equals(target.PerformanceEvaluationTitle, source.PerformanceEvaluationTitle))
-                || (target.PerformanceEvaluationTypeDescriptor != source.PerformanceEvaluationTypeDescriptor)
+                || !string.Equals(target.PerformanceEvaluationTypeDescriptor, source.PerformanceEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.PersonId, source.PersonId))
                 || (target.SchoolYear != source.SchoolYear)
-                || (target.SourceSystemDescriptor != source.SourceSystemDescriptor)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.SourceSystemDescriptor, source.SourceSystemDescriptor, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on EvaluationRating
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -6206,7 +6206,7 @@ namespace EdFi.Ods.Entities.Common.TPDM //.FinancialAidAggregate
 
             // Detect primary key changes
             if (
-                 (target.AidTypeDescriptor != source.AidTypeDescriptor)
+                 !string.Equals(target.AidTypeDescriptor, source.AidTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.BeginDate != source.BeginDate)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
@@ -6664,11 +6664,11 @@ namespace EdFi.Ods.Entities.Common.TPDM //.PerformanceEvaluationAggregate
             // Detect primary key changes
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
-                || (target.EvaluationPeriodDescriptor != source.EvaluationPeriodDescriptor)
+                || !string.Equals(target.EvaluationPeriodDescriptor, source.EvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.PerformanceEvaluationTitle, source.PerformanceEvaluationTitle))
-                || (target.PerformanceEvaluationTypeDescriptor != source.PerformanceEvaluationTypeDescriptor)
+                || !string.Equals(target.PerformanceEvaluationTypeDescriptor, source.PerformanceEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.SchoolYear != source.SchoolYear)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on PerformanceEvaluation
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -6972,13 +6972,13 @@ namespace EdFi.Ods.Entities.Common.TPDM //.PerformanceEvaluationRatingAggregate
             // Detect primary key changes
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
-                || (target.EvaluationPeriodDescriptor != source.EvaluationPeriodDescriptor)
+                || !string.Equals(target.EvaluationPeriodDescriptor, source.EvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.PerformanceEvaluationTitle, source.PerformanceEvaluationTitle))
-                || (target.PerformanceEvaluationTypeDescriptor != source.PerformanceEvaluationTypeDescriptor)
+                || !string.Equals(target.PerformanceEvaluationTypeDescriptor, source.PerformanceEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.PersonId, source.PersonId))
                 || (target.SchoolYear != source.SchoolYear)
-                || (target.SourceSystemDescriptor != source.SourceSystemDescriptor)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.SourceSystemDescriptor, source.SourceSystemDescriptor, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on PerformanceEvaluationRating
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -7825,13 +7825,13 @@ namespace EdFi.Ods.Entities.Common.TPDM //.RubricDimensionAggregate
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.EvaluationElementTitle, source.EvaluationElementTitle))
                 || (!keyStringComparer.Equals(target.EvaluationObjectiveTitle, source.EvaluationObjectiveTitle))
-                || (target.EvaluationPeriodDescriptor != source.EvaluationPeriodDescriptor)
+                || !string.Equals(target.EvaluationPeriodDescriptor, source.EvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.EvaluationTitle, source.EvaluationTitle))
                 || (!keyStringComparer.Equals(target.PerformanceEvaluationTitle, source.PerformanceEvaluationTitle))
-                || (target.PerformanceEvaluationTypeDescriptor != source.PerformanceEvaluationTypeDescriptor)
+                || !string.Equals(target.PerformanceEvaluationTypeDescriptor, source.PerformanceEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.RubricRating != source.RubricRating)
                 || (target.SchoolYear != source.SchoolYear)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on RubricDimension
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -8307,7 +8307,7 @@ namespace EdFi.Ods.Entities.Common.TPDM //.SurveyResponsePersonTargetAssociation
             if (
                  (!keyStringComparer.Equals(target.Namespace, source.Namespace))
                 || (!keyStringComparer.Equals(target.PersonId, source.PersonId))
-                || (target.SourceSystemDescriptor != source.SourceSystemDescriptor)
+                || !string.Equals(target.SourceSystemDescriptor, source.SourceSystemDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.SurveyIdentifier, source.SurveyIdentifier))
                 || (!keyStringComparer.Equals(target.SurveyResponseIdentifier, source.SurveyResponseIdentifier)))
             {
@@ -8408,7 +8408,7 @@ namespace EdFi.Ods.Entities.Common.TPDM //.SurveySectionResponsePersonTargetAsso
             if (
                  (!keyStringComparer.Equals(target.Namespace, source.Namespace))
                 || (!keyStringComparer.Equals(target.PersonId, source.PersonId))
-                || (target.SourceSystemDescriptor != source.SourceSystemDescriptor)
+                || !string.Equals(target.SourceSystemDescriptor, source.SourceSystemDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.SurveyIdentifier, source.SurveyIdentifier))
                 || (!keyStringComparer.Equals(target.SurveyResponseIdentifier, source.SurveyResponseIdentifier))
                 || (!keyStringComparer.Equals(target.SurveySectionTitle, source.SurveySectionTitle)))

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/4.0.0/DataStandard_400_ApprovalTests.Verify.Standard_Std_4.0.0_Models_Mappers_EntityMapper.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/4.0.0/DataStandard_400_ApprovalTests.Verify.Standard_Std_4.0.0_Models_Mappers_EntityMapper.generated.approved.cs
@@ -10129,7 +10129,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.CompetencyObjectiveAggregate
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.Objective, source.Objective))
-                || (target.ObjectiveGradeLevelDescriptor != source.ObjectiveGradeLevelDescriptor))
+                || !string.Equals(target.ObjectiveGradeLevelDescriptor, source.ObjectiveGradeLevelDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on CompetencyObjective
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -13266,13 +13266,13 @@ namespace EdFi.Ods.Entities.Common.EdFi //.CourseTranscriptAggregate
 
             // Detect primary key changes
             if (
-                 (target.CourseAttemptResultDescriptor != source.CourseAttemptResultDescriptor)
+                 !string.Equals(target.CourseAttemptResultDescriptor, source.CourseAttemptResultDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.CourseCode, source.CourseCode))
                 || (target.CourseEducationOrganizationId != source.CourseEducationOrganizationId)
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.SchoolYear != source.SchoolYear)
                 || (target.StudentUniqueId != source.StudentUniqueId)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on CourseTranscript
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -14073,7 +14073,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.CredentialAggregate
             // Detect primary key changes
             if (
                  (!keyStringComparer.Equals(target.CredentialIdentifier, source.CredentialIdentifier))
-                || (target.StateOfIssueStateAbbreviationDescriptor != source.StateOfIssueStateAbbreviationDescriptor))
+                || !string.Equals(target.StateOfIssueStateAbbreviationDescriptor, source.StateOfIssueStateAbbreviationDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on Credential
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -23243,7 +23243,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.GeneralStudentProgramAssociationAggre
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on GeneralStudentProgramAssociation
@@ -23722,8 +23722,8 @@ namespace EdFi.Ods.Entities.Common.EdFi //.GradeAggregate
             // Detect primary key changes
             if (
                  (target.BeginDate != source.BeginDate)
-                || (target.GradeTypeDescriptor != source.GradeTypeDescriptor)
-                || (target.GradingPeriodDescriptor != source.GradingPeriodDescriptor)
+                || !string.Equals(target.GradeTypeDescriptor, source.GradeTypeDescriptor, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(target.GradingPeriodDescriptor, source.GradingPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.GradingPeriodSchoolYear != source.GradingPeriodSchoolYear)
                 || (target.GradingPeriodSequence != source.GradingPeriodSequence)
                 || (!keyStringComparer.Equals(target.LocalCourseCode, source.LocalCourseCode))
@@ -25093,7 +25093,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.GradingPeriodAggregate
 
             // Detect primary key changes
             if (
-                 (target.GradingPeriodDescriptor != source.GradingPeriodDescriptor)
+                 !string.Equals(target.GradingPeriodDescriptor, source.GradingPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.PeriodSequence != source.PeriodSequence)
                 || (target.SchoolId != source.SchoolId)
                 || (target.SchoolYear != source.SchoolYear))
@@ -25384,7 +25384,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.GraduationPlanAggregate
             // Detect primary key changes
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
-                || (target.GraduationPlanTypeDescriptor != source.GraduationPlanTypeDescriptor)
+                || !string.Equals(target.GraduationPlanTypeDescriptor, source.GraduationPlanTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.GraduationSchoolYear != source.GraduationSchoolYear))
             {
                 // Disallow PK column updates on GraduationPlan
@@ -42293,7 +42293,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.PersonAggregate
             // Detect primary key changes
             if (
                  (!keyStringComparer.Equals(target.PersonId, source.PersonId))
-                || (target.SourceSystemDescriptor != source.SourceSystemDescriptor))
+                || !string.Equals(target.SourceSystemDescriptor, source.SourceSystemDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on Person
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -43025,7 +43025,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.PostSecondaryEventAggregate
             // Detect primary key changes
             if (
                  (target.EventDate != source.EventDate)
-                || (target.PostSecondaryEventCategoryDescriptor != source.PostSecondaryEventCategoryDescriptor)
+                || !string.Equals(target.PostSecondaryEventCategoryDescriptor, source.PostSecondaryEventCategoryDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on PostSecondaryEvent
@@ -44428,7 +44428,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.ProgramAggregate
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor))
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on Program
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -48095,7 +48095,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.ReportCardAggregate
             // Detect primary key changes
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
-                || (target.GradingPeriodDescriptor != source.GradingPeriodDescriptor)
+                || !string.Equals(target.GradingPeriodDescriptor, source.GradingPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.GradingPeriodSchoolId != source.GradingPeriodSchoolId)
                 || (target.GradingPeriodSchoolYear != source.GradingPeriodSchoolYear)
                 || (target.GradingPeriodSequence != source.GradingPeriodSequence)
@@ -56465,7 +56465,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StaffAbsenceEventAggregate
 
             // Detect primary key changes
             if (
-                 (target.AbsenceEventCategoryDescriptor != source.AbsenceEventCategoryDescriptor)
+                 !string.Equals(target.AbsenceEventCategoryDescriptor, source.AbsenceEventCategoryDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.EventDate != source.EventDate)
                 || (target.StaffUniqueId != source.StaffUniqueId))
             {
@@ -57056,7 +57056,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StaffEducationOrganizationAssignmentA
             if (
                  (target.BeginDate != source.BeginDate)
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
-                || (target.StaffClassificationDescriptor != source.StaffClassificationDescriptor)
+                || !string.Equals(target.StaffClassificationDescriptor, source.StaffClassificationDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StaffUniqueId != source.StaffUniqueId))
             {
                 // Disallow PK column updates on StaffEducationOrganizationAssignmentAssociation
@@ -57847,7 +57847,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StaffEducationOrganizationEmploymentA
             // Detect primary key changes
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
-                || (target.EmploymentStatusDescriptor != source.EmploymentStatusDescriptor)
+                || !string.Equals(target.EmploymentStatusDescriptor, source.EmploymentStatusDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.HireDate != source.HireDate)
                 || (target.StaffUniqueId != source.StaffUniqueId))
             {
@@ -58201,7 +58201,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StaffLeaveAggregate
             // Detect primary key changes
             if (
                  (target.BeginDate != source.BeginDate)
-                || (target.StaffLeaveEventCategoryDescriptor != source.StaffLeaveEventCategoryDescriptor)
+                || !string.Equals(target.StaffLeaveEventCategoryDescriptor, source.StaffLeaveEventCategoryDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StaffUniqueId != source.StaffUniqueId))
             {
                 // Disallow PK column updates on StaffLeave
@@ -58493,7 +58493,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StaffProgramAssociationAggregate
                  (target.BeginDate != source.BeginDate)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StaffUniqueId != source.StaffUniqueId))
             {
                 // Disallow PK column updates on StaffProgramAssociation
@@ -58613,7 +58613,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StaffSchoolAssociationAggregate
 
             // Detect primary key changes
             if (
-                 (target.ProgramAssignmentDescriptor != source.ProgramAssignmentDescriptor)
+                 !string.Equals(target.ProgramAssignmentDescriptor, source.ProgramAssignmentDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.SchoolId != source.SchoolId)
                 || (target.StaffUniqueId != source.StaffUniqueId))
             {
@@ -60431,7 +60431,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentAcademicRecordAggregate
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.SchoolYear != source.SchoolYear)
                 || (target.StudentUniqueId != source.StudentUniqueId)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on StudentAcademicRecord
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -62902,7 +62902,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentAssessmentEducationOrganizatio
             // Detect primary key changes
             if (
                  (!keyStringComparer.Equals(target.AssessmentIdentifier, source.AssessmentIdentifier))
-                || (target.EducationOrganizationAssociationTypeDescriptor != source.EducationOrganizationAssociationTypeDescriptor)
+                || !string.Equals(target.EducationOrganizationAssociationTypeDescriptor, source.EducationOrganizationAssociationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.Namespace, source.Namespace))
                 || (!keyStringComparer.Equals(target.StudentAssessmentIdentifier, source.StudentAssessmentIdentifier))
@@ -63391,13 +63391,13 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentCompetencyObjectiveAggregate
 
             // Detect primary key changes
             if (
-                 (target.GradingPeriodDescriptor != source.GradingPeriodDescriptor)
+                 !string.Equals(target.GradingPeriodDescriptor, source.GradingPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.GradingPeriodSchoolId != source.GradingPeriodSchoolId)
                 || (target.GradingPeriodSchoolYear != source.GradingPeriodSchoolYear)
                 || (target.GradingPeriodSequence != source.GradingPeriodSequence)
                 || (!keyStringComparer.Equals(target.Objective, source.Objective))
                 || (target.ObjectiveEducationOrganizationId != source.ObjectiveEducationOrganizationId)
-                || (target.ObjectiveGradeLevelDescriptor != source.ObjectiveGradeLevelDescriptor)
+                || !string.Equals(target.ObjectiveGradeLevelDescriptor, source.ObjectiveGradeLevelDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentCompetencyObjective
@@ -63725,7 +63725,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentCTEProgramAssociationAggregate
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentCTEProgramAssociation
@@ -64534,7 +64534,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentDisciplineIncidentBehaviorAsso
 
             // Detect primary key changes
             if (
-                 (target.BehaviorDescriptor != source.BehaviorDescriptor)
+                 !string.Equals(target.BehaviorDescriptor, source.BehaviorDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.IncidentIdentifier, source.IncidentIdentifier))
                 || (target.SchoolId != source.SchoolId)
                 || (target.StudentUniqueId != source.StudentUniqueId))
@@ -67283,7 +67283,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentEducationOrganizationResponsib
             if (
                  (target.BeginDate != source.BeginDate)
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
-                || (target.ResponsibilityDescriptor != source.ResponsibilityDescriptor)
+                || !string.Equals(target.ResponsibilityDescriptor, source.ResponsibilityDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentEducationOrganizationResponsibilityAssociation
@@ -67589,7 +67589,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentHomelessProgramAssociationAggr
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentHomelessProgramAssociation
@@ -68359,7 +68359,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentInterventionAttendanceEventAgg
 
             // Detect primary key changes
             if (
-                 (target.AttendanceEventCategoryDescriptor != source.AttendanceEventCategoryDescriptor)
+                 !string.Equals(target.AttendanceEventCategoryDescriptor, source.AttendanceEventCategoryDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.EventDate != source.EventDate)
                 || (!keyStringComparer.Equals(target.InterventionIdentificationCode, source.InterventionIdentificationCode))
@@ -68508,7 +68508,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentLanguageInstructionProgramAsso
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentLanguageInstructionProgramAssociation
@@ -68988,7 +68988,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentLearningObjectiveAggregate
 
             // Detect primary key changes
             if (
-                 (target.GradingPeriodDescriptor != source.GradingPeriodDescriptor)
+                 !string.Equals(target.GradingPeriodDescriptor, source.GradingPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.GradingPeriodSchoolId != source.GradingPeriodSchoolId)
                 || (target.GradingPeriodSchoolYear != source.GradingPeriodSchoolYear)
                 || (target.GradingPeriodSequence != source.GradingPeriodSequence)
@@ -69320,7 +69320,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentMigrantEducationProgramAssocia
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentMigrantEducationProgramAssociation
@@ -69741,7 +69741,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentNeglectedOrDelinquentProgramAs
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentNeglectedOrDelinquentProgramAssociation
@@ -70430,7 +70430,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentProgramAssociationAggregate
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentProgramAssociation
@@ -70757,12 +70757,12 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentProgramAttendanceEventAggregat
 
             // Detect primary key changes
             if (
-                 (target.AttendanceEventCategoryDescriptor != source.AttendanceEventCategoryDescriptor)
+                 !string.Equals(target.AttendanceEventCategoryDescriptor, source.AttendanceEventCategoryDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.EventDate != source.EventDate)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentProgramAttendanceEvent
@@ -71399,7 +71399,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentSchoolAttendanceEventAggregate
 
             // Detect primary key changes
             if (
-                 (target.AttendanceEventCategoryDescriptor != source.AttendanceEventCategoryDescriptor)
+                 !string.Equals(target.AttendanceEventCategoryDescriptor, source.AttendanceEventCategoryDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.EventDate != source.EventDate)
                 || (target.SchoolId != source.SchoolId)
                 || (target.SchoolYear != source.SchoolYear)
@@ -71571,7 +71571,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentSchoolFoodServiceProgramAssoci
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentSchoolFoodServiceProgramAssociation
@@ -72107,7 +72107,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentSectionAttendanceEventAggregat
 
             // Detect primary key changes
             if (
-                 (target.AttendanceEventCategoryDescriptor != source.AttendanceEventCategoryDescriptor)
+                 !string.Equals(target.AttendanceEventCategoryDescriptor, source.AttendanceEventCategoryDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.EventDate != source.EventDate)
                 || (!keyStringComparer.Equals(target.LocalCourseCode, source.LocalCourseCode))
                 || (target.SchoolId != source.SchoolId)
@@ -72376,7 +72376,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentSpecialEducationProgramAssocia
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentSpecialEducationProgramAssociation
@@ -73219,7 +73219,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentTitleIPartAProgramAssociationA
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentTitleIPartAProgramAssociation
@@ -74432,7 +74432,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.SurveyProgramAssociationAggregate
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.Namespace, source.Namespace))
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.SurveyIdentifier, source.SurveyIdentifier)))
             {
                 // Disallow PK column updates on SurveyProgramAssociation

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/5.0.0/DataStandard_500_ApprovalTests.Verify.Extensions.Sample.1.0.0_Std_5.0.0_Models_Mappers_EntityMapper.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/5.0.0/DataStandard_500_ApprovalTests.Verify.Extensions.Sample.1.0.0_Std_5.0.0_Models_Mappers_EntityMapper.generated.approved.cs
@@ -3708,7 +3708,7 @@ namespace EdFi.Ods.Entities.Common.Sample //.StudentArtProgramAssociationAggrega
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentArtProgramAssociation
@@ -5762,7 +5762,7 @@ namespace EdFi.Ods.Entities.Common.Sample //.StudentGraduationPlanAssociationAgg
             // Detect primary key changes
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
-                || (target.GraduationPlanTypeDescriptor != source.GraduationPlanTypeDescriptor)
+                || !string.Equals(target.GraduationPlanTypeDescriptor, source.GraduationPlanTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.GraduationSchoolYear != source.GraduationSchoolYear)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/5.0.0/DataStandard_500_ApprovalTests.Verify.Extensions.TPDM.1.1.0_Std_5.0.0_Models_Mappers_EntityMapper.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/5.0.0/DataStandard_500_ApprovalTests.Verify.Extensions.TPDM.1.1.0_Std_5.0.0_Models_Mappers_EntityMapper.generated.approved.cs
@@ -1911,7 +1911,7 @@ namespace EdFi.Ods.Entities.Common.TPDM //.CandidateEducatorPreparationProgramAs
                 || (!keyStringComparer.Equals(target.CandidateIdentifier, source.CandidateIdentifier))
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor))
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on CandidateEducatorPreparationProgramAssociation
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -2979,7 +2979,7 @@ namespace EdFi.Ods.Entities.Common.TPDM //.EducatorPreparationProgramAggregate
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor))
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on EducatorPreparationProgram
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -3659,12 +3659,12 @@ namespace EdFi.Ods.Entities.Common.TPDM //.EvaluationAggregate
             // Detect primary key changes
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
-                || (target.EvaluationPeriodDescriptor != source.EvaluationPeriodDescriptor)
+                || !string.Equals(target.EvaluationPeriodDescriptor, source.EvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.EvaluationTitle, source.EvaluationTitle))
                 || (!keyStringComparer.Equals(target.PerformanceEvaluationTitle, source.PerformanceEvaluationTitle))
-                || (target.PerformanceEvaluationTypeDescriptor != source.PerformanceEvaluationTypeDescriptor)
+                || !string.Equals(target.PerformanceEvaluationTypeDescriptor, source.PerformanceEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.SchoolYear != source.SchoolYear)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on Evaluation
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -3917,12 +3917,12 @@ namespace EdFi.Ods.Entities.Common.TPDM //.EvaluationElementAggregate
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.EvaluationElementTitle, source.EvaluationElementTitle))
                 || (!keyStringComparer.Equals(target.EvaluationObjectiveTitle, source.EvaluationObjectiveTitle))
-                || (target.EvaluationPeriodDescriptor != source.EvaluationPeriodDescriptor)
+                || !string.Equals(target.EvaluationPeriodDescriptor, source.EvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.EvaluationTitle, source.EvaluationTitle))
                 || (!keyStringComparer.Equals(target.PerformanceEvaluationTitle, source.PerformanceEvaluationTitle))
-                || (target.PerformanceEvaluationTypeDescriptor != source.PerformanceEvaluationTypeDescriptor)
+                || !string.Equals(target.PerformanceEvaluationTypeDescriptor, source.PerformanceEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.SchoolYear != source.SchoolYear)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on EvaluationElement
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -4168,14 +4168,14 @@ namespace EdFi.Ods.Entities.Common.TPDM //.EvaluationElementRatingAggregate
                 || (target.EvaluationDate != source.EvaluationDate)
                 || (!keyStringComparer.Equals(target.EvaluationElementTitle, source.EvaluationElementTitle))
                 || (!keyStringComparer.Equals(target.EvaluationObjectiveTitle, source.EvaluationObjectiveTitle))
-                || (target.EvaluationPeriodDescriptor != source.EvaluationPeriodDescriptor)
+                || !string.Equals(target.EvaluationPeriodDescriptor, source.EvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.EvaluationTitle, source.EvaluationTitle))
                 || (!keyStringComparer.Equals(target.PerformanceEvaluationTitle, source.PerformanceEvaluationTitle))
-                || (target.PerformanceEvaluationTypeDescriptor != source.PerformanceEvaluationTypeDescriptor)
+                || !string.Equals(target.PerformanceEvaluationTypeDescriptor, source.PerformanceEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.PersonId, source.PersonId))
                 || (target.SchoolYear != source.SchoolYear)
-                || (target.SourceSystemDescriptor != source.SourceSystemDescriptor)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.SourceSystemDescriptor, source.SourceSystemDescriptor, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on EvaluationElementRating
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -4586,12 +4586,12 @@ namespace EdFi.Ods.Entities.Common.TPDM //.EvaluationObjectiveAggregate
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.EvaluationObjectiveTitle, source.EvaluationObjectiveTitle))
-                || (target.EvaluationPeriodDescriptor != source.EvaluationPeriodDescriptor)
+                || !string.Equals(target.EvaluationPeriodDescriptor, source.EvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.EvaluationTitle, source.EvaluationTitle))
                 || (!keyStringComparer.Equals(target.PerformanceEvaluationTitle, source.PerformanceEvaluationTitle))
-                || (target.PerformanceEvaluationTypeDescriptor != source.PerformanceEvaluationTypeDescriptor)
+                || !string.Equals(target.PerformanceEvaluationTypeDescriptor, source.PerformanceEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.SchoolYear != source.SchoolYear)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on EvaluationObjective
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -4845,14 +4845,14 @@ namespace EdFi.Ods.Entities.Common.TPDM //.EvaluationObjectiveRatingAggregate
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.EvaluationDate != source.EvaluationDate)
                 || (!keyStringComparer.Equals(target.EvaluationObjectiveTitle, source.EvaluationObjectiveTitle))
-                || (target.EvaluationPeriodDescriptor != source.EvaluationPeriodDescriptor)
+                || !string.Equals(target.EvaluationPeriodDescriptor, source.EvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.EvaluationTitle, source.EvaluationTitle))
                 || (!keyStringComparer.Equals(target.PerformanceEvaluationTitle, source.PerformanceEvaluationTitle))
-                || (target.PerformanceEvaluationTypeDescriptor != source.PerformanceEvaluationTypeDescriptor)
+                || !string.Equals(target.PerformanceEvaluationTypeDescriptor, source.PerformanceEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.PersonId, source.PersonId))
                 || (target.SchoolYear != source.SchoolYear)
-                || (target.SourceSystemDescriptor != source.SourceSystemDescriptor)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.SourceSystemDescriptor, source.SourceSystemDescriptor, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on EvaluationObjectiveRating
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -5232,14 +5232,14 @@ namespace EdFi.Ods.Entities.Common.TPDM //.EvaluationRatingAggregate
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.EvaluationDate != source.EvaluationDate)
-                || (target.EvaluationPeriodDescriptor != source.EvaluationPeriodDescriptor)
+                || !string.Equals(target.EvaluationPeriodDescriptor, source.EvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.EvaluationTitle, source.EvaluationTitle))
                 || (!keyStringComparer.Equals(target.PerformanceEvaluationTitle, source.PerformanceEvaluationTitle))
-                || (target.PerformanceEvaluationTypeDescriptor != source.PerformanceEvaluationTypeDescriptor)
+                || !string.Equals(target.PerformanceEvaluationTypeDescriptor, source.PerformanceEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.PersonId, source.PersonId))
                 || (target.SchoolYear != source.SchoolYear)
-                || (target.SourceSystemDescriptor != source.SourceSystemDescriptor)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.SourceSystemDescriptor, source.SourceSystemDescriptor, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on EvaluationRating
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -6226,7 +6226,7 @@ namespace EdFi.Ods.Entities.Common.TPDM //.FinancialAidAggregate
 
             // Detect primary key changes
             if (
-                 (target.AidTypeDescriptor != source.AidTypeDescriptor)
+                 !string.Equals(target.AidTypeDescriptor, source.AidTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.BeginDate != source.BeginDate)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
@@ -6684,11 +6684,11 @@ namespace EdFi.Ods.Entities.Common.TPDM //.PerformanceEvaluationAggregate
             // Detect primary key changes
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
-                || (target.EvaluationPeriodDescriptor != source.EvaluationPeriodDescriptor)
+                || !string.Equals(target.EvaluationPeriodDescriptor, source.EvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.PerformanceEvaluationTitle, source.PerformanceEvaluationTitle))
-                || (target.PerformanceEvaluationTypeDescriptor != source.PerformanceEvaluationTypeDescriptor)
+                || !string.Equals(target.PerformanceEvaluationTypeDescriptor, source.PerformanceEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.SchoolYear != source.SchoolYear)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on PerformanceEvaluation
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -6992,13 +6992,13 @@ namespace EdFi.Ods.Entities.Common.TPDM //.PerformanceEvaluationRatingAggregate
             // Detect primary key changes
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
-                || (target.EvaluationPeriodDescriptor != source.EvaluationPeriodDescriptor)
+                || !string.Equals(target.EvaluationPeriodDescriptor, source.EvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.PerformanceEvaluationTitle, source.PerformanceEvaluationTitle))
-                || (target.PerformanceEvaluationTypeDescriptor != source.PerformanceEvaluationTypeDescriptor)
+                || !string.Equals(target.PerformanceEvaluationTypeDescriptor, source.PerformanceEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.PersonId, source.PersonId))
                 || (target.SchoolYear != source.SchoolYear)
-                || (target.SourceSystemDescriptor != source.SourceSystemDescriptor)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.SourceSystemDescriptor, source.SourceSystemDescriptor, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on PerformanceEvaluationRating
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -7845,13 +7845,13 @@ namespace EdFi.Ods.Entities.Common.TPDM //.RubricDimensionAggregate
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.EvaluationElementTitle, source.EvaluationElementTitle))
                 || (!keyStringComparer.Equals(target.EvaluationObjectiveTitle, source.EvaluationObjectiveTitle))
-                || (target.EvaluationPeriodDescriptor != source.EvaluationPeriodDescriptor)
+                || !string.Equals(target.EvaluationPeriodDescriptor, source.EvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.EvaluationTitle, source.EvaluationTitle))
                 || (!keyStringComparer.Equals(target.PerformanceEvaluationTitle, source.PerformanceEvaluationTitle))
-                || (target.PerformanceEvaluationTypeDescriptor != source.PerformanceEvaluationTypeDescriptor)
+                || !string.Equals(target.PerformanceEvaluationTypeDescriptor, source.PerformanceEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.RubricRating != source.RubricRating)
                 || (target.SchoolYear != source.SchoolYear)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on RubricDimension
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -8327,7 +8327,7 @@ namespace EdFi.Ods.Entities.Common.TPDM //.SurveyResponsePersonTargetAssociation
             if (
                  (!keyStringComparer.Equals(target.Namespace, source.Namespace))
                 || (!keyStringComparer.Equals(target.PersonId, source.PersonId))
-                || (target.SourceSystemDescriptor != source.SourceSystemDescriptor)
+                || !string.Equals(target.SourceSystemDescriptor, source.SourceSystemDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.SurveyIdentifier, source.SurveyIdentifier))
                 || (!keyStringComparer.Equals(target.SurveyResponseIdentifier, source.SurveyResponseIdentifier)))
             {
@@ -8428,7 +8428,7 @@ namespace EdFi.Ods.Entities.Common.TPDM //.SurveySectionResponsePersonTargetAsso
             if (
                  (!keyStringComparer.Equals(target.Namespace, source.Namespace))
                 || (!keyStringComparer.Equals(target.PersonId, source.PersonId))
-                || (target.SourceSystemDescriptor != source.SourceSystemDescriptor)
+                || !string.Equals(target.SourceSystemDescriptor, source.SourceSystemDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.SurveyIdentifier, source.SurveyIdentifier))
                 || (!keyStringComparer.Equals(target.SurveyResponseIdentifier, source.SurveyResponseIdentifier))
                 || (!keyStringComparer.Equals(target.SurveySectionTitle, source.SurveySectionTitle)))

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/5.0.0/DataStandard_500_ApprovalTests.Verify.Standard_Std_5.0.0_Models_Mappers_EntityMapper.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/5.0.0/DataStandard_500_ApprovalTests.Verify.Standard_Std_5.0.0_Models_Mappers_EntityMapper.generated.approved.cs
@@ -10129,7 +10129,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.CompetencyObjectiveAggregate
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.Objective, source.Objective))
-                || (target.ObjectiveGradeLevelDescriptor != source.ObjectiveGradeLevelDescriptor))
+                || !string.Equals(target.ObjectiveGradeLevelDescriptor, source.ObjectiveGradeLevelDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on CompetencyObjective
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -14611,13 +14611,13 @@ namespace EdFi.Ods.Entities.Common.EdFi //.CourseTranscriptAggregate
 
             // Detect primary key changes
             if (
-                 (target.CourseAttemptResultDescriptor != source.CourseAttemptResultDescriptor)
+                 !string.Equals(target.CourseAttemptResultDescriptor, source.CourseAttemptResultDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.CourseCode, source.CourseCode))
                 || (target.CourseEducationOrganizationId != source.CourseEducationOrganizationId)
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.SchoolYear != source.SchoolYear)
                 || (target.StudentUniqueId != source.StudentUniqueId)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on CourseTranscript
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -15408,7 +15408,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.CredentialAggregate
             // Detect primary key changes
             if (
                  (!keyStringComparer.Equals(target.CredentialIdentifier, source.CredentialIdentifier))
-                || (target.StateOfIssueStateAbbreviationDescriptor != source.StateOfIssueStateAbbreviationDescriptor))
+                || !string.Equals(target.StateOfIssueStateAbbreviationDescriptor, source.StateOfIssueStateAbbreviationDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on Credential
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -24130,11 +24130,11 @@ namespace EdFi.Ods.Entities.Common.EdFi //.EvaluationRubricDimensionAggregate
                  (target.EvaluationRubricRating != source.EvaluationRubricRating)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramEvaluationElementTitle, source.ProgramEvaluationElementTitle))
-                || (target.ProgramEvaluationPeriodDescriptor != source.ProgramEvaluationPeriodDescriptor)
+                || !string.Equals(target.ProgramEvaluationPeriodDescriptor, source.ProgramEvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.ProgramEvaluationTitle, source.ProgramEvaluationTitle))
-                || (target.ProgramEvaluationTypeDescriptor != source.ProgramEvaluationTypeDescriptor)
+                || !string.Equals(target.ProgramEvaluationTypeDescriptor, source.ProgramEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor))
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on EvaluationRubricDimension
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -25244,7 +25244,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.GeneralStudentProgramAssociationAggre
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on GeneralStudentProgramAssociation
@@ -25562,8 +25562,8 @@ namespace EdFi.Ods.Entities.Common.EdFi //.GradeAggregate
             // Detect primary key changes
             if (
                  (target.BeginDate != source.BeginDate)
-                || (target.GradeTypeDescriptor != source.GradeTypeDescriptor)
-                || (target.GradingPeriodDescriptor != source.GradingPeriodDescriptor)
+                || !string.Equals(target.GradeTypeDescriptor, source.GradeTypeDescriptor, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(target.GradingPeriodDescriptor, source.GradingPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.GradingPeriodSchoolYear != source.GradingPeriodSchoolYear)
                 || (target.GradingPeriodSequence != source.GradingPeriodSequence)
                 || (!keyStringComparer.Equals(target.LocalCourseCode, source.LocalCourseCode))
@@ -26943,7 +26943,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.GradingPeriodAggregate
 
             // Detect primary key changes
             if (
-                 (target.GradingPeriodDescriptor != source.GradingPeriodDescriptor)
+                 !string.Equals(target.GradingPeriodDescriptor, source.GradingPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.PeriodSequence != source.PeriodSequence)
                 || (target.SchoolId != source.SchoolId)
                 || (target.SchoolYear != source.SchoolYear))
@@ -27234,7 +27234,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.GraduationPlanAggregate
             // Detect primary key changes
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
-                || (target.GraduationPlanTypeDescriptor != source.GraduationPlanTypeDescriptor)
+                || !string.Equals(target.GraduationPlanTypeDescriptor, source.GraduationPlanTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.GraduationSchoolYear != source.GraduationSchoolYear))
             {
                 // Disallow PK column updates on GraduationPlan
@@ -41976,7 +41976,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.PersonAggregate
             // Detect primary key changes
             if (
                  (!keyStringComparer.Equals(target.PersonId, source.PersonId))
-                || (target.SourceSystemDescriptor != source.SourceSystemDescriptor))
+                || !string.Equals(target.SourceSystemDescriptor, source.SourceSystemDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on Person
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -42708,7 +42708,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.PostSecondaryEventAggregate
             // Detect primary key changes
             if (
                  (target.EventDate != source.EventDate)
-                || (target.PostSecondaryEventCategoryDescriptor != source.PostSecondaryEventCategoryDescriptor)
+                || !string.Equals(target.PostSecondaryEventCategoryDescriptor, source.PostSecondaryEventCategoryDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on PostSecondaryEvent
@@ -44111,7 +44111,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.ProgramAggregate
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor))
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on Program
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -44996,11 +44996,11 @@ namespace EdFi.Ods.Entities.Common.EdFi //.ProgramEvaluationAggregate
             // Detect primary key changes
             if (
                  (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
-                || (target.ProgramEvaluationPeriodDescriptor != source.ProgramEvaluationPeriodDescriptor)
+                || !string.Equals(target.ProgramEvaluationPeriodDescriptor, source.ProgramEvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.ProgramEvaluationTitle, source.ProgramEvaluationTitle))
-                || (target.ProgramEvaluationTypeDescriptor != source.ProgramEvaluationTypeDescriptor)
+                || !string.Equals(target.ProgramEvaluationTypeDescriptor, source.ProgramEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor))
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on ProgramEvaluation
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -45239,11 +45239,11 @@ namespace EdFi.Ods.Entities.Common.EdFi //.ProgramEvaluationElementAggregate
             if (
                  (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramEvaluationElementTitle, source.ProgramEvaluationElementTitle))
-                || (target.ProgramEvaluationPeriodDescriptor != source.ProgramEvaluationPeriodDescriptor)
+                || !string.Equals(target.ProgramEvaluationPeriodDescriptor, source.ProgramEvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.ProgramEvaluationTitle, source.ProgramEvaluationTitle))
-                || (target.ProgramEvaluationTypeDescriptor != source.ProgramEvaluationTypeDescriptor)
+                || !string.Equals(target.ProgramEvaluationTypeDescriptor, source.ProgramEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor))
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on ProgramEvaluationElement
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -45505,11 +45505,11 @@ namespace EdFi.Ods.Entities.Common.EdFi //.ProgramEvaluationObjectiveAggregate
             if (
                  (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramEvaluationObjectiveTitle, source.ProgramEvaluationObjectiveTitle))
-                || (target.ProgramEvaluationPeriodDescriptor != source.ProgramEvaluationPeriodDescriptor)
+                || !string.Equals(target.ProgramEvaluationPeriodDescriptor, source.ProgramEvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.ProgramEvaluationTitle, source.ProgramEvaluationTitle))
-                || (target.ProgramEvaluationTypeDescriptor != source.ProgramEvaluationTypeDescriptor)
+                || !string.Equals(target.ProgramEvaluationTypeDescriptor, source.ProgramEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor))
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on ProgramEvaluationObjective
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -48841,7 +48841,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.ReportCardAggregate
             // Detect primary key changes
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
-                || (target.GradingPeriodDescriptor != source.GradingPeriodDescriptor)
+                || !string.Equals(target.GradingPeriodDescriptor, source.GradingPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.GradingPeriodSchoolId != source.GradingPeriodSchoolId)
                 || (target.GradingPeriodSchoolYear != source.GradingPeriodSchoolYear)
                 || (target.GradingPeriodSequence != source.GradingPeriodSequence)
@@ -57267,7 +57267,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StaffAbsenceEventAggregate
 
             // Detect primary key changes
             if (
-                 (target.AbsenceEventCategoryDescriptor != source.AbsenceEventCategoryDescriptor)
+                 !string.Equals(target.AbsenceEventCategoryDescriptor, source.AbsenceEventCategoryDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.EventDate != source.EventDate)
                 || (target.StaffUniqueId != source.StaffUniqueId))
             {
@@ -57858,7 +57858,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StaffEducationOrganizationAssignmentA
             if (
                  (target.BeginDate != source.BeginDate)
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
-                || (target.StaffClassificationDescriptor != source.StaffClassificationDescriptor)
+                || !string.Equals(target.StaffClassificationDescriptor, source.StaffClassificationDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StaffUniqueId != source.StaffUniqueId))
             {
                 // Disallow PK column updates on StaffEducationOrganizationAssignmentAssociation
@@ -58649,7 +58649,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StaffEducationOrganizationEmploymentA
             // Detect primary key changes
             if (
                  (target.EducationOrganizationId != source.EducationOrganizationId)
-                || (target.EmploymentStatusDescriptor != source.EmploymentStatusDescriptor)
+                || !string.Equals(target.EmploymentStatusDescriptor, source.EmploymentStatusDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.HireDate != source.HireDate)
                 || (target.StaffUniqueId != source.StaffUniqueId))
             {
@@ -59003,7 +59003,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StaffLeaveAggregate
             // Detect primary key changes
             if (
                  (target.BeginDate != source.BeginDate)
-                || (target.StaffLeaveEventCategoryDescriptor != source.StaffLeaveEventCategoryDescriptor)
+                || !string.Equals(target.StaffLeaveEventCategoryDescriptor, source.StaffLeaveEventCategoryDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StaffUniqueId != source.StaffUniqueId))
             {
                 // Disallow PK column updates on StaffLeave
@@ -59295,7 +59295,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StaffProgramAssociationAggregate
                  (target.BeginDate != source.BeginDate)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StaffUniqueId != source.StaffUniqueId))
             {
                 // Disallow PK column updates on StaffProgramAssociation
@@ -59415,7 +59415,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StaffSchoolAssociationAggregate
 
             // Detect primary key changes
             if (
-                 (target.ProgramAssignmentDescriptor != source.ProgramAssignmentDescriptor)
+                 !string.Equals(target.ProgramAssignmentDescriptor, source.ProgramAssignmentDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.SchoolId != source.SchoolId)
                 || (target.StaffUniqueId != source.StaffUniqueId))
             {
@@ -61253,7 +61253,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentAcademicRecordAggregate
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.SchoolYear != source.SchoolYear)
                 || (target.StudentUniqueId != source.StudentUniqueId)
-                || (target.TermDescriptor != source.TermDescriptor))
+                || !string.Equals(target.TermDescriptor, source.TermDescriptor, StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow PK column updates on StudentAcademicRecord
                 throw new BadRequestException("Key values for this resource cannot be changed. Delete and recreate the resource item.");
@@ -63674,7 +63674,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentAssessmentEducationOrganizatio
             // Detect primary key changes
             if (
                  (!keyStringComparer.Equals(target.AssessmentIdentifier, source.AssessmentIdentifier))
-                || (target.EducationOrganizationAssociationTypeDescriptor != source.EducationOrganizationAssociationTypeDescriptor)
+                || !string.Equals(target.EducationOrganizationAssociationTypeDescriptor, source.EducationOrganizationAssociationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.Namespace, source.Namespace))
                 || (!keyStringComparer.Equals(target.StudentAssessmentIdentifier, source.StudentAssessmentIdentifier))
@@ -64163,13 +64163,13 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentCompetencyObjectiveAggregate
 
             // Detect primary key changes
             if (
-                 (target.GradingPeriodDescriptor != source.GradingPeriodDescriptor)
+                 !string.Equals(target.GradingPeriodDescriptor, source.GradingPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.GradingPeriodSchoolId != source.GradingPeriodSchoolId)
                 || (target.GradingPeriodSchoolYear != source.GradingPeriodSchoolYear)
                 || (target.GradingPeriodSequence != source.GradingPeriodSequence)
                 || (!keyStringComparer.Equals(target.Objective, source.Objective))
                 || (target.ObjectiveEducationOrganizationId != source.ObjectiveEducationOrganizationId)
-                || (target.ObjectiveGradeLevelDescriptor != source.ObjectiveGradeLevelDescriptor)
+                || !string.Equals(target.ObjectiveGradeLevelDescriptor, source.ObjectiveGradeLevelDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentCompetencyObjective
@@ -64664,7 +64664,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentCTEProgramAssociationAggregate
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentCTEProgramAssociation
@@ -64979,7 +64979,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentDisciplineIncidentBehaviorAsso
 
             // Detect primary key changes
             if (
-                 (target.BehaviorDescriptor != source.BehaviorDescriptor)
+                 !string.Equals(target.BehaviorDescriptor, source.BehaviorDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.IncidentIdentifier, source.IncidentIdentifier))
                 || (target.SchoolId != source.SchoolId)
                 || (target.StudentUniqueId != source.StudentUniqueId))
@@ -67514,7 +67514,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentEducationOrganizationResponsib
             if (
                  (target.BeginDate != source.BeginDate)
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
-                || (target.ResponsibilityDescriptor != source.ResponsibilityDescriptor)
+                || !string.Equals(target.ResponsibilityDescriptor, source.ResponsibilityDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentEducationOrganizationResponsibilityAssociation
@@ -67820,7 +67820,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentHomelessProgramAssociationAggr
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentHomelessProgramAssociation
@@ -68538,7 +68538,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentInterventionAttendanceEventAgg
 
             // Detect primary key changes
             if (
-                 (target.AttendanceEventCategoryDescriptor != source.AttendanceEventCategoryDescriptor)
+                 !string.Equals(target.AttendanceEventCategoryDescriptor, source.AttendanceEventCategoryDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.EventDate != source.EventDate)
                 || (!keyStringComparer.Equals(target.InterventionIdentificationCode, source.InterventionIdentificationCode))
@@ -68687,7 +68687,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentLanguageInstructionProgramAsso
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentLanguageInstructionProgramAssociation
@@ -69119,7 +69119,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentMigrantEducationProgramAssocia
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentMigrantEducationProgramAssociation
@@ -69488,7 +69488,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentNeglectedOrDelinquentProgramAs
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentNeglectedOrDelinquentProgramAssociation
@@ -69958,7 +69958,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentProgramAssociationAggregate
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentProgramAssociation
@@ -70233,12 +70233,12 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentProgramAttendanceEventAggregat
 
             // Detect primary key changes
             if (
-                 (target.AttendanceEventCategoryDescriptor != source.AttendanceEventCategoryDescriptor)
+                 !string.Equals(target.AttendanceEventCategoryDescriptor, source.AttendanceEventCategoryDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.EventDate != source.EventDate)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentProgramAttendanceEvent
@@ -70386,11 +70386,11 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentProgramEvaluationAggregate
             if (
                  (target.EvaluationDate != source.EvaluationDate)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
-                || (target.ProgramEvaluationPeriodDescriptor != source.ProgramEvaluationPeriodDescriptor)
+                || !string.Equals(target.ProgramEvaluationPeriodDescriptor, source.ProgramEvaluationPeriodDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.ProgramEvaluationTitle, source.ProgramEvaluationTitle))
-                || (target.ProgramEvaluationTypeDescriptor != source.ProgramEvaluationTypeDescriptor)
+                || !string.Equals(target.ProgramEvaluationTypeDescriptor, source.ProgramEvaluationTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentProgramEvaluation
@@ -71416,7 +71416,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentSchoolAttendanceEventAggregate
 
             // Detect primary key changes
             if (
-                 (target.AttendanceEventCategoryDescriptor != source.AttendanceEventCategoryDescriptor)
+                 !string.Equals(target.AttendanceEventCategoryDescriptor, source.AttendanceEventCategoryDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.EventDate != source.EventDate)
                 || (target.SchoolId != source.SchoolId)
                 || (target.SchoolYear != source.SchoolYear)
@@ -71588,7 +71588,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentSchoolFoodServiceProgramAssoci
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentSchoolFoodServiceProgramAssociation
@@ -72072,7 +72072,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentSectionAttendanceEventAggregat
 
             // Detect primary key changes
             if (
-                 (target.AttendanceEventCategoryDescriptor != source.AttendanceEventCategoryDescriptor)
+                 !string.Equals(target.AttendanceEventCategoryDescriptor, source.AttendanceEventCategoryDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.EventDate != source.EventDate)
                 || (!keyStringComparer.Equals(target.LocalCourseCode, source.LocalCourseCode))
                 || (target.SchoolId != source.SchoolId)
@@ -72341,7 +72341,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentSpecialEducationProgramAssocia
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentSpecialEducationProgramAssociation
@@ -73131,7 +73131,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentSpecialEducationProgramEligibi
                  (target.ConsentToEvaluationReceivedDate != source.ConsentToEvaluationReceivedDate)
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentSpecialEducationProgramEligibilityAssociation
@@ -73379,7 +73379,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentTitleIPartAProgramAssociationA
                 || (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (target.ProgramEducationOrganizationId != source.ProgramEducationOrganizationId)
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (target.StudentUniqueId != source.StudentUniqueId))
             {
                 // Disallow PK column updates on StudentTitleIPartAProgramAssociation
@@ -74423,7 +74423,7 @@ namespace EdFi.Ods.Entities.Common.EdFi //.SurveyProgramAssociationAggregate
                  (target.EducationOrganizationId != source.EducationOrganizationId)
                 || (!keyStringComparer.Equals(target.Namespace, source.Namespace))
                 || (!keyStringComparer.Equals(target.ProgramName, source.ProgramName))
-                || (target.ProgramTypeDescriptor != source.ProgramTypeDescriptor)
+                || !string.Equals(target.ProgramTypeDescriptor, source.ProgramTypeDescriptor, StringComparison.OrdinalIgnoreCase)
                 || (!keyStringComparer.Equals(target.SurveyIdentifier, source.SurveyIdentifier)))
             {
                 // Disallow PK column updates on SurveyProgramAssociation

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Generators/EntityMapper.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Generators/EntityMapper.cs
@@ -221,6 +221,7 @@ namespace EdFi.Ods.CodeGen.Generators
                     {
                         Name = x.GetModelsInterfacePropertyName(),
                         IsString = x.PropertyType.IsString(),
+                        IsDescriptorUsage = x.IsDescriptorUsage,
                     })
                 .OrderBy(x => x.Name)
                 .ToList();
@@ -235,6 +236,7 @@ namespace EdFi.Ods.CodeGen.Generators
                      {
                          PrimaryKeyName = x.Name,
                          IsString = x.IsString,
+                         IsDescriptorUsage = x.IsDescriptorUsage,
                          IsFirst = i == 0,
                          IsLast = i == contextualIdList.Count - 1,
                      });

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Mustache/EntityMapper.mustache
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Mustache/EntityMapper.mustache
@@ -42,7 +42,7 @@ namespace {{NamespaceName}} //.{{AggregateName}}Aggregate
             // Detect primary key changes
             if (
                 {{#AnnotatedLocalPrimaryKeyList}}
-                {{^IsFirst}}||{{/IsFirst}} {{#IsString}}(!keyStringComparer.Equals(target.{{PrimaryKeyName}}, source.{{PrimaryKeyName}})){{/IsString}}{{^IsString}}(target.{{PrimaryKeyName}} != source.{{PrimaryKeyName}}){{/IsString}}{{#IsLast}}){{/IsLast}}
+                {{^IsFirst}}||{{/IsFirst}} {{#IsDescriptorUsage}}!string.Equals(target.{{PrimaryKeyName}}, source.{{PrimaryKeyName}}, StringComparison.OrdinalIgnoreCase){{/IsDescriptorUsage}}{{#IsString}}(!keyStringComparer.Equals(target.{{PrimaryKeyName}}, source.{{PrimaryKeyName}})){{/IsString}}{{^IsString}}{{^IsDescriptorUsage}}(target.{{PrimaryKeyName}} != source.{{PrimaryKeyName}}){{/IsDescriptorUsage}}{{/IsString}}{{#IsLast}}){{/IsLast}}
                 {{/AnnotatedLocalPrimaryKeyList}}
             {
                 {{#AllowPrimaryKeyUpdates}}


### PR DESCRIPTION
ℹ️ **NOTE:** Though the changes to the Postman tests look huge, the actual addition to the Postman tests is found in this [commit](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/pull/839/commits/1d9ce388a9c1054405e6b64ab475bc1915dcb19f). The bulk of the diff seen was simply from a slight reorganization of the Offset/Limit/Total Count tests, and a correction of a spelling error.