### PR TITLE
[ODS-6229] Migrate EdFi.Common to .NET 8

### DIFF
--- a/.github/workflows/Lib edFi.common.yml
+++ b/.github/workflows/Lib edFi.common.yml
@@ -18,10 +18,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-    - name: Setup .NET
-      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
-      with:
-        dotnet-version: 3.1.x   
     - name: build
       run: |
         .\build.githubactions.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Solution "Application/EdFi.Common/EdFi.Common.sln" -ProjectFile "Application/EdFi.Common/EdFi.Common.csproj"

--- a/Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj
+++ b/Application/EdFi.Admin.DataAccess/EdFi.Admin.DataAccess.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.395" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.443" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="log4net" Version="2.0.13" />

--- a/Application/EdFi.Common/Database/SqlConnectionStringBuilderAdapter.cs
+++ b/Application/EdFi.Common/Database/SqlConnectionStringBuilderAdapter.cs
@@ -5,7 +5,7 @@
 
 using System;
 using System.Data.Common;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace EdFi.Common.Database
 {

--- a/Application/EdFi.Common/EdFi.Common.csproj
+++ b/Application/EdFi.Common/EdFi.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RestorePackages>true</RestorePackages>
@@ -13,9 +13,9 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="log4net" Version="2.0.13" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="log4net" Version="2.0.17" />
     <PackageReference Include="Npgsql" Version="6.0.11" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
   </ItemGroup>
 </Project>

--- a/Application/EdFi.Common/Security/Pbkdf2HmacSha1SecureHasher.cs
+++ b/Application/EdFi.Common/Security/Pbkdf2HmacSha1SecureHasher.cs
@@ -34,7 +34,7 @@ namespace EdFi.Common.Security
         {
             byte[] bytes;
 
-            using (var rfc2898DeriveBytes = new Rfc2898DeriveBytes(secret, salt, iterations))
+            using (var rfc2898DeriveBytes = new Rfc2898DeriveBytes(secret, salt, iterations, HashAlgorithmName.SHA1))
             {
                 bytes = rfc2898DeriveBytes.GetBytes(32);
             }
@@ -54,7 +54,7 @@ namespace EdFi.Common.Security
             byte[] bytes;
             byte[] salt;
 
-            using (var rfc2898DeriveBytes = new Rfc2898DeriveBytes(secret, saltSizeInBytes, iterations))
+            using (var rfc2898DeriveBytes = new Rfc2898DeriveBytes(secret, saltSizeInBytes, iterations, HashAlgorithmName.SHA1))
             {
                 salt = rfc2898DeriveBytes.Salt;
                 bytes = rfc2898DeriveBytes.GetBytes(32);

--- a/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
+++ b/Application/EdFi.Ods.Api/EdFi.Ods.Api.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.1" />
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.406" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.395" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.443" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.397" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FluentValidation" Version="10.4.0" />

--- a/Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj
+++ b/Application/EdFi.Ods.Common/EdFi.Ods.Common.csproj
@@ -16,7 +16,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.395" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.443" />
     <PackageReference Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
+++ b/Application/EdFi.Ods.Repositories.NHibernate.Tests/EdFi.Ods.Repositories.NHibernate.Tests.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.395" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.443" />
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.397" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />

--- a/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
+++ b/Application/EdFi.Ods.Sandbox/EdFi.Ods.Sandbox.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.406" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.395" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.443" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="Dapper" Version="2.0.123" />

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Autofac.Extras.FakeItEasy" Version="7.0.0" />
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="CompareNETObjects" Version="4.74.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.395" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.443" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFrameworkTesting.FakeItEasy" Version="1.3.0" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />

--- a/Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj
+++ b/Application/EdFi.Security.DataAccess/EdFi.Security.DataAccess.csproj
@@ -15,7 +15,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.395" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.443" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="Npgsql" Version="6.0.11" />

--- a/Application/EdFi.TestObjects/EdFi.TestObjects.csproj
+++ b/Application/EdFi.TestObjects/EdFi.TestObjects.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.395" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.443" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj
+++ b/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Autofac" Version="6.1.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.395" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.443" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
@@ -21,7 +21,7 @@
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="aqua-graphcompare" Version="1.2.2" />
-      <PackageReference Include="EdFi.Suite3.Common" Version="5.4.395" />
+      <PackageReference Include="EdFi.Suite3.Common" Version="5.4.443" />
       <PackageReference Include="EdFi.Suite3.OdsApi.TestSdk" Version="5.3.243" />
       <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
       <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />

--- a/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.1.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.395" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.443" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
     <PackageReference Include="log4net" Version="2.0.13" />

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Autofac" Version="6.1.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.395" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.443" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
     <PackageReference Include="log4net" Version="2.0.13" />

--- a/Utilities/DataLoading/EdFi.XmlLookup.Console/EdFi.XmlLookup.Console.csproj
+++ b/Utilities/DataLoading/EdFi.XmlLookup.Console/EdFi.XmlLookup.Console.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Autofac" Version="6.1.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.395" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.443" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />

--- a/tests/EdFi.Admin.DataAccess.UnitTests/EdFi.Admin.DataAccess.UnitTests.csproj
+++ b/tests/EdFi.Admin.DataAccess.UnitTests/EdFi.Admin.DataAccess.UnitTests.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.395" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.443" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />

--- a/tests/EdFi.Common.UnitTests/EdFi.Common.UnitTests.csproj
+++ b/tests/EdFi.Common.UnitTests/EdFi.Common.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RestorePackages>true</RestorePackages>
@@ -19,27 +19,26 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="FakeItEasy" Version="7.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
+    <PackageReference Include="FakeItEasy" Version="8.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="nunit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.30" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.6" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-	<ProjectReference Include="..\..\Application\EdFi.Common\EdFi.Common.csproj" />
-	<ProjectReference Include="..\EdFi.TestFixture\EdFi.TestFixture.csproj" />
+    <ProjectReference Include="..\..\Application\EdFi.Common\EdFi.Common.csproj" />
+    <ProjectReference Include="..\EdFi.TestFixture\EdFi.TestFixture.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/EdFi.Common.UnitTests/Inflection/InflectorTests.cs
+++ b/tests/EdFi.Common.UnitTests/Inflection/InflectorTests.cs
@@ -6,6 +6,7 @@
 using System.Linq;
 using EdFi.Common.Inflection;
 using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.Ods.Common.UnitTests.Inflection
 {

--- a/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
+++ b/tests/EdFi.Ods.WebApi.CompositeSpecFlowTests/EdFi.Ods.WebApi.CompositeSpecFlowTests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="ApprovalTests" Version="5.7.1" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.395" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.443" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="FluentValidation" Version="10.4.0" />

--- a/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
+++ b/tests/EdFi.Ods.WebApi.IntegrationTests/EdFi.Ods.WebApi.IntegrationTests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="ApprovalUtilities" Version="5.7.1" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.395" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.443" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />

--- a/tests/EdFi.Security.DataAccess.UnitTests/EdFi.Security.DataAccess.UnitTests.csproj
+++ b/tests/EdFi.Security.DataAccess.UnitTests/EdFi.Security.DataAccess.UnitTests.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.395" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.443" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFrameworkTesting.FakeItEasy" Version="1.3.0" />
     <PackageReference Include="FakeItEasy" Version="7.2.0" />

--- a/tests/EdFi.TestFixture/EdFi.TestFixture.csproj
+++ b/tests/EdFi.TestFixture/EdFi.TestFixture.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Copyright>Copyright © 2020 Ed-Fi Alliance, LLC and Contributors</Copyright>
     <TreatErrorsAsWarning>true</TreatErrorsAsWarning>
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="FakeItEasy" Version="7.2.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="FakeItEasy" Version="8.2.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Changes included in this PR:
- Update the `EdFi.Common` solution to net8.
- Re-generate the package (`EdFi.Suite3.Common`).
- Reference the newly generated package.

The builds will fail until the rest of the projects get migrated to net8, which will be done in subsequent stories.