### PR TITLE
[ODS-3746] Update EdFi.LoadTools.Test to use FakeItEasy

### DIFF
--- a/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
@@ -30,12 +30,12 @@
     <ItemGroup>
       <PackageReference Include="EdFi.Suite3.Common" Version="7.2.99" />
       <PackageReference Include="aqua-graphcompare" Version="1.3.0" />
+      <PackageReference Include="FakeItEasy" Version="8.1.0" />
       <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
       <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
       <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.2" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
       <PackageReference Include="log4net" Version="2.0.15" />
-      <PackageReference Include="Moq" Version="4.20.70" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="NUnit" Version="4.0.1" />
       <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/APIGetTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/APIGetTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using EdFi.LoadTools.ApiClient;
 using EdFi.LoadTools.Engine;
 using EdFi.LoadTools.SmokeTest.ApiTests;
+using FakeItEasy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -18,7 +19,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers;
-using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -85,7 +85,7 @@ namespace EdFi.LoadTools.Test.SmokeTests
 
         private OpenApiDocument _doc;
 
-        private readonly IOAuthTokenHandler _tokenHandler = Mock.Of<IOAuthTokenHandler>();
+        private readonly IOAuthTokenHandler _tokenHandler = A.Fake<IOAuthTokenHandler>();
 
         private Resource _resource;
 
@@ -185,7 +185,8 @@ namespace EdFi.LoadTools.Test.SmokeTests
         {
             var dictionary = new Dictionary<string, JArray>();
 
-            var configuration = Mock.Of<IApiConfiguration>(cfg => cfg.Url == Address);
+            var configuration = A.Fake<IApiConfiguration>();
+            A.CallTo(() => configuration.Url).Returns(Address);
 
             var subject = new GetAllTest(_resource, dictionary, configuration, _tokenHandler);
             var result = await subject.PerformTest();
@@ -199,7 +200,9 @@ namespace EdFi.LoadTools.Test.SmokeTests
         {
             var dictionary = new Dictionary<string, JArray> { [ResourceName] = _data };
 
-            var configuration = Mock.Of<IApiConfiguration>(cfg => cfg.Url == Address);
+            var configuration = A.Fake<IApiConfiguration>();
+            A.CallTo(() => configuration.Url).Returns(Address);
+
             var subject = new GetAllSkipLimitTest(_resource, dictionary, configuration, _tokenHandler);
             var result = await subject.PerformTest();
 
@@ -211,7 +214,9 @@ namespace EdFi.LoadTools.Test.SmokeTests
         {
             var dictionary = new Dictionary<string, JArray> { [ResourceName] = _data };
 
-            var configuration = Mock.Of<IApiConfiguration>(cfg => cfg.Url == Address);
+            var configuration = A.Fake<IApiConfiguration>();
+            A.CallTo(() => configuration.Url).Returns(Address);
+
             var subject = new GetByIdTest(_resource, dictionary, configuration, _tokenHandler);
             var result = await subject.PerformTest();
 
@@ -223,7 +228,9 @@ namespace EdFi.LoadTools.Test.SmokeTests
         {
             var dictionary = new Dictionary<string, JArray> { [ResourceName] = _data };
 
-            var configuration = Mock.Of<IApiConfiguration>(cfg => cfg.Url == Address);
+            var configuration = A.Fake<IApiConfiguration>();
+            A.CallTo(() => configuration.Url).Returns(Address);
+
             var subject = new GetByExampleTest(_resource, dictionary, configuration, _tokenHandler);
             var result = await subject.PerformTest();
 

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/GetDependenciesTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/GetDependenciesTests.cs
@@ -6,12 +6,12 @@
 using System.Threading.Tasks;
 using EdFi.LoadTools.Engine;
 using EdFi.LoadTools.SmokeTest.CommonTests;
+using FakeItEasy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Moq;
 using NUnit.Framework;
 using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
@@ -62,7 +62,9 @@ namespace EdFi.LoadTools.Test.SmokeTests
         [Test]
         public async Task Should_succeed_against_a_running_serverAsync()
         {
-            var configuration = Mock.Of<IApiMetadataConfiguration>(cfg => cfg.Url == _address);
+            var configuration = A.Fake<IApiMetadataConfiguration>();
+            A.CallTo(() => configuration.Url).Returns(_address);
+
             var subject = new GetStaticDependenciesTest(configuration);
             var result = await subject.PerformTest();
             Assert.IsTrue(result);
@@ -72,7 +74,10 @@ namespace EdFi.LoadTools.Test.SmokeTests
         public async Task Should_fail_against_no_serverAsync()
         {
             const string DependenciesUrl = "http://localhost:12345";
-            var configuration = Mock.Of<IApiMetadataConfiguration>(cfg => cfg.DependenciesUrl == DependenciesUrl);
+
+            var configuration = A.Fake<IApiMetadataConfiguration>();
+            A.CallTo(() => configuration.DependenciesUrl).Returns(DependenciesUrl);
+
             var subject = new GetStaticDependenciesTest(configuration);
             var result = await subject.PerformTest();
             Assert.IsFalse(result);

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/GetVersionTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/GetVersionTests.cs
@@ -6,12 +6,12 @@
 using System.Threading.Tasks;
 using EdFi.LoadTools.Engine;
 using EdFi.LoadTools.SmokeTest.CommonTests;
+using FakeItEasy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Moq;
 using NUnit.Framework;
 using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
@@ -62,7 +62,9 @@ namespace EdFi.LoadTools.Test.SmokeTests
         [Test]
         public async Task Should_succeed_against_a_running_serverAsync()
         {
-            var configuration = Mock.Of<IApiMetadataConfiguration>(cfg => cfg.Url == _address);
+            var configuration = A.Fake<IApiMetadataConfiguration>();
+            A.CallTo(() => configuration.Url).Returns(_address);
+
             var subject = new GetStaticVersionTest(configuration);
             var result = await subject.PerformTest();
             Assert.IsTrue(result);
@@ -72,7 +74,10 @@ namespace EdFi.LoadTools.Test.SmokeTests
         public async Task Should_fail_against_no_serverAsync()
         {
             const string Url = "http://localhost:12345";
-            var configuration = Mock.Of<IApiMetadataConfiguration>(cfg => cfg.Url == Url);
+
+            var configuration = A.Fake<IApiMetadataConfiguration>();
+            A.CallTo(() => configuration.Url).Returns(Url);
+
             var subject = new GetStaticVersionTest(configuration);
             var result = await subject.PerformTest();
             Assert.IsFalse(result);

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/ModelDependencySortTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/ModelDependencySortTests.cs
@@ -10,7 +10,7 @@ using EdFi.LoadTools.Engine;
 using EdFi.LoadTools.SmokeTest;
 using EdFi.LoadTools.SmokeTest.SdkTests;
 using EdFi.OdsApi.Sdk.Apis.All;
-using Moq;
+using FakeItEasy;
 using NUnit.Framework;
 using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
@@ -19,25 +19,30 @@ namespace EdFi.LoadTools.Test.SmokeTests
     [TestFixture]
     public class DirectedGraphTests
     {
-        private static readonly ISdkLibraryFactory SdkLibraryFactory =
-            Mock.Of<ISdkLibraryFactory>(f => f.SdkLibrary == typeof(AcademicWeeksApi).Assembly);
+        private static readonly ISdkLibraryFactory _sdkLibraryFactory = FakeItEasy.A.Fake<ISdkLibraryFactory>();
+
+        [SetUp]
+        public void SetUp()
+        {
+            FakeItEasy.A.CallTo(() => _sdkLibraryFactory.SdkLibrary).Returns(typeof(AcademicWeeksApi).Assembly);
+        }
 
         [Test]
         public void Should_order_types()
         {
-            var cat = Mock.Of<ISdkCategorizer>(
-                c => c.ModelTypes == new[]
-                {
-                    typeof(A),
-                    typeof(B),
-                    typeof(C),
-                    typeof(D),
-                    typeof(DReference),
-                    typeof(E),
-                    typeof(EReference),
-                    typeof(FType),
-                    typeof(FDescriptor)
-                });
+            var cat = FakeItEasy.A.Fake<ISdkCategorizer>();
+            FakeItEasy.A.CallTo(() => cat.ModelTypes).Returns(new[]
+            {
+                typeof(A),
+                typeof(B),
+                typeof(C),
+                typeof(D),
+                typeof(DReference),
+                typeof(E),
+                typeof(EReference),
+                typeof(FType),
+                typeof(FDescriptor)
+            });
 
             var mds = new ModelDependencySort(cat);
             var sortedResult = mds.OrderedModels().ToList();
@@ -66,13 +71,13 @@ namespace EdFi.LoadTools.Test.SmokeTests
         [Test]
         public void Should_resolve_longer_reference()
         {
-            var cat = Mock.Of<ISdkCategorizer>(
-                c => c.ModelTypes == new[]
-                {
-                    typeof(Alpha),
-                    typeof(BravoCharlieType),
-                    typeof(AlphaBravoCharlieType)
-                });
+            var cat = FakeItEasy.A.Fake<ISdkCategorizer>();
+            FakeItEasy.A.CallTo(() => cat.ModelTypes).Returns(new[]
+            {
+                typeof(Alpha), 
+                typeof(BravoCharlieType), 
+                typeof(AlphaBravoCharlieType)
+            });
 
             var mds = new ModelDependencySort(cat);
             var sortedResult = mds.OrderedModels().ToList();
@@ -90,7 +95,7 @@ namespace EdFi.LoadTools.Test.SmokeTests
         [Category("RunManually")]
         public void Should_order_types_from_Sdk()
         {
-            var cat = new SdkCategorizer(SdkLibraryFactory);
+            var cat = new SdkCategorizer(_sdkLibraryFactory);
             var mds = new ModelDependencySort(cat);
             var sortedResult = mds.OrderedModels().ToArray();
 
@@ -104,7 +109,7 @@ namespace EdFi.LoadTools.Test.SmokeTests
         [Category("RunManually")]
         public void Should_order_Apis_from_Sdk()
         {
-            var cat = new SdkCategorizer(SdkLibraryFactory);
+            var cat = new SdkCategorizer(_sdkLibraryFactory);
             var mds = new ModelDependencySort(cat);
             var sortedResult = mds.OrderedApis().ToArray();
 

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/PropertyBuilderTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/PropertyBuilderTests.cs
@@ -9,8 +9,8 @@ using System.Globalization;
 using EdFi.LoadTools.Engine;
 using EdFi.LoadTools.SmokeTest;
 using EdFi.LoadTools.SmokeTest.PropertyBuilders;
+using FakeItEasy;
 using Microsoft.OpenApi.Models;
-using Moq;
 using NUnit.Framework;
 using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
@@ -43,7 +43,7 @@ namespace EdFi.LoadTools.Test.SmokeTests
                        };
 
             var propInfo = typeof(Class1).GetProperty("class2Property1");
-            var builder = new ExistingResourceBuilder(dict, Mock.Of<IPropertyInfoMetadataLookup>());
+            var builder = new ExistingResourceBuilder(dict, A.Fake<IPropertyInfoMetadataLookup>());
             Assert.IsTrue(builder.BuildProperty(obj, propInfo));
             Assert.IsNotNull(obj.class2Property1);
         }
@@ -58,12 +58,12 @@ namespace EdFi.LoadTools.Test.SmokeTests
             var obj = new Class1();
             var propInfo = typeof(Class1).GetProperty("listProperty1");
 
-            var propInfoMetadataLookup =
-                Mock.Of<IPropertyInfoMetadataLookup>(
-                    x => x.GetMetadata(propInfo) == new OpenApiParameter
-                                                    {
-                                                        Required = true
-                                                    });
+            var propInfoMetadataLookup = A.Fake<IPropertyInfoMetadataLookup>();
+            A.CallTo(() => propInfoMetadataLookup.GetMetadata(propInfo))
+                .Returns(new OpenApiParameter
+                {
+                    Required = true
+                });
 
             var builder = new ListPropertyBuilder(propInfoMetadataLookup);
             Assert.IsTrue(builder.BuildProperty(obj, propInfo));
@@ -94,7 +94,7 @@ namespace EdFi.LoadTools.Test.SmokeTests
                        };
 
             var propInfo = typeof(Class1).GetProperty("class2ReferenceProperty");
-            var builder = new ReferencePropertyBuilder(dict, Mock.Of<IPropertyInfoMetadataLookup>());
+            var builder = new ReferencePropertyBuilder(dict, A.Fake<IPropertyInfoMetadataLookup>());
             Assert.IsTrue(builder.BuildProperty(obj, propInfo));
             Assert.IsNotNull(obj.class2ReferenceProperty);
             Assert.AreEqual(5, obj.class2ReferenceProperty.intProperty);
@@ -110,13 +110,13 @@ namespace EdFi.LoadTools.Test.SmokeTests
             var obj = new Class1();
             var propInfo = typeof(Class1).GetProperty("stringProperty1");
 
-            var lookup = Mock.Of<IPropertyInfoMetadataLookup>(
-                f =>
-                    f.GetMetadata(propInfo) == new OpenApiParameter
-                                               {
-                                                   Required = true,
-                                                   Schema = new OpenApiSchema()
-                                               });
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+            A.CallTo(() => lookup.GetMetadata(propInfo))
+                .Returns(new OpenApiParameter
+                {
+                    Required = true,
+                    Schema = new OpenApiSchema()
+                });
 
             var builder = new StringPropertyBuilder(lookup);
             Assert.IsTrue(builder.BuildProperty(obj, propInfo));
@@ -135,12 +135,12 @@ namespace EdFi.LoadTools.Test.SmokeTests
             var obj = new Class1();
             var propInfo = typeof(Class1).GetProperty("startTime");
 
-            var lookup = Mock.Of<IPropertyInfoMetadataLookup>(
-                f =>
-                    f.GetMetadata(propInfo) == new OpenApiParameter
-                                               {
-                                                   Required = true
-                                               });
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+            A.CallTo(() => lookup.GetMetadata(propInfo))
+                .Returns(new OpenApiParameter
+                {
+                    Required = true,
+                });
 
             var builder = new TimeStringPropertyBuilder(lookup);
             Assert.IsTrue(builder.BuildProperty(obj, propInfo));
@@ -161,7 +161,7 @@ namespace EdFi.LoadTools.Test.SmokeTests
         {
             var obj = new Class1();
             var propInfo = typeof(Class1).GetProperty("testUniqueId");
-            var builder = new UniqueIdPropertyBuilder(Mock.Of<IPropertyInfoMetadataLookup>());
+            var builder = new UniqueIdPropertyBuilder(A.Fake<IPropertyInfoMetadataLookup>());
             Assert.IsTrue(builder.BuildProperty(obj, propInfo));
             Assert.IsFalse(string.IsNullOrEmpty(obj.testUniqueId));
         }
@@ -176,12 +176,13 @@ namespace EdFi.LoadTools.Test.SmokeTests
             var obj = new Class1();
             var propInfo = typeof(Class1).GetProperty("dateTimeProperty1");
 
-            var lookup = Mock.Of<IPropertyInfoMetadataLookup>(
-                f =>
-                    f.GetMetadata(propInfo) == new OpenApiParameter
-                    {
-                        Required = true
-                    });
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+            A.CallTo(() => lookup.GetMetadata(propInfo))
+                .Returns(new OpenApiParameter
+                {
+                    Required = true
+                });
+
             var builder = new DateTimePropertyBuilder(lookup);
             Assert.IsTrue(builder.BuildProperty(obj, propInfo));
             Assert.AreNotEqual(obj.dateTimeProperty1, default(DateTime));
@@ -192,12 +193,12 @@ namespace EdFi.LoadTools.Test.SmokeTests
         {
             var obj = new Class1();
             var propInfo = typeof(Class1).GetProperty("dateTimeProperty1");
-            var lookup = Mock.Of<IPropertyInfoMetadataLookup>(
-                f =>
-                    f.GetMetadata(propInfo) == new OpenApiParameter
-                    {
-                        Required = false
-                    });
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+            A.CallTo(() => lookup.GetMetadata(propInfo))
+                .Returns(new OpenApiParameter
+                {
+                    Required = false
+                });
 
             var builder = new DateTimePropertyBuilder(lookup);
             Assert.IsTrue(builder.BuildProperty(obj, propInfo));
@@ -234,7 +235,7 @@ namespace EdFi.LoadTools.Test.SmokeTests
 
             public string _etag { get; set; }
 
-            public string _lastModifiedDate { get;set; }
+            public string _lastModifiedDate { get; set; }
         }
 
         private class Class2
@@ -263,7 +264,7 @@ namespace EdFi.LoadTools.Test.SmokeTests
         {
             var obj = new Class1();
             var propInfo = typeof(Class1).GetProperty("id");
-            var builder = new IgnorePropertyBuilder(Mock.Of<IPropertyInfoMetadataLookup>());
+            var builder = new IgnorePropertyBuilder(A.Fake<IPropertyInfoMetadataLookup>());
             Assert.IsTrue(builder.BuildProperty(obj, propInfo));
             Assert.IsTrue(string.IsNullOrEmpty(obj.id));
         }
@@ -273,7 +274,7 @@ namespace EdFi.LoadTools.Test.SmokeTests
         {
             var obj = new Class1();
             var propInfo = typeof(Class1).GetProperty("_etag");
-            var builder = new IgnorePropertyBuilder(Mock.Of<IPropertyInfoMetadataLookup>());
+            var builder = new IgnorePropertyBuilder(A.Fake<IPropertyInfoMetadataLookup>());
             Assert.IsTrue(builder.BuildProperty(obj, propInfo));
             Assert.IsTrue(string.IsNullOrEmpty(obj._etag));
         }
@@ -283,7 +284,7 @@ namespace EdFi.LoadTools.Test.SmokeTests
         {
             var obj = new Class1();
             var propInfo = typeof(Class1).GetProperty("link");
-            var builder = new IgnorePropertyBuilder(Mock.Of<IPropertyInfoMetadataLookup>());
+            var builder = new IgnorePropertyBuilder(A.Fake<IPropertyInfoMetadataLookup>());
             Assert.IsTrue(builder.BuildProperty(obj, propInfo));
             Assert.IsNull(obj.link);
         }
@@ -293,7 +294,7 @@ namespace EdFi.LoadTools.Test.SmokeTests
         {
             var obj = new Class1();
             var propInfo = typeof(Class1).GetProperty("_lastModifiedDate");
-            var builder = new IgnorePropertyBuilder(Mock.Of<IPropertyInfoMetadataLookup>());
+            var builder = new IgnorePropertyBuilder(A.Fake<IPropertyInfoMetadataLookup>());
             Assert.IsTrue(builder.BuildProperty(obj, propInfo));
             Assert.IsNull(obj._lastModifiedDate);
         }
@@ -308,14 +309,14 @@ namespace EdFi.LoadTools.Test.SmokeTests
             var obj = new Class1();
             var propInfo = typeof(Class1).GetProperty("nullableProperty1");
 
-            var lookup = Mock.Of<IPropertyInfoMetadataLookup>(
-                f =>
-                    f.GetMetadata(propInfo) == new OpenApiParameter
-                                               {
-                                                   Required = false
-                                               });
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+            A.CallTo(() => lookup.GetMetadata(propInfo))
+                .Returns(new OpenApiParameter
+                {
+                    Required = false
+                });
 
-            var builder = new SimplePropertyBuilder(lookup, Mock.Of<IDestructiveTestConfiguration>());
+            var builder = new SimplePropertyBuilder(lookup, A.Fake<IDestructiveTestConfiguration>());
             Assert.IsTrue(builder.BuildProperty(obj, propInfo));
             Assert.IsFalse(obj.nullableProperty1.HasValue);
         }
@@ -326,15 +327,15 @@ namespace EdFi.LoadTools.Test.SmokeTests
             var obj = new Class1();
             var propInfo = typeof(Class1).GetProperty("nullableProperty1");
 
-            var lookup = Mock.Of<IPropertyInfoMetadataLookup>(
-                f =>
-                    f.GetMetadata(propInfo) == new OpenApiParameter
-                                               {
-                                                   Required = true,
-                                                   Schema = new OpenApiSchema()
-                                               });
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+            A.CallTo(() => lookup.GetMetadata(propInfo))
+                .Returns(new OpenApiParameter
+                {
+                    Required = true,
+                    Schema = new OpenApiSchema()
+                });
 
-            var builder = new SimplePropertyBuilder(lookup, Mock.Of<IDestructiveTestConfiguration>());
+            var builder = new SimplePropertyBuilder(lookup, A.Fake<IDestructiveTestConfiguration>());
             Assert.IsTrue(builder.BuildProperty(obj, propInfo));
             Assert.AreNotEqual(default(int), obj.nullableProperty1);
         }
@@ -345,14 +346,14 @@ namespace EdFi.LoadTools.Test.SmokeTests
             var obj = new Class1();
             var propInfo = typeof(Class1).GetProperty("nullableProperty1");
 
-            var lookup = Mock.Of<IPropertyInfoMetadataLookup>(
-                f =>
-                    f.GetMetadata(propInfo) == new OpenApiParameter
-                                               {
-                                                   Required = false
-                                               });
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+            A.CallTo(() => lookup.GetMetadata(propInfo))
+                .Returns(new OpenApiParameter
+                {
+                    Required = false
+                });
 
-            var builder = new SimplePropertyBuilder(lookup, Mock.Of<IDestructiveTestConfiguration>());
+            var builder = new SimplePropertyBuilder(lookup, A.Fake<IDestructiveTestConfiguration>());
             Assert.IsTrue(builder.BuildProperty(obj, propInfo));
             Assert.AreEqual(default(int?), obj.nullableProperty1);
         }

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/XsdFileRetrieverTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/XsdFileRetrieverTests.cs
@@ -56,7 +56,7 @@ namespace EdFi.LoadTools.Test
                     new Dictionary<string, string>
                     {
                         {"name", "Ed-Fi"},
-                        {"version", "3.3.1-b"}
+                        {"version", "5.0.0"}
                     },
                     new Dictionary<string, string>
                     {
@@ -65,6 +65,8 @@ namespace EdFi.LoadTools.Test
                     }
                 }
             };
+
+            _configuration.Extension = "TPDM";
 
             using var sut = new XsdFilesRetriever(
                 _configuration,


### PR DESCRIPTION
This transitions the LoadTools tests from Moq to FakeItEasy. The changes include updating package references, replacing `Mock.Of` with `A.Fake`, and utilizing `A.CallTo().Returns()` for property setups. Additionally, there's a change in `XsdFileRetrieverTests`, which updates the expected data standard to "**5.0.0**" and adds the "**TPDM**" extension, which is required for the manual test `Should_get_xsd_metadata_information_and_download_files` to pass when running against the latest initdev ODS deployment.