### PR TITLE
[ODS-6442] Authentication problem when using instance year-specific mode (5.x)

### DIFF
--- a/Application/EdFi.Ods.Api/Caching/InstanceSecurityRepositoryCache.cs
+++ b/Application/EdFi.Ods.Api/Caching/InstanceSecurityRepositoryCache.cs
@@ -122,7 +122,7 @@ namespace EdFi.Ods.Api.Caching
             {
                 var application =
                     context.Applications.First(
-                        app => app.ApplicationName.Equals(EdFiOdsApi, StringComparison.InvariantCultureIgnoreCase));
+                        app => app.ApplicationName.Equals(EdFiOdsApi));
 
                 var actions = context.Actions.ToList();
 


### PR DESCRIPTION
- Removes the `StringComparison` parameter from the LINQ expression used to find the Ed-Fi ODS API application entry in the security database. 