### PR TITLE
[ODS-6266] Cherry Picked from ODS-6045 Role-named fields in EdOrg Only and People Only authorization strategies do not apply appropriate filters

### DIFF
--- a/Application/EdFi.Ods.Api/Security/Authorization/EducationOrganizationIdNamesProvider.cs
+++ b/Application/EdFi.Ods.Api/Security/Authorization/EducationOrganizationIdNamesProvider.cs
@@ -57,7 +57,14 @@ namespace EdFi.Ods.Api.Security.Authorization
         /// <inheritdoc cref="IEducationOrganizationIdNamesProvider.IsEducationOrganizationIdName" />
         public bool IsEducationOrganizationIdName(string candidateName)
         {
-            return _sortedEducationOrganizationIdNames.Value.BinarySearch(candidateName) >= 0;
+            // First look for an exact match (no role name)
+            if (_sortedEducationOrganizationIdNames.Value.BinarySearch(candidateName) >= 0)
+            {
+                return true;
+            }
+
+            // Now check iteratively through known names as a matching suffix on the property name (allowing for a role name)
+            return _sortedEducationOrganizationIdNames.Value.Any(candidateName.EndsWith);
         }
     }
 }

--- a/Application/EdFi.Ods.Api/Security/Authorization/IEducationOrganizationIdNamesProvider.cs
+++ b/Application/EdFi.Ods.Api/Security/Authorization/IEducationOrganizationIdNamesProvider.cs
@@ -23,10 +23,10 @@ namespace EdFi.Ods.Api.Security.Authorization
         string[] GetConcreteNames();
 
         /// <summary>
-        /// Indicates whether the supplied name is a known education organization id.
+        /// Indicates whether the supplied name is a known education organization id, allowing for the presence of role names.
         /// </summary>
         /// <param name="candidateName">The name to be evaluated.</param>
-        /// <returns><b>true</b> if the name matches a known education organization id; otherwise <b>false</b>.</returns>
+        /// <returns><b>true</b> if the name matches a known education organization id as a suffix; otherwise <b>false</b>.</returns>
         bool IsEducationOrganizationIdName(string candidateName);
     }
 }

--- a/Application/EdFi.Ods.Common/Specifications/UniqueIdSpecification.cs
+++ b/Application/EdFi.Ods.Common/Specifications/UniqueIdSpecification.cs
@@ -11,8 +11,8 @@ namespace EdFi.Ods.Common.Specifications
 {
     public static class UniqueIdSpecification
     {
-        private const string USI = "USI";
-        private const string UniqueId = "UniqueId";
+        public const string USI = "USI";
+        public const string UniqueId = "UniqueId";
 
         public static string GetUniqueIdPersonType(string propertyName)
         {


### PR DESCRIPTION
Role-named fields in EdOrg Only and People Only authorization strategies do not apply appropriate filters