### PR TITLE
[ODS-6154] Migrate VisualStudioProjectTemplates to .NET 8

### DIFF
--- a/Utilities/VisualStudioProjectTemplates/EdFi.ProjectTemplates.Composites/Template_Project.csproj
+++ b/Utilities/VisualStudioProjectTemplates/EdFi.ProjectTemplates.Composites/Template_Project.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<TargetFramework>net6.0</TargetFramework>
+	<TargetFramework>net8.0</TargetFramework>
     <AssemblyName>$safeprojectname$</AssemblyName>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <RestorePackages>true</RestorePackages>

--- a/Utilities/VisualStudioProjectTemplates/EdFi.ProjectTemplates.Extensions/EdFi.Ods.Extensions.ExtensionName.nuspec
+++ b/Utilities/VisualStudioProjectTemplates/EdFi.ProjectTemplates.Extensions/EdFi.Ods.Extensions.ExtensionName.nuspec
@@ -15,6 +15,6 @@
     <file src="Versions/$extensionversion$/Standard/$standardversion$/Artifacts/**/*.sql" target="."/>
     <file src="Versions/$extensionversion$/Standard/$standardversion$/Artifacts/**/*.json" target="."/>
     <file src="assemblyMetadata.json" target="."/>
-    <file src="bin\$configuration$\net6.0\$safeprojectname$.dll" target="."/>
+    <file src="bin\$configuration$\net8.0\$safeprojectname$.dll" target="."/>
   </files>
 </package>

--- a/Utilities/VisualStudioProjectTemplates/EdFi.ProjectTemplates.Extensions/Template_Project.csproj
+++ b/Utilities/VisualStudioProjectTemplates/EdFi.ProjectTemplates.Extensions/Template_Project.csproj
@@ -4,7 +4,7 @@
 		<ExtensionVersion Condition="'$(ExtensionVersion)' == '' ">1.0.0</ExtensionVersion>
   </PropertyGroup>	
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <AssemblyName>$safeprojectname$</AssemblyName>
     <RestorePackages>true</RestorePackages>
@@ -15,7 +15,7 @@
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
   </ItemGroup>

--- a/Utilities/VisualStudioProjectTemplates/EdFi.ProjectTemplates.Profiles/Template_Project.csproj
+++ b/Utilities/VisualStudioProjectTemplates/EdFi.ProjectTemplates.Profiles/Template_Project.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>$safeprojectname$</AssemblyName>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <RestorePackages>true</RestorePackages>


### PR DESCRIPTION
I've tested that:
- A Composite/Profile/Extension project gets generated using net8 and works when added to the API.
- Calling nuget pack on the Extension's .nuspec works as expected.
- The .vsix gets installed and uninstalled successfully.