### PR TITLE
[ODS-4830] Add Secret Support to the Load Tools

### DIFF
--- a/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj
+++ b/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj
@@ -17,6 +17,7 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackAsTool>true</PackAsTool>
     <PackageId>EdFi.BulkLoadClient.Console</PackageId>
+    <UserSecretsId>8562c1b6-4865-4db2-97dd-b7bad8f54d69</UserSecretsId>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>DEBUG;TRACE</DefineConstants>
@@ -40,6 +41,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EdFi.LoadTools\EdFi.LoadTools.csproj" />

--- a/Utilities/DataLoading/EdFi.BulkLoadClient.Console/Program.cs
+++ b/Utilities/DataLoading/EdFi.BulkLoadClient.Console/Program.cs
@@ -58,6 +58,7 @@ namespace EdFi.BulkLoadClient.Console
                     .SetBasePath(Directory.GetParent(AppContext.BaseDirectory).FullName)
                     .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
                     .AddCommandLine(args, CommandLineOverrides.SwitchingMapping())
+                    .AddUserSecrets<CommandLineOverrides>()
                     .Build();
 
                 // apply the command line args overrides for boolean values

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
@@ -17,6 +17,7 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackAsTool>true</PackAsTool>
     <PackageId>EdFi.SmokeTest.Console</PackageId>
+    <UserSecretsId>5e04e4d3-afef-4845-9dd8-23d0153c2b6f</UserSecretsId>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -44,6 +45,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/Program.cs
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/Program.cs
@@ -61,6 +61,7 @@ namespace EdFi.SmokeTest.Console
                     .SetBasePath(Directory.GetParent(AppContext.BaseDirectory).FullName)
                     .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
                     .AddCommandLine(args, CommandLineOverrides.SwitchingMapping())
+                    .AddUserSecrets<CommandLineOverrides>()
                     .Build();
 
                 await SetOdsEndpoints(configRoot);


### PR DESCRIPTION
Steps to test:

- Open **LoadTools.sln** in VS2022
- Right-click on either the **EdFi.BulkLoadClient.Console** or **EdFi.SmokeTest.Console** project
- Click "**Manage User Secrets**" in the context menu - this should open an empty **secrets.json** file
- Save an API key and secret in the **secrets.json** file using the following format
```
{
  "OdsApi:Key": "your key",
  "OdsApi:Secret": "your secret"
}
```
- Run the console application and observe that the key and secret saved in **secrets.json** are used, overriding any values provided in **appsettings.json** or as command line arguments