### PR TITLE
[ODS-6227] Migrate SdkGen to target .NET 8 (5.x)

### DIFF
--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/DescriptorPropertyBuilder.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/DescriptorPropertyBuilder.cs
@@ -60,7 +60,7 @@ namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
                 .GetValue(lookup).ToString();
 
             var uri = lookup.GetType()
-                .GetProperty(EdFiConstants.Namespace)
+                .GetProperty($"Var{EdFiConstants.Namespace}")
                 .GetValue(lookup);
 
             var descriptorValue = uri != null &&  !string.IsNullOrEmpty(uri.ToString())

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/NamespacePropertyBuilder.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/NamespacePropertyBuilder.cs
@@ -27,7 +27,7 @@ namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
         {
             var typeName = obj.GetType().Name;
 
-            if (propertyInfo.PropertyType != typeof(string) || propertyInfo.Name != EdFiConstants.Namespace)
+            if (propertyInfo.PropertyType != typeof(string) || propertyInfo.Name != $"Var{EdFiConstants.Namespace}")
             {
                 return false;
             }

--- a/Utilities/SdkGen/EdFi.SdkGen.Console/EdFi.OdsApi.Sdk.nuspec
+++ b/Utilities/SdkGen/EdFi.SdkGen.Console/EdFi.OdsApi.Sdk.nuspec
@@ -21,6 +21,6 @@
   </metadata>
   <files>
     <file src="readme.txt" target="" />
-    <file src="csharp\src\EdFi.OdsApi.Sdk\bin\$configuration$\net6.0\EdFi.OdsApi.Sdk.dll" target="lib\net6.0" />
+    <file src="csharp\src\EdFi.OdsApi.Sdk\bin\$configuration$\net8.0\EdFi.OdsApi.Sdk.dll" target="lib\net6.0" />
   </files>
 </package>

--- a/Utilities/SdkGen/EdFi.SdkGen.Console/EdFi.SdkGen.Console.csproj
+++ b/Utilities/SdkGen/EdFi.SdkGen.Console/EdFi.SdkGen.Console.csproj
@@ -1,29 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
+  <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-	<GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>		
+    <TargetFramework>net8.0</TargetFramework>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-	<ItemGroup>
-	  <Compile Remove="csharp\**" />
-	  <EmbeddedResource Remove="csharp\**" />
-	  <None Remove="csharp\**" />
-	</ItemGroup>
-	<ItemGroup>
+  <ItemGroup>
+    <Compile Remove="csharp\**" />
+    <EmbeddedResource Remove="csharp\**" />
+    <None Remove="csharp\**" />
+  </ItemGroup>
+  <ItemGroup>
     <None Remove="readme.txt" />
   </ItemGroup>
-	<ItemGroup>
+  <ItemGroup>
     <Content Include="readme.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-	<ItemGroup>
+  <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
-	<ItemGroup>
+  <ItemGroup>
     <None Update="EdFi.OdsApi.Sdk.nuspec">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Utilities/SdkGen/EdFi.SdkGen.Console/OpenApiCodeGenCliRunner.cs
+++ b/Utilities/SdkGen/EdFi.SdkGen.Console/OpenApiCodeGenCliRunner.cs
@@ -67,7 +67,7 @@ namespace EdFi.SdkGen.Console
                 // code-gen paramaters
                 string[] @params =
                 {
-                    $"-Xms3g -jar {_options.CliExecutableFullName()}", "generate", "-g csharp-netcore", $"-i {apiEndpoint.EndpointUri}",
+                    $"-Xms3g -jar {_options.CliExecutableFullName()}", "generate", "-g csharp", $"-i {apiEndpoint.EndpointUri}",
                     $"--api-package {apiPackage}", $"--model-package {modelPackage}", $"-o {_options.OutputFolder}",
                     $"--additional-properties packageName={_options.Namespace},targetFramework=net8.0,netCoreProjectFile=true",
                     "--global-property modelTests=false --global-property apiTests=false --global-property apiDocs=false --global-property modelDocs=false --skip-validate-spec"

--- a/Utilities/SdkGen/EdFi.SdkGen.Console/OpenApiCodeGenCliRunner.cs
+++ b/Utilities/SdkGen/EdFi.SdkGen.Console/OpenApiCodeGenCliRunner.cs
@@ -20,7 +20,6 @@ namespace EdFi.SdkGen.Console
         private const string Profiles = "Profiles";
         private const string Composites = "Composites";
         private const string Identity = "Identity";
-        private const string Java = "java";
         private const string All = "All";
         private readonly ILog _log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private readonly Options _options;
@@ -70,13 +69,13 @@ namespace EdFi.SdkGen.Console
                 {
                     $"-Xms3g -jar {_options.CliExecutableFullName()}", "generate", "-g csharp-netcore", $"-i {apiEndpoint.EndpointUri}",
                     $"--api-package {apiPackage}", $"--model-package {modelPackage}", $"-o {_options.OutputFolder}",
-                    $"--additional-properties packageName={_options.Namespace},targetFramework=net6.0,netCoreProjectFile=true",
+                    $"--additional-properties packageName={_options.Namespace},targetFramework=net8.0,netCoreProjectFile=true",
                     "--global-property modelTests=false --global-property apiTests=false --global-property apiDocs=false --global-property modelDocs=false --skip-validate-spec"
                 };
 
                 _log.Info($"Generating C# SDK for {apiEndpoint.EndpointUri}");
 
-                ShellProcess(Java, @params);
+                ShellProcess(_options.JavaPath, @params);
             }
         }
 

--- a/Utilities/SdkGen/EdFi.SdkGen.Console/Options.cs
+++ b/Utilities/SdkGen/EdFi.SdkGen.Console/Options.cs
@@ -75,6 +75,13 @@ namespace EdFi.SdkGen.Console
         public bool IncludeIdentity { get; set; }
 
         [Option(
+            'j',
+            "java-path",
+            Default = "java",
+            HelpText = "the path to the java executable")]
+        public string JavaPath { get; set; }
+
+        [Option(
             'k',
             "core-only",
             Default = false,

--- a/Utilities/SdkGen/EdFi.SdkGen.Console/Options.cs
+++ b/Utilities/SdkGen/EdFi.SdkGen.Console/Options.cs
@@ -28,7 +28,7 @@ namespace EdFi.SdkGen.Console
         [Option(
             'v',
             "cliVersion",
-            Default = "6.6.0",
+            Default = "7.2.0",
             HelpText = "the version of openapi-codegen-cli to download")]
         public string CliVersion { get; set; }
 


### PR DESCRIPTION
Summary of Changes:
- Update SdkGen project to use .NET 8
- Add JavaPath parameter to SdkGen cli
- Update Java CodeGen utility default version selection to 7.2.0
- Update SmokeTest to handle Var prefixes (added by the new version of Java CodeGen utility) on reserved words