### PR TITLE
[ODS-6226] Migrate DataLoading solution to .NET 8

### DIFF
--- a/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj
+++ b/Utilities/DataLoading/EdFi.BulkLoadClient.Console/EdFi.BulkLoadClient.Console.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RestorePackages>true</RestorePackages>
     <Configurations>Debug;Release</Configurations>
@@ -35,17 +35,17 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.1.0" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Autofac" Version="8.0.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.4.447" />
-    <PackageReference Include="log4net" Version="2.0.13" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="log4net" Version="2.0.17" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EdFi.LoadTools\EdFi.LoadTools.csproj" />

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>EdFi.LoadTools.Test</AssemblyName>
         <RootNamespace>EdFi.LoadTools.Test</RootNamespace>
         <Copyright>Copyright © 2020 Ed-Fi Alliance, LLC and Contributors</Copyright>
@@ -20,20 +20,20 @@
         <ProjectReference Include="..\EdFi.LoadTools\EdFi.LoadTools.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="aqua-graphcompare" Version="1.2.2" />
+      <PackageReference Include="aqua-graphcompare" Version="1.3.0" />
       <PackageReference Include="EdFi.Suite3.Common" Version="5.4.447" />
       <PackageReference Include="EdFi.Suite3.OdsApi.TestSdk" Version="5.3.243" />
       <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
       <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
-      <PackageReference Include="log4net" Version="2.0.13" />
-      <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-      <PackageReference Include="Moq" Version="4.16.1" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-      <PackageReference Include="NUnit" Version="3.13.2" />
-      <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
-      <PackageReference Include="Shouldly" Version="4.0.3" />
+      <PackageReference Include="log4net" Version="2.0.17" />
+      <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+      <PackageReference Include="Moq" Version="4.20.70" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+      <PackageReference Include="NUnit" Version="4.1.0" />
+      <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+      <PackageReference Include="Shouldly" Version="4.2.1" />
     </ItemGroup>
     <ItemGroup>
       <None Update="appsettings.json">

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/EducationOrganizationCacheLookupStepTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/EducationOrganizationCacheLookupStepTests.cs
@@ -8,6 +8,7 @@ using System.Xml.Linq;
 using EdFi.LoadTools.Engine;
 using EdFi.LoadTools.Engine.XmlLookupPipeline;
 using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/ExtensionMethodsTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/ExtensionMethodsTests.cs
@@ -6,6 +6,7 @@
 using System;
 using EdFi.LoadTools.Engine;
 using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/LookupPipelineTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/LookupPipelineTests.cs
@@ -13,6 +13,7 @@ using System.Xml.Linq;
 using EdFi.LoadTools.Engine;
 using EdFi.LoadTools.Engine.XmlLookupPipeline;
 using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/MapXmlLookupToGetByExampleJsonStepTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/MapXmlLookupToGetByExampleJsonStepTests.cs
@@ -10,6 +10,7 @@ using EdFi.LoadTools.Engine.Mapping;
 using EdFi.LoadTools.Engine.XmlLookupPipeline;
 using EdFi.LoadTools.Test.MappingFactories;
 using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/Mapping/MapperTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/Mapping/MapperTests.cs
@@ -9,6 +9,7 @@ using EdFi.LoadTools.Mapping;
 using EdFi.OdsApi.Sdk.Models.All;
 using NUnit.Framework;
 using Newtonsoft.Json;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test.Mapping
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/OAuthTokenHandlerTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/OAuthTokenHandlerTests.cs
@@ -4,12 +4,11 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using EdFi.LoadTools.ApiClient;
 using Microsoft.Extensions.Configuration;
-using Newtonsoft.Json;
 using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/PercentMatchToTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/PercentMatchToTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using EdFi.LoadTools.Engine;
 using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/PropertyMapperTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/PropertyMapperTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using EdFi.LoadTools.ApiClient;
 using EdFi.LoadTools.Engine.Mapping;
 using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/ResourceReferencePreloadStepTest.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/ResourceReferencePreloadStepTest.cs
@@ -12,6 +12,7 @@ using EdFi.LoadTools.ApiClient;
 using EdFi.LoadTools.Engine;
 using EdFi.LoadTools.Engine.FileImportPipeline;
 using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/APIGetTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/APIGetTests.cs
@@ -19,7 +19,7 @@ using Newtonsoft.Json.Linq;
 using Swashbuckle.Swagger;
 using Microsoft.Extensions.Configuration;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test.SmokeTests
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/GetDependenciesTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/GetDependenciesTests.cs
@@ -7,13 +7,13 @@ using EdFi.LoadTools.Engine;
 using EdFi.LoadTools.SmokeTest.CommonTests;
 using NUnit.Framework;
 using Moq;
-using Microsoft.AspNetCore.TestHost;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using System.Threading.Tasks;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test.SmokeTests
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/GetVersionTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/GetVersionTests.cs
@@ -3,19 +3,17 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System.Configuration;
 using EdFi.LoadTools.Engine;
 using EdFi.LoadTools.SmokeTest.CommonTests;
 using NUnit.Framework;
 using Moq;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.TestHost;
-using System.Net.Http;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Configuration;
 using System.Threading.Tasks;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test.SmokeTests
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/ModelDependencySortTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/ModelDependencySortTests.cs
@@ -12,6 +12,7 @@ using EdFi.LoadTools.SmokeTest.SdkTests;
 using EdFi.OdsApi.Sdk.Apis.All;
 using NUnit.Framework;
 using Moq;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test.SmokeTests
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/PropertyBuilderTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/PropertyBuilderTests.cs
@@ -11,6 +11,7 @@ using EdFi.LoadTools.SmokeTest.PropertyBuilders;
 using NUnit.Framework;
 using Moq;
 using Swashbuckle.Swagger;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedAutoPropertyAccessor.Local

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SwaggerRetrieverTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SwaggerRetrieverTests.cs
@@ -10,6 +10,7 @@ using EdFi.LoadTools.ApiClient;
 using EdFi.LoadTools.Engine;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/UtilitiesTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/UtilitiesTests.cs
@@ -8,6 +8,7 @@ using System.Dynamic;
 using EdFi.LoadTools.ApiClient;
 using NUnit.Framework;
 using Newtonsoft.Json.Linq;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/XmlLookupPipeline/XmlToWorkItemsProcessorTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/XmlLookupPipeline/XmlToWorkItemsProcessorTests.cs
@@ -11,6 +11,7 @@ using System.Xml;
 using System.Xml.Linq;
 using EdFi.LoadTools.Engine.XmlLookupPipeline;
 using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test.XmlLookupPipeline
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/XmlLookupToResourceProcessorTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/XmlLookupToResourceProcessorTests.cs
@@ -13,6 +13,7 @@ using System.Xml.Linq;
 using EdFi.LoadTools.Engine;
 using EdFi.LoadTools.Engine.XmlLookupPipeline;
 using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/XmlReferenceCacheTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/XmlReferenceCacheTests.cs
@@ -14,6 +14,7 @@ using log4net.Appender;
 using log4net.Core;
 using log4net.Repository.Hierarchy;
 using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 // ReSharper disable InconsistentNaming
 

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/XmlResourceHashCacheTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/XmlResourceHashCacheTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using EdFi.LoadTools.Engine;
 using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/XmlResourcePipelineTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/XmlResourcePipelineTests.cs
@@ -10,6 +10,7 @@ using EdFi.LoadTools.Engine.Mapping;
 using EdFi.LoadTools.Engine.ResourcePipeline;
 using NUnit.Framework;
 using Newtonsoft.Json.Linq;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace EdFi.LoadTools.Test
 {

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/XsdMetadataRetrievalTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/XsdMetadataRetrievalTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using EdFi.LoadTools.ApiClient;
 using EdFi.LoadTools.Engine.Factories;
 using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 // ReSharper disable InconsistentNaming
 

--- a/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RestorePackages>true</RestorePackages>
     <Configurations>Debug;Release</Configurations>
@@ -22,18 +22,18 @@
     <None Include="../../../LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.1.0" />
+    <PackageReference Include="Autofac" Version="8.0.0" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.4.447" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
-    <PackageReference Include="log4net" Version="2.0.13" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="JsonSubTypes" Version="1.8.0" />
-    <PackageReference Include="Polly" Version="7.2.2" />
-    <PackageReference Include="RestSharp" Version="106.13.0" />
+    <PackageReference Include="log4net" Version="2.0.17" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="JsonSubTypes" Version="2.0.1" />
+    <PackageReference Include="Polly" Version="8.4.0" />
+    <PackageReference Include="RestSharp" Version="111.3.0" />
     <PackageReference Include="Sandwych.QuickGraph.Core" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RestorePackages>true</RestorePackages>
     <Configurations>Debug;Release</Configurations>
@@ -37,19 +37,19 @@
     <ProjectReference Include="..\EdFi.LoadTools\EdFi.LoadTools.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.1.0" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Autofac" Version="8.0.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.4.447" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
-    <PackageReference Include="log4net" Version="2.0.13" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="log4net" Version="2.0.17" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/Utilities/DataLoading/EdFi.XmlLookup.Console/EdFi.XmlLookup.Console.csproj
+++ b/Utilities/DataLoading/EdFi.XmlLookup.Console/EdFi.XmlLookup.Console.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>EdFi.XmlLookup.Console</AssemblyName>
     <RootNamespace>EdFi.XmlLookup.Console</RootNamespace>
     <Copyright>Copyright © 2020 Ed-Fi Alliance, LLC and Contributors</Copyright>
@@ -26,17 +26,17 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.1.0" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Autofac" Version="8.0.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.4.447" />
-    <PackageReference Include="log4net" Version="2.0.13" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="log4net" Version="2.0.17" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EdFi.LoadTools\EdFi.LoadTools.csproj" />


### PR DESCRIPTION
Some of the tests in this project require that the ODS/API is actively running. The application does not run from the main-5x branch yet since we are still in the middle of the upgrades. However, I was able to test from the v5.3-patch5 tag. Thus I ran the ODS/API from the older tag, while running the EdFi.LoadTools.Test project from my feature branch for main-5x. Here you can see that all tests are passing:

![image](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/assets/158314644/201234c6-c89b-4c74-a20b-d0510d904544)