### PR TITLE
[ODS-6394] Added If  Check Condition for RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes

### DIFF
--- a/Application/EdFi.Ods.Standard/Standard/4.0.0/Artifacts/MsSql/Data/Security/2145-Add-RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes-strategy.sql
+++ b/Application/EdFi.Ods.Standard/Standard/4.0.0/Artifacts/MsSql/Data/Security/2145-Add-RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes-strategy.sql
@@ -4,6 +4,11 @@
 -- See the LICENSE and NOTICES files in the project root for more information.
 
 -- Define a new authorization strategy for reading changes when authorizing access to student data through the responsiblity association
-INSERT INTO dbo.AuthorizationStrategies(DisplayName, AuthorizationStrategyName)
-VALUES ('Relationships with Students only (through StudentEducationOrganizationResponsibilityAssociation, including deletes)', 	'RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes')
+
+IF NOT EXISTS(SELECT 1 FROM [dbo].[AuthorizationStrategies] WHERE [AuthorizationStrategyName] ='RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes')
+BEGIN
+    INSERT INTO [dbo].[AuthorizationStrategies] ([DisplayName], [AuthorizationStrategyName])
+    VALUES ('Relationships with Students only (through StudentEducationOrganizationResponsibilityAssociation, including deletes)', 'RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes');
+END
+
 GO

--- a/Application/EdFi.Ods.Standard/Standard/4.0.0/Artifacts/PgSql/Data/Security/2145-Add-RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes-strategy.sql
+++ b/Application/EdFi.Ods.Standard/Standard/4.0.0/Artifacts/PgSql/Data/Security/2145-Add-RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes-strategy.sql
@@ -4,5 +4,14 @@
 -- See the LICENSE and NOTICES files in the project root for more information.
 
 -- Define a new authorization strategy for reading changes when authorizing access to student data through the responsiblity association
-insert into dbo.AuthorizationStrategies(DisplayName, AuthorizationStrategyName)
-values ('Relationships with Students only (through StudentEducationOrganizationResponsibilityAssociation, including deletes)', 	'RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes');
+DO language plpgsql $$
+
+BEGIN
+
+    IF NOT EXISTS(SELECT 1 FROM dbo.AuthorizationStrategies WHERE AuthorizationStrategyName ='RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes') THEN
+
+        INSERT INTO dbo.AuthorizationStrategies (DisplayName, AuthorizationStrategyName)
+        VALUES ('Relationships with Students only (through StudentEducationOrganizationResponsibilityAssociation, including deletes)', 'RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes');
+    END IF;
+
+END $$;

--- a/Application/EdFi.Ods.Standard/Standard/5.1.0/Artifacts/MsSql/Data/Security/2145-Add-RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes-strategy.sql
+++ b/Application/EdFi.Ods.Standard/Standard/5.1.0/Artifacts/MsSql/Data/Security/2145-Add-RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes-strategy.sql
@@ -4,6 +4,10 @@
 -- See the LICENSE and NOTICES files in the project root for more information.
 
 -- Define a new authorization strategy for reading changes when authorizing access to student data through the responsiblity association
-INSERT INTO dbo.AuthorizationStrategies(DisplayName, AuthorizationStrategyName)
-VALUES ('Relationships with Students only (through StudentEducationOrganizationResponsibilityAssociation, including deletes)', 	'RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes')
+IF NOT EXISTS(SELECT 1 FROM [dbo].[AuthorizationStrategies] WHERE [AuthorizationStrategyName] ='RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes')
+BEGIN
+    INSERT INTO [dbo].[AuthorizationStrategies] ([DisplayName], [AuthorizationStrategyName])
+    VALUES ('Relationships with Students only (through StudentEducationOrganizationResponsibilityAssociation, including deletes)', 'RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes');
+END
+
 GO

--- a/Application/EdFi.Ods.Standard/Standard/5.1.0/Artifacts/PgSql/Data/Security/2145-Add-RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes-strategy.sql
+++ b/Application/EdFi.Ods.Standard/Standard/5.1.0/Artifacts/PgSql/Data/Security/2145-Add-RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes-strategy.sql
@@ -3,6 +3,14 @@
 -- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 -- See the LICENSE and NOTICES files in the project root for more information.
 
--- Define a new authorization strategy for reading changes when authorizing access to student data through the responsiblity association
-insert into dbo.AuthorizationStrategies(DisplayName, AuthorizationStrategyName)
-values ('Relationships with Students only (through StudentEducationOrganizationResponsibilityAssociation, including deletes)', 	'RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes');
+DO language plpgsql $$
+
+BEGIN
+
+    IF NOT EXISTS(SELECT 1 FROM dbo.AuthorizationStrategies WHERE AuthorizationStrategyName ='RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes') THEN
+
+        INSERT INTO dbo.AuthorizationStrategies (DisplayName, AuthorizationStrategyName)
+        VALUES ('Relationships with Students only (through StudentEducationOrganizationResponsibilityAssociation, including deletes)', 'RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes');
+    END IF;
+
+END $$;


### PR DESCRIPTION
Upgrading the Security DB:
From EdFi.Suite3.RestApi.Databases.Standard.5.0.0.7.1.1192
To EdFi.Suite3.RestApi.Databases.Standard.5.1.0.7.2.1186

https://dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_artifacts/feed/EdFi/NuGet/EdFi.Suite3.RestApi.Databases.Standard.5.1.0/versions/7.2.1186



SELECT *   FROM [EdFi_Security].[dbo].[DeployJournal]  where ScriptName like '%RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes-strategy%'

SELECT *  FROM [EdFi_Security].[dbo].[AuthorizationStrategies] 
where AuthorizationStrategyName ='RelationshipsWithStudentsOnlyThroughResponsibilityIncludingDeletes'