### PR TITLE
[ODS-6349] Profiles expiration doesn't clear mapping contracts

### DIFF
--- a/Application/EdFi.Ods.Api/Container/Modules/ApplicationModule.cs
+++ b/Application/EdFi.Ods.Api/Container/Modules/ApplicationModule.cs
@@ -26,6 +26,7 @@ using EdFi.Ods.Api.Jobs.Extensions;
 using EdFi.Ods.Api.Middleware;
 using EdFi.Ods.Api.Providers;
 using EdFi.Ods.Api.Security.Authentication;
+using EdFi.Ods.Api.Serialization;
 using EdFi.Ods.Api.Validation;
 using EdFi.Ods.Common;
 using EdFi.Ods.Common.Caching;
@@ -47,16 +48,15 @@ using EdFi.Ods.Common.ProblemDetails;
 using EdFi.Ods.Common.Providers;
 using EdFi.Ods.Common.Security;
 using EdFi.Ods.Common.Specifications;
-using EdFi.Ods.Common.Utils;
 using EdFi.Ods.Common.Validation;
 using FluentValidation;
 using log4net;
-using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Serialization;
 using Module = Autofac.Module;
 
 namespace EdFi.Ods.Api.Container.Modules
@@ -91,6 +91,15 @@ namespace EdFi.Ods.Api.Container.Modules
             // api model conventions should be singletons
             builder.RegisterType<MvcOptionsConfigurator>()
                 .As<IConfigureOptions<MvcOptions>>()
+                .SingleInstance();
+
+            builder.RegisterType<ProfilesAwareContractResolver>()
+                .WithProperty("NamingStrategy", 
+                    new CamelCaseNamingStrategy
+                    {
+                        ProcessDictionaryKeys = true,
+                        OverrideSpecifiedNames = true
+                    })
                 .SingleInstance();
 
             builder.RegisterType<VersionRouteConvention>()

--- a/Application/EdFi.Ods.Api/Filters/EnforceAssignedProfileUsageFilter.cs
+++ b/Application/EdFi.Ods.Api/Filters/EnforceAssignedProfileUsageFilter.cs
@@ -22,7 +22,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace EdFi.Ods.Api.Filters;
 
-public class EnforceAssignedProfileUsageFilter : IAsyncActionFilter
+public class EnforceAssignedProfileUsageFilter : IAsyncResourceFilter
 {
     private readonly IApiClientContextProvider _apiClientContextProvider;
     private readonly IContextProvider<DataManagementResourceContext> _dataManagementResourceContextProvider;
@@ -49,7 +49,7 @@ public class EnforceAssignedProfileUsageFilter : IAsyncActionFilter
         _isEnabled = apiSettings.IsFeatureEnabled("Profiles");
     }
 
-    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
     {
         // If Profiles feature is not enabled, don't do any processing.
         if (!_isEnabled)

--- a/Application/EdFi.Ods.Api/Serialization/ProfilesAwareContractResolver.cs
+++ b/Application/EdFi.Ods.Api/Serialization/ProfilesAwareContractResolver.cs
@@ -8,8 +8,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 using EdFi.Ods.Common;
 using EdFi.Ods.Common.Context;
 using EdFi.Ods.Common.Models;
@@ -17,13 +15,13 @@ using EdFi.Ods.Common.Models.Domain;
 using EdFi.Ods.Common.Profiles;
 using EdFi.Ods.Common.Security.Claims;
 using EdFi.Ods.Common.Utils.Profiles;
-using MediatR;
+using log4net;
 using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json.Serialization;
 
 namespace EdFi.Ods.Api.Serialization;
 
-public class ProfilesAwareContractResolver : DefaultContractResolver, INotificationHandler<ProfileMetadataCacheExpired>
+public class ProfilesAwareContractResolver : DefaultContractResolver
 {
     private static readonly string[] _extensionsInArray = { "Extensions" };
     private static readonly string[] _metadataProperties =
@@ -43,6 +41,7 @@ public class ProfilesAwareContractResolver : DefaultContractResolver, INotificat
     private readonly string _resourcesNamespacePrefix = $"{Namespaces.Resources.BaseNamespace}.";
     private readonly ISchemaNameMapProvider _schemaNameMapProvider;
     private static readonly char[] _decimalAsCharArray = { '.' };
+    private readonly ILog _logger = LogManager.GetLogger(typeof(ProfilesAwareContractResolver));
 
     public ProfilesAwareContractResolver(
         IContextProvider<ProfileContentTypeContext> profileContentTypeContextProvider,
@@ -216,10 +215,13 @@ public class ProfilesAwareContractResolver : DefaultContractResolver, INotificat
         return profileConstrainedMembers;
     }
 
-    public Task Handle(ProfileMetadataCacheExpired notification, CancellationToken cancellationToken)
+    public void Clear()
     {
-        _contractByKey.Clear();
+        if (_logger.IsDebugEnabled)
+        {
+            _logger.Debug("Clears profile contracts due to profile metadata cache expiration...");
+        }
 
-        return Task.CompletedTask;
+        _contractByKey.Clear();
     }
 }

--- a/Application/EdFi.Ods.Api/Serialization/ProfilesAwareContractResolver.cs
+++ b/Application/EdFi.Ods.Api/Serialization/ProfilesAwareContractResolver.cs
@@ -8,6 +8,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using EdFi.Ods.Common;
 using EdFi.Ods.Common.Context;
 using EdFi.Ods.Common.Models;
@@ -15,12 +17,13 @@ using EdFi.Ods.Common.Models.Domain;
 using EdFi.Ods.Common.Profiles;
 using EdFi.Ods.Common.Security.Claims;
 using EdFi.Ods.Common.Utils.Profiles;
+using MediatR;
 using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json.Serialization;
 
 namespace EdFi.Ods.Api.Serialization;
 
-public class ProfilesAwareContractResolver : DefaultContractResolver
+public class ProfilesAwareContractResolver : DefaultContractResolver, INotificationHandler<ProfileMetadataCacheExpired>
 {
     private static readonly string[] _extensionsInArray = { "Extensions" };
     private static readonly string[] _metadataProperties =
@@ -211,5 +214,12 @@ public class ProfilesAwareContractResolver : DefaultContractResolver
             .ToList();
 
         return profileConstrainedMembers;
+    }
+
+    public Task Handle(ProfileMetadataCacheExpired notification, CancellationToken cancellationToken)
+    {
+        _contractByKey.Clear();
+
+        return Task.CompletedTask;
     }
 }

--- a/Application/EdFi.Ods.Api/Startup/NewtonsoftJsonOptionConfigurator.cs
+++ b/Application/EdFi.Ods.Api/Startup/NewtonsoftJsonOptionConfigurator.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System;
 using EdFi.Ods.Api.Serialization;
 using EdFi.Ods.Common;
 using EdFi.Ods.Common.Context;
@@ -11,6 +12,7 @@ using EdFi.Ods.Common.Profiles;
 using EdFi.Ods.Common.Security.Claims;
 using EdFi.Ods.Common.Serialization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -23,21 +25,11 @@ namespace EdFi.Ods.Api.Startup;
 /// </summary>
 public class NewtonsoftJsonOptionConfigurator : IConfigureOptions<MvcNewtonsoftJsonOptions>
 {
-    private readonly IContextProvider<ProfileContentTypeContext> _profileContentTypeContextProvider;
-    private readonly IContextProvider<DataManagementResourceContext> _dataManagementResourceContextProvider;
-    private readonly IProfileResourceModelProvider _profileResourceModelProvider;
-    private readonly ISchemaNameMapProvider _schemaNameMapProvider;
+    private readonly IServiceProvider _serviceProvider;
 
-    public NewtonsoftJsonOptionConfigurator(
-        IContextProvider<ProfileContentTypeContext> profileContentTypeContextProvider,
-        IContextProvider<DataManagementResourceContext> dataManagementResourceContextProvider,
-        IProfileResourceModelProvider profileResourceModelProvider,
-        ISchemaNameMapProvider schemaNameMapProvider)
+    public NewtonsoftJsonOptionConfigurator(IServiceProvider serviceProvider)
     {
-        _profileContentTypeContextProvider = profileContentTypeContextProvider;
-        _dataManagementResourceContextProvider = dataManagementResourceContextProvider;
-        _profileResourceModelProvider = profileResourceModelProvider;
-        _schemaNameMapProvider = schemaNameMapProvider;
+        _serviceProvider = serviceProvider;
     }
 
     public void Configure(MvcNewtonsoftJsonOptions options)
@@ -47,18 +39,9 @@ public class NewtonsoftJsonOptionConfigurator : IConfigureOptions<MvcNewtonsoftJ
         options.SerializerSettings.DateParseHandling = DateParseHandling.None;
         options.SerializerSettings.Formatting = Formatting.Indented;
         options.SerializerSettings.Converters = new JsonConverter[] { new Int64Converter() };
-        options.SerializerSettings.ContractResolver 
-            = new ProfilesAwareContractResolver(
-                _profileContentTypeContextProvider, 
-                _dataManagementResourceContextProvider, 
-                _profileResourceModelProvider,
-                _schemaNameMapProvider)
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    ProcessDictionaryKeys = true,
-                    OverrideSpecifiedNames = true
-                }
-            };
+
+        var contactResolver = _serviceProvider.GetService<ProfilesAwareContractResolver>();
+
+        options.SerializerSettings.ContractResolver = contactResolver;
     }
 }

--- a/Application/EdFi.Ods.Common/Models/IMappingContractProvider.cs
+++ b/Application/EdFi.Ods.Common/Models/IMappingContractProvider.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.Ods.Common.Caching;
 using EdFi.Ods.Common.Models.Domain;
 
 namespace EdFi.Ods.Common.Models;
@@ -11,7 +12,7 @@ namespace EdFi.Ods.Common.Models;
 /// Defines a method for obtaining a mapping contract appropriate for a resource/entity in the current context that indicates
 /// what should be mapped/synchronized between entities/resources.
 /// </summary>
-public interface IMappingContractProvider
+public interface IMappingContractProvider : IClearable
 {
     /// <summary>
     /// Gets a mapping contract appropriate for a resource/entity in the current context.

--- a/Application/EdFi.Ods.Common/Models/MappingContractProvider.cs
+++ b/Application/EdFi.Ods.Common/Models/MappingContractProvider.cs
@@ -6,8 +6,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using EdFi.Common;
 using EdFi.Common.Extensions;
 using EdFi.Common.Inflection;
@@ -18,16 +16,17 @@ using EdFi.Ods.Common.Models.Domain;
 using EdFi.Ods.Common.Profiles;
 using EdFi.Ods.Common.Security.Claims;
 using EdFi.Ods.Common.Utils.Profiles;
-using MediatR;
+using log4net;
 
 namespace EdFi.Ods.Common.Models;
 
-public class MappingContractProvider : IMappingContractProvider, INotificationHandler<ProfileMetadataCacheExpired>
+public class MappingContractProvider : IMappingContractProvider
 {
     private readonly IContextProvider<DataManagementResourceContext> _dataManagementResourceContextProvider;
     private readonly IContextProvider<ProfileContentTypeContext> _profileContentTypeContextProvider;
     private readonly IProfileResourceModelProvider _profileResourceModelProvider;
     private readonly ISchemaNameMapProvider _schemaNameMapProvider;
+    private readonly ILog _logger = LogManager.GetLogger(typeof(MappingContractProvider));
 
     private readonly ConcurrentDictionary<MappingContractKey, IMappingContract>
         _mappingContractByKey = new();
@@ -267,11 +266,14 @@ public class MappingContractProvider : IMappingContractProvider, INotificationHa
         return mappingContract;
     }
 
-    public Task Handle(ProfileMetadataCacheExpired notification, CancellationToken cancellationToken)
+    public void Clear()
     {
-        _mappingContractByKey.Clear();
+        if (_logger.IsDebugEnabled)
+        {
+            _logger.Debug("Clears mapping Contracts due to profile metadata cache expiration...");
+        }
 
-        return Task.CompletedTask;
+        _mappingContractByKey.Clear();
     }
 }
 

--- a/Application/EdFi.Ods.Common/Models/MappingContractProvider.cs
+++ b/Application/EdFi.Ods.Common/Models/MappingContractProvider.cs
@@ -6,6 +6,8 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using EdFi.Common;
 using EdFi.Common.Extensions;
 using EdFi.Common.Inflection;
@@ -16,11 +18,11 @@ using EdFi.Ods.Common.Models.Domain;
 using EdFi.Ods.Common.Profiles;
 using EdFi.Ods.Common.Security.Claims;
 using EdFi.Ods.Common.Utils.Profiles;
-using Microsoft.AspNetCore.Http;
+using MediatR;
 
 namespace EdFi.Ods.Common.Models;
 
-public class MappingContractProvider : IMappingContractProvider
+public class MappingContractProvider : IMappingContractProvider, INotificationHandler<ProfileMetadataCacheExpired>
 {
     private readonly IContextProvider<DataManagementResourceContext> _dataManagementResourceContextProvider;
     private readonly IContextProvider<ProfileContentTypeContext> _profileContentTypeContextProvider;
@@ -263,6 +265,13 @@ public class MappingContractProvider : IMappingContractProvider
             this);
 
         return mappingContract;
+    }
+
+    public Task Handle(ProfileMetadataCacheExpired notification, CancellationToken cancellationToken)
+    {
+        _mappingContractByKey.Clear();
+
+        return Task.CompletedTask;
     }
 }
 

--- a/Application/EdFi.Ods.Features/Container/Modules/OpenApiMetadataModule.cs
+++ b/Application/EdFi.Ods.Features/Container/Modules/OpenApiMetadataModule.cs
@@ -29,7 +29,7 @@ namespace EdFi.Ods.Features.Container.Modules
         public override void ApplyConfigurationSpecificRegistrations(ContainerBuilder builder)
         {
             builder.RegisterType<OpenApiMetadataCacheProvider>()
-                .AsImplementedInterfaces()
+                .As<IOpenApiMetadataCacheProvider>()
                 .SingleInstance();
 
             builder.RegisterType<InitializeOpenApiMetadataCache>()

--- a/Application/EdFi.Ods.Features/Container/Modules/ProfilesModule.cs
+++ b/Application/EdFi.Ods.Features/Container/Modules/ProfilesModule.cs
@@ -79,10 +79,6 @@ namespace EdFi.Ods.Features.Container.Modules
                 .As<IAdminProfileNamesPublisher>()
                 .SingleInstance();
 
-            builder.RegisterType<ProfileMetadataCacheExpiredNotificationHandler>()
-                .AsImplementedInterfaces()
-                .SingleInstance();
-
             builder.RegisterType<AdminProfileNamesPublisherTask>()
                 .As<IExternalTask>()
                 .SingleInstance();

--- a/Application/EdFi.Ods.Features/Notifications/ProfilesExpireCacheHandler.cs
+++ b/Application/EdFi.Ods.Features/Notifications/ProfilesExpireCacheHandler.cs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using EdFi.Ods.Common.Caching;
+using EdFi.Ods.Common.Profiles;
+using MediatR;
+
+namespace EdFi.Ods.Features.Notifications;
+
+/// <summary>
+/// Implements a notification handler with additional special handling required for the explicit expiration of profile metadata
+/// by publishing an <see cref="ProfileMetadataCacheExpired" /> message using MediatR.
+/// </summary>
+public class ProfilesExpireCacheHandler : INotificationHandler<ExpireCache>
+{
+    private readonly IMediator _mediator;
+
+    public ProfilesExpireCacheHandler(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public async Task Handle(ExpireCache notification, CancellationToken cancellationToken)
+    {
+        string cacheKey = $"cache-{notification.CacheType?.ToLower()}";
+
+        // If this is not expiring profile metadata, do nothing
+        if (cacheKey != InterceptorCacheKeys.ProfileMetadata)
+        {
+            return;
+        }
+
+        // Publish the notification message related specifically to Profiles expiration
+        await _mediator.Publish(new ProfileMetadataCacheExpired(), cancellationToken);
+    }
+}

--- a/Application/EdFi.Ods.Features/OpenApiMetadata/Providers/OpenApiMetadataCacheProvider.cs
+++ b/Application/EdFi.Ods.Features/OpenApiMetadata/Providers/OpenApiMetadataCacheProvider.cs
@@ -8,26 +8,22 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using EdFi.Common.Extensions;
 using EdFi.Ods.Api.Constants;
 using EdFi.Ods.Api.Models;
 using EdFi.Ods.Api.Providers;
 using EdFi.Ods.Api.Routing;
 using EdFi.Ods.Common.Models;
-using EdFi.Ods.Common.Profiles;
 using EdFi.Ods.Features.OpenApiMetadata.Dtos;
 using EdFi.Ods.Features.OpenApiMetadata.Factories;
 using EdFi.Ods.Features.OpenApiMetadata.Strategies.ResourceStrategies;
 using log4net;
-using MediatR;
 using Microsoft.OpenApi;
 using OpenApiMetadataSections = EdFi.Ods.Api.Constants.OpenApiMetadataSections;
 
 namespace EdFi.Ods.Features.OpenApiMetadata.Providers
 {
-    public class OpenApiMetadataCacheProvider : IOpenApiMetadataCacheProvider, INotificationHandler<ProfileMetadataCacheExpired>
+    public class OpenApiMetadataCacheProvider : IOpenApiMetadataCacheProvider
     {
         private const string Descriptors = "descriptors";
         private const string Resources = "resources";
@@ -110,6 +106,11 @@ namespace EdFi.Ods.Features.OpenApiMetadata.Providers
 
         public void ResetCacheInitialization()
         {
+            if (_logger.IsDebugEnabled)
+            {
+                _logger.Debug("Resetting OpenApiMetadata initialization due to profile metadata cache expiration...");
+            }
+
             // Reset the underlying cache
             _openApiMetadataMetadataCache = new Lazy<ConcurrentDictionary<string, OpenApiContent>>(LazyInitializeCache);
         }
@@ -223,18 +224,6 @@ namespace EdFi.Ods.Features.OpenApiMetadata.Providers
                             : existing);
                 }
             }
-        }
-
-        public Task Handle(ProfileMetadataCacheExpired notification, CancellationToken cancellationToken)
-        {
-            if (_logger.IsDebugEnabled)
-            {
-                _logger.Debug("Resetting OpenApiMetadata initialization due to profile metadata cache expiration...");
-            }
-
-            ResetCacheInitialization();
-
-            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
MediatR registers all handler implementations as Transient, so I grouped all profile-related cached data objects to have the cache cleared by the same handler.