### PR TITLE
[ODS-6290][ODS-6436][ODS-6227] Pre release tasks for ODS/API 5.4

### DIFF
--- a/.github/workflows/CodeQL Security Scan.yml
+++ b/.github/workflows/CodeQL Security Scan.yml
@@ -58,7 +58,7 @@ jobs:
             .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@896079047b4bb059ba6f150a5d87d47dde99e6e5  # codeql-bundle-20221211
+        uses: github/codeql-action/init@df32e399139a3050671466d7d9b3cbacc1cfd034 # codeql-bundle-v2.15.2
         with:
           languages: 'csharp'
 
@@ -78,4 +78,4 @@ jobs:
              .\build.githubactions.ps1 build -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}}  -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@896079047b4bb059ba6f150a5d87d47dde99e6e5  # codeql-bundle-20221211
+        uses: github/codeql-action/analyze@df32e399139a3050671466d7d9b3cbacc1cfd034 # codeql-bundle-v2.15.2

--- a/.github/workflows/Pkg EdFi.ProjectTemplates.Installer.yml
+++ b/.github/workflows/Pkg EdFi.ProjectTemplates.Installer.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Setup MSBuild for .NET Framework 4.8
       uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce #v2.0.0
     - name: Cache Nuget packages
-      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 #v4.0.1
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
@@ -122,7 +122,7 @@ jobs:
       shell: powershell     
     - name: Upload EdFi.Suite3.ProjectTemplates.Installer Artifacts
       if: success()
-      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
       with:
         name: NugetPackages.Artifacts
         path: ${{ github.workspace }}/Ed-Fi-ODS/NugetPackages/*.nupkg

--- a/Application/Directory.Build.props
+++ b/Application/Directory.Build.props
@@ -3,6 +3,5 @@
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
     <InformationalVersion>1.0.0</InformationalVersion>
-    <WarningsNotAsErrors>NU1901;NU1902</WarningsNotAsErrors>
   </PropertyGroup>
 </Project>

--- a/Application/Directory.Build.props
+++ b/Application/Directory.Build.props
@@ -1,5 +1,8 @@
 <Project>
   <PropertyGroup>
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditLevel>high</NuGetAuditLevel>
+    <NuGetAuditMode>direct</NuGetAuditMode>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
     <InformationalVersion>1.0.0</InformationalVersion>

--- a/Application/Directory.Build.props
+++ b/Application/Directory.Build.props
@@ -3,5 +3,6 @@
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
     <InformationalVersion>1.0.0</InformationalVersion>
+    <WarningsNotAsErrors>NU1901;NU1902</WarningsNotAsErrors>
   </PropertyGroup>
 </Project>

--- a/Application/EdFi.Ods.Standard/Artifacts/MsSql/Structure/Ods/1330-UpdateVersionTo54.sql
+++ b/Application/EdFi.Ods.Standard/Artifacts/MsSql/Structure/Ods/1330-UpdateVersionTo54.sql
@@ -1,0 +1,18 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+IF object_id('util.GetEdFiOdsVersion', 'FN') IS NOT NULL
+BEGIN
+    DROP FUNCTION util.GetEdFiOdsVersion;
+END
+GO
+
+CREATE FUNCTION util.GetEdFiOdsVersion()
+RETURNS VARCHAR(60)
+AS
+BEGIN
+    RETURN '5.4'
+END
+GO

--- a/Application/EdFi.Ods.Standard/Artifacts/PgSql/Structure/Ods/1330-UpdateVersionTo54.sql
+++ b/Application/EdFi.Ods.Standard/Artifacts/PgSql/Structure/Ods/1330-UpdateVersionTo54.sql
@@ -1,0 +1,11 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+CREATE OR REPLACE FUNCTION util.GetEdFiOdsVersion()
+RETURNS VARCHAR(60) AS $$
+BEGIN	
+   RETURN '5.4';
+END;
+$$ LANGUAGE plpgsql;

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
@@ -22,7 +22,7 @@
     <ItemGroup>
       <PackageReference Include="aqua-graphcompare" Version="1.3.0" />
       <PackageReference Include="EdFi.Suite3.Common" Version="5.4.452" />
-      <PackageReference Include="EdFi.Suite3.OdsApi.TestSdk" Version="5.3.243" />
+      <PackageReference Include="EdFi.Suite3.OdsApi.TestSdk" Version="5.4.2210" />
       <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
       <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
       <PackageReference Include="log4net" Version="2.0.17" />

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/Mapping/MapperTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/Mapping/MapperTests.cs
@@ -35,7 +35,7 @@ namespace EdFi.LoadTools.Test.Mapping
     ""credentials"": [],
     ""electronicMails"": [
       {
-        ""electronicMailType"": ""Work"",
+        ""electronicMailTypeDescriptor"": ""Work"",
         ""electronicMailAddress"": ""BarryTanner@edfi.org""
       }
     ],
@@ -47,8 +47,8 @@ namespace EdFi.LoadTools.Test.Mapping
     ],
     ""identificationDocuments"": [
       {
-        ""personalInformationVerificationType"": ""State-issued ID"",
-        ""identificationDocumentUseType"": ""Personal Information Verification""
+        ""personalInformationVerificationDescriptor"": ""State-issued ID"",
+        ""identificationDocumentUseDescriptor"": ""Personal Information Verification""
       }
     ],
     ""internationalAddresses"": [],
@@ -56,7 +56,7 @@ namespace EdFi.LoadTools.Test.Mapping
     ""otherNames"": [],
     ""races"": [
       {
-        ""raceType"": ""American Indian - Alaskan Native""
+        ""raceDescriptor"": ""American Indian - Alaskan Native""
       }
     ],
     ""telephones"": [],

--- a/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     <PackageReference Include="Polly" Version="8.4.0" />
-    <PackageReference Include="RestSharp" Version="111.3.0" />
+    <PackageReference Include="RestSharp" Version="110.2.0" />
     <PackageReference Include="Sandwych.QuickGraph.Core" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/Utilities/DataLoading/EdFi.LoadTools/Engine/ExtensionMethods.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/Engine/ExtensionMethods.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
 
 namespace EdFi.LoadTools.Engine
@@ -47,6 +48,19 @@ namespace EdFi.LoadTools.Engine
         public static bool IsPrimitiveType(this Type t)
         {
             return t.IsPrimitive || t.IsValueType || t == typeof(string);
+        }
+
+        /// <summary>
+        /// Returns an array with as many <see cref="Type.Missing"/> as optional parameters.
+        /// Useful while invoking methods by reflection.
+        /// </summary>
+        public static object[] BuildOptionalParameters(this MethodInfo methodInfo)
+        {
+            return methodInfo
+                .GetParameters()
+                .Where(p => p.HasDefaultValue)
+                .Select(_ => Type.Missing)
+                .ToArray();
         }
 
         /// <summary>

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/BaseTest.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/BaseTest.cs
@@ -122,12 +122,9 @@ namespace EdFi.LoadTools.SmokeTest.SdkTests
             var getByIdMethod = ResourceApi.GetByIdMethod;
             var id = Path.GetFileName(resourceUri.ToString());
 
-            var @params = new object[]
-            {
-                id,
-                Type.Missing,
-                Type.Missing
-            };
+            var @params = new object[] {id}
+                .Concat(getByIdMethod.BuildOptionalParameters())
+                .ToArray();
 
             try
             {

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/DeleteTest.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/DeleteTest.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Reflection;
 using EdFi.LoadTools.Engine;
@@ -34,10 +35,9 @@ namespace EdFi.LoadTools.SmokeTest.SdkTests
             var uri = _createdDictionary[ResourceApi.ModelType.Name];
             var id = Path.GetFileName(uri.ToString());
 
-            return new object[]
-                   {
-                       id, null
-                   };
+            return new object[] {id}
+                .Concat(methodInfo.BuildOptionalParameters())
+                .ToArray();
         }
 
         protected override MethodInfo GetMethodInfo()

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/GetByIdTest.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/GetByIdTest.cs
@@ -30,9 +30,9 @@ namespace EdFi.LoadTools.SmokeTest.SdkTests
                 ? typeValue.Id.ToString()
                 : Guid.Empty.ToString("n");
 
-            object[] paramArray = Enumerable.Repeat<object>(string.Empty, methodInfo.GetParameters().Length).ToArray();
-            paramArray[0] = id;
-            return paramArray;
+            return new object[] {id}
+                .Concat(methodInfo.BuildOptionalParameters())
+                .ToArray();
         }
 
         protected override bool ShouldPerformTest()

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/PostTest.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/PostTest.cs
@@ -35,10 +35,9 @@ namespace EdFi.LoadTools.SmokeTest.SdkTests
         {
             var model = BuildNewModel(ResourceApi.ModelType);
 
-            return new[]
-                   {
-                       model
-                   };
+            return new[] {model}
+                .Concat(methodInfo.BuildOptionalParameters())
+                .ToArray();
         }
 
         private object BuildNewModel(Type t, object obj = null)
@@ -113,7 +112,7 @@ namespace EdFi.LoadTools.SmokeTest.SdkTests
             var resourceUri = new Uri(location[0]);
 
             // Add the POSTed resource to the ResultsDictionary so that it can be referenced by subsequent POSTs
-            ResultsDictionary.Add(ResourceApi.ModelType.Name, new List<object> { requestParameters.Single() });
+            ResultsDictionary.Add(ResourceApi.ModelType.Name, new List<object> { requestParameters.First() });
             _createdDictionary.Add(ResourceApi.ModelType.Name, resourceUri);
 
             return true;

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/PutTest.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/PutTest.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Reflection;
 using EdFi.LoadTools.Engine;
@@ -36,9 +37,11 @@ namespace EdFi.LoadTools.SmokeTest.SdkTests
             dynamic model = GetResourceFromUri(uri);
 
             return new object[]
-                   {
-                       id, model, null
-                   };
+                {
+                    id,
+                    model
+                }.Concat(methodInfo.BuildOptionalParameters())
+                .ToArray();
         }
 
         protected override MethodInfo GetMethodInfo()

--- a/Utilities/SdkGen/EdFi.SdkGen.Console/EdFi.OdsApi.Sdk.nuspec
+++ b/Utilities/SdkGen/EdFi.SdkGen.Console/EdFi.OdsApi.Sdk.nuspec
@@ -21,6 +21,6 @@
   </metadata>
   <files>
     <file src="readme.txt" target="" />
-    <file src="csharp\src\EdFi.OdsApi.Sdk\bin\$configuration$\net8.0\EdFi.OdsApi.Sdk.dll" target="lib\net6.0" />
+    <file src="csharp\src\EdFi.OdsApi.Sdk\bin\$configuration$\net8.0\EdFi.OdsApi.Sdk.dll" target="lib\net8.0" />
   </files>
 </package>


### PR DESCRIPTION
Changes included in this PR:
- Brought a subset of changes from #1100
- Updated the DB Function `util.GetEdFiOdsVersion` to return '5.4'
- Updated references to `EdFi.Suite3.OdsApi.TestSdk` to the latest version
- General fixes to the SDK Smoke tests

Note that the builds `Pkg EdFi.Database.Admin` and `Pkg EdFi.Database.Security` failed, but this PR didn't change any of those DBs (these builds have always failed in the `main-5x` branch), so we might consider fixing these builds in a different PR.