### PR TITLE
[ODS-6098] Read profile content-type is wrong in swagger 

### DIFF
--- a/Application/EdFi.Ods.Features/OpenApiMetadata/Providers/OpenApiV3UpconversionProvider.cs
+++ b/Application/EdFi.Ods.Features/OpenApiMetadata/Providers/OpenApiV3UpconversionProvider.cs
@@ -152,9 +152,9 @@ public class OpenApiV3UpconversionProvider : IOpenApiUpconversionProvider
             {
                 OpenApiResponses newResponses = new OpenApiResponses();
 
-                // Replace all responses except 500, 400, and 200 with responses without a content-type set
+                // Replace all responses except 500, 400, 409, and 200 with new responses having no content-type set
                 foreach (KeyValuePair<string, OpenApiResponse> response in operation.Value.Responses.Where(
-                             r => r.Key != "500" && r.Key != "200" && r.Key != "400"))
+                             r => r.Key != "500" && r.Key != "200" && r.Key != "400" && r.Key != "409"))
                 {
                     response.Value.Content.Clear();
                 }

--- a/Utilities/DataLoading/EdFi.LoadTools/ApiClient/SwaggerMetadataRetriever.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/ApiClient/SwaggerMetadataRetriever.cs
@@ -174,10 +174,10 @@ namespace EdFi.LoadTools.ApiClient
         private string GetPathForModel(OpenApiDocument swaggerDocument, string modelName)
         {
             return swaggerDocument.Paths
-                .Where(p => p.Value.Operations.Keys.Any(k => k == OperationType.Post))
                 .FirstOrDefault(
-                    p => p.Value.Operations[OperationType.Post].RequestBody.Content.First().Value.Schema.Reference.Id == modelName
-                 )
+                    path => path.Value.Operations?.Any(
+                                operation => operation.Value.Tags?.Any(tag => modelName.Split('_').Last() == modelName) ?? false
+                                ) ?? false)
                 .Key;
         }
 
@@ -198,7 +198,7 @@ namespace EdFi.LoadTools.ApiClient
                 referenceType = parameter.Items.Reference.ReferenceV3;
             }
 
-            if ((string.IsNullOrEmpty(parameter?.Type) || parameter?.Type == "object") && !string.IsNullOrEmpty(parameter?.Reference.ReferenceV3))
+            if (string.IsNullOrEmpty(parameter?.Type) && !string.IsNullOrEmpty(parameter?.Reference.ReferenceV3))
             {
                 referenceType = parameter.Reference.ReferenceV3;
             }

--- a/Utilities/DataLoading/EdFi.LoadTools/ApiClient/SwaggerMetadataRetriever.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/ApiClient/SwaggerMetadataRetriever.cs
@@ -174,10 +174,10 @@ namespace EdFi.LoadTools.ApiClient
         private string GetPathForModel(OpenApiDocument swaggerDocument, string modelName)
         {
             return swaggerDocument.Paths
+                .Where(p => p.Value.Operations.Keys.Any(k => k == OperationType.Post))
                 .FirstOrDefault(
-                    path => path.Value.Operations?.Any(
-                                operation => operation.Value.Tags?.Any(tag => modelName.Split('_').Last() == modelName) ?? false
-                                ) ?? false)
+                    p => p.Value.Operations[OperationType.Post].RequestBody.Content.First().Value.Schema.Reference.Id == modelName
+                 )
                 .Key;
         }
 

--- a/Utilities/DataLoading/EdFi.LoadTools/ApiClient/SwaggerMetadataRetriever.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/ApiClient/SwaggerMetadataRetriever.cs
@@ -198,7 +198,7 @@ namespace EdFi.LoadTools.ApiClient
                 referenceType = parameter.Items.Reference.ReferenceV3;
             }
 
-            if (string.IsNullOrEmpty(parameter?.Type) && !string.IsNullOrEmpty(parameter?.Reference.ReferenceV3))
+            if ((string.IsNullOrEmpty(parameter?.Type) || parameter?.Type == "object") && !string.IsNullOrEmpty(parameter?.Reference.ReferenceV3))
             {
                 referenceType = parameter.Reference.ReferenceV3;
             }


### PR DESCRIPTION
This adds a step that updates the content-types for responses in the upconverted OpenApi V3.0 metadata to accurately reflect the content type returned from the server for each HTTP response code. 