### PR TITLE
[ODS-6418] Enforce token limits on API clients

### DIFF
--- a/Application/EdFi.Ods.Api/Container/Modules/ApplicationModule.cs
+++ b/Application/EdFi.Ods.Api/Container/Modules/ApplicationModule.cs
@@ -261,6 +261,10 @@ namespace EdFi.Ods.Api.Container.Modules
                     new ResolvedParameter(
                         (p, c) => p.Name == "tokenDurationMinutes",
                         (p, c) => c.Resolve<ApiSettings>().BearerTokenTimeoutMinutes))
+                .WithParameter(
+                    new ResolvedParameter(
+                        (p, c) => p.Name == "tokenPerClientLimit",
+                        (p, c) => c.Resolve<ApiSettings>().BearerTokenPerClientLimit))
                 .SingleInstance();
 
             builder.RegisterType<PackedHashConverter>()

--- a/Application/EdFi.Ods.Api/Security/Authentication/EdFiAdminAccessTokenFactory.cs
+++ b/Application/EdFi.Ods.Api/Security/Authentication/EdFiAdminAccessTokenFactory.cs
@@ -60,8 +60,7 @@ public class EdFiAdminAccessTokenFactory : IAccessTokenFactory
         {
             await connection.ExecuteAsync(AddTokenProcedureName, @params, commandType: CommandType.StoredProcedure);
         }
-        catch (DbException ex) when ((ex.Data["MessageText"]?.Equals(TokenLimitReachedDbMessage) ?? false) ||
-                                     ex.Message.Equals(TokenLimitReachedDbMessage))
+        catch (DbException ex) when (ex.Message.Contains(TokenLimitReachedDbMessage))
         {
             throw new TooManyTokensException(_tokenPerClientLimit);
         }

--- a/Application/EdFi.Ods.Api/Security/Authentication/EdFiAdminAccessTokenFactory.cs
+++ b/Application/EdFi.Ods.Api/Security/Authentication/EdFiAdminAccessTokenFactory.cs
@@ -16,13 +16,15 @@ public class EdFiAdminAccessTokenFactory : IAccessTokenFactory
     private readonly DbProviderFactory _dbProviderFactory;
     private readonly IAdminDatabaseConnectionStringProvider _adminDatabaseConnectionStringProvider;
     private readonly int _tokenDurationMinutes;
+    private readonly int _tokenPerClientLimit;
 
     private const string InsertClientAccessTokenSql = "INSERT INTO dbo.ClientAccessTokens(Id, Expiration, Scope, ApiClient_ApiClientId) VALUES (@Id, @Expiration, @Scope, @ApiClientId);";
 
     public EdFiAdminAccessTokenFactory(
         DbProviderFactory dbProviderFactory,
         IAdminDatabaseConnectionStringProvider adminDatabaseConnectionStringProvider,
-        int tokenDurationMinutes)
+        int tokenDurationMinutes,
+        int tokenPerClientLimit)
     {
         if (tokenDurationMinutes <= 0)
         {
@@ -33,6 +35,7 @@ public class EdFiAdminAccessTokenFactory : IAccessTokenFactory
         _adminDatabaseConnectionStringProvider = adminDatabaseConnectionStringProvider;
 
         _tokenDurationMinutes = tokenDurationMinutes;
+        _tokenPerClientLimit = tokenPerClientLimit;
     }
     
     public async Task<AccessToken> CreateAccessTokenAsync(int apiClientId, string scope = null)

--- a/Application/EdFi.Ods.Common/Configuration/ApiSettings.cs
+++ b/Application/EdFi.Ods.Common/Configuration/ApiSettings.cs
@@ -26,6 +26,8 @@ namespace EdFi.Ods.Common.Configuration
         }
 
         public int BearerTokenTimeoutMinutes { get; set; } = 60;
+        
+        public int BearerTokenPerClientLimit { get; set; } = 15;
 
         public int DefaultPageSizeLimit { get; set; } = 500;
 

--- a/Application/EdFi.Ods.Common/Exceptions/TooManyTokensException.cs
+++ b/Application/EdFi.Ods.Common/Exceptions/TooManyTokensException.cs
@@ -20,8 +20,8 @@ public class TooManyTokensException : EdFiProblemDetailsExceptionBase
     private const string ErrorText = "Too many access tokens have been requested (limit is {0}). Access tokens should be reused until they expire.";
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="OptimisticLockException"/> class using the default text and error messages
-    /// indicating an optimistic locking evaluation detected changes from another API client.
+    /// Initializes a new instance of the <see cref="TooManyTokensException"/> class using the default text and error messages
+    /// indicating that the maximum token limit has been reached by the API client.
     /// </summary>
     public TooManyTokensException(int tokenPerClientLimit)
         : base(DetailText, [string.Format(ErrorText, tokenPerClientLimit.ToString())]) { }

--- a/Application/EdFi.Ods.Common/Exceptions/TooManyTokensException.cs
+++ b/Application/EdFi.Ods.Common/Exceptions/TooManyTokensException.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+
+namespace EdFi.Ods.Common.Exceptions;
+
+public class TooManyTokensException : EdFiProblemDetailsExceptionBase
+{
+    // Fields containing override values for Problem Details
+    private const string TypePart = "security:authentication:too-many-tokens";
+    private const string TitleText = "Too Many Tokens";
+
+    private const int StatusValue = StatusCodes.Status429TooManyRequests;
+
+    private const string DetailText = "The caller has authenticated too many times in too short of a time period.";
+    private const string ErrorText = "Too many access tokens have been requested (limit is {0}). Access tokens should be reused until they expire.";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OptimisticLockException"/> class using the default text and error messages
+    /// indicating an optimistic locking evaluation detected changes from another API client.
+    /// </summary>
+    public TooManyTokensException(int tokenPerClientLimit)
+        : base(DetailText, [string.Format(ErrorText, tokenPerClientLimit.ToString())]) { }
+
+    // ---------------------------
+    //  Boilerplate for overrides
+    // ---------------------------
+    public override string Title { get => TitleText; }
+
+    public override int Status { get => StatusValue; }
+    
+    protected override IEnumerable<string> GetTypeParts()
+    {
+        foreach (var part in base.GetTypeParts())
+        {
+            yield return part;
+        }
+
+        yield return TypePart;
+    }
+    // ---------------------------
+}

--- a/Artifacts/MsSql/Structure/Admin/0175-Add-CreateClientAccessToken.sql
+++ b/Artifacts/MsSql/Structure/Admin/0175-Add-CreateClientAccessToken.sql
@@ -3,8 +3,7 @@
 -- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 -- See the LICENSE and NOTICES files in the project root for more information.
 
-CREATE OR ALTER PROCEDURE dbo.CreateClientAccessToken
-(
+CREATE OR ALTER PROCEDURE dbo.CreateClientAccessToken(
     @Id UNIQUEIDENTIFIER = NULL,
     @Expiration DATETIME = NULL,
     @Scope NVARCHAR(max) = NULL,
@@ -14,15 +13,20 @@ CREATE OR ALTER PROCEDURE dbo.CreateClientAccessToken
 AS
 BEGIN
     SET NOCOUNT ON
+	
+	DECLARE @msg AS nvarchar(max)
 
-    DECLARE @ActiveTokenCount INT = (
-        SELECT COUNT(1)
-        FROM dbo.clientaccesstokens actoken
-        WHERE ApiClient_ApiClientId = @ApiClientId AND actoken.Expiration > GETUTCDATE())
+    DECLARE @ActiveTokenCount INT = (SELECT COUNT(1)
+                                     FROM dbo.clientaccesstokens actoken
+                                     WHERE ApiClient_ApiClientId = @ApiClientId
+                                       AND actoken.Expiration > GETUTCDATE())
 
     IF (@MaxTokenCount < 1) OR (@ActiveTokenCount < @MaxTokenCount)
-        INSERT INTO dbo.ClientAccessTokens(Id, Expiration, Scope, ApiClient_ApiClientId) VALUES (@Id, @Expiration, @Scope, @ApiClientId);
+	BEGIN
+        INSERT INTO dbo.ClientAccessTokens(Id, Expiration, Scope, ApiClient_ApiClientId)
+        VALUES (@Id, @Expiration, @Scope, @ApiClientId);
+	END
     ELSE
-        RAISERROR (N'Token limit reached', 16, 1);
+		THROW 50000, 'Token limit reached', 1;
 END
 GO

--- a/Artifacts/MsSql/Structure/Admin/0175-Add-CreateClientAccessToken.sql
+++ b/Artifacts/MsSql/Structure/Admin/0175-Add-CreateClientAccessToken.sql
@@ -1,4 +1,4 @@
--- SPDX-License-Identifier: Apache-2.0
+ -- SPDX-License-Identifier: Apache-2.0
 -- Licensed to the Ed-Fi Alliance under one or more agreements.
 -- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 -- See the LICENSE and NOTICES files in the project root for more information.
@@ -14,17 +14,22 @@ AS
 BEGIN
     SET NOCOUNT ON
 	
-	DECLARE @msg AS nvarchar(max)
-
-    DECLARE @ActiveTokenCount INT = (SELECT COUNT(1)
-                                     FROM dbo.clientaccesstokens actoken
+    DECLARE @ActiveTokenCount INT
+	
+	IF @MaxTokenCount < 1
+		SET @ActiveTokenCount = 0
+	ELSE
+	BEGIN
+		SET @ActiveTokenCount = (SELECT COUNT(1)
+                                     FROM dbo.ClientAccessTokens actoken
                                      WHERE ApiClient_ApiClientId = @ApiClientId
                                        AND actoken.Expiration > GETUTCDATE())
-
+	END
+	
     IF (@MaxTokenCount < 1) OR (@ActiveTokenCount < @MaxTokenCount)
 	BEGIN
         INSERT INTO dbo.ClientAccessTokens(Id, Expiration, Scope, ApiClient_ApiClientId)
-        VALUES (@Id, @Expiration, @Scope, @ApiClientId);
+        VALUES (@Id, @Expiration, @Scope, @ApiClientId)
 	END
     ELSE
 		THROW 50000, 'Token limit reached', 1;

--- a/Artifacts/MsSql/Structure/Admin/0175-Add-CreateClientAccessToken.sql
+++ b/Artifacts/MsSql/Structure/Admin/0175-Add-CreateClientAccessToken.sql
@@ -1,0 +1,28 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+CREATE OR ALTER PROCEDURE dbo.CreateClientAccessToken
+(
+    @Id UNIQUEIDENTIFIER = NULL,
+    @Expiration DATETIME = NULL,
+    @Scope NVARCHAR(max) = NULL,
+    @ApiClientId INT = NULL,
+    @MaxTokenCount INT = NULL
+)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    DECLARE @ActiveTokenCount INT = (
+        SELECT COUNT(1)
+        FROM dbo.clientaccesstokens actoken
+        WHERE ApiClient_ApiClientId = @ApiClientId AND actoken.Expiration > GETUTCDATE())
+
+    IF (@MaxTokenCount < 1) OR (@ActiveTokenCount < @MaxTokenCount)
+        INSERT INTO dbo.ClientAccessTokens(Id, Expiration, Scope, ApiClient_ApiClientId) VALUES (@Id, @Expiration, @Scope, @ApiClientId);
+    ELSE
+        RAISERROR (N'Token limit reached', 16, 1);
+END
+GO

--- a/Artifacts/PgSql/Structure/Admin/0175-Add-CreateClientAccessToken.sql
+++ b/Artifacts/PgSql/Structure/Admin/0175-Add-CreateClientAccessToken.sql
@@ -1,0 +1,27 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+CREATE OR REPLACE PROCEDURE dbo.CreateClientAccessToken (
+	Id uuid, 
+	Expiration timestamp without time zone, 
+	Scope text, 
+	ApiClientId integer, 
+	MaxTokenCount integer)
+AS
+$BODY$
+DECLARE
+    ActiveTokenCount integer DEFAULT 0;
+BEGIN
+        ActiveTokenCount := (SELECT COUNT(1)
+        FROM dbo.clientaccesstokens actoken
+        WHERE apiclient_apiclientid = ApiClientId AND actoken.Expiration > current_timestamp at time zone 'utc');
+    IF (MaxTokenCount < 1) OR (ActiveTokenCount < MaxTokenCount)  THEN
+        INSERT INTO dbo.ClientAccessTokens(id, expiration, scope, apiclient_apiclientid) VALUES (Id, Expiration, Scope, ApiClientId);
+    ELSE
+        RAISE EXCEPTION 'Token limit reached';
+    END IF;
+END
+$BODY$
+LANGUAGE plpgsql;

--- a/Artifacts/PgSql/Structure/Admin/0175-Add-CreateClientAccessToken.sql
+++ b/Artifacts/PgSql/Structure/Admin/0175-Add-CreateClientAccessToken.sql
@@ -3,25 +3,28 @@
 -- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 -- See the LICENSE and NOTICES files in the project root for more information.
 
-CREATE OR REPLACE PROCEDURE dbo.CreateClientAccessToken (
-	Id uuid, 
-	Expiration timestamp without time zone, 
-	Scope text, 
-	ApiClientId integer, 
-	MaxTokenCount integer)
+CREATE OR REPLACE PROCEDURE dbo.CreateClientAccessToken(
+    id uuid,
+    expiration timestamp without time zone,
+    scope text,
+    apiclientid integer,
+    maxtokencount integer)
 AS
 $BODY$
 DECLARE
-    ActiveTokenCount integer DEFAULT 0;
+    active_token_count integer = 0;
 BEGIN
-        ActiveTokenCount := (SELECT COUNT(1)
-        FROM dbo.clientaccesstokens actoken
-        WHERE apiclient_apiclientid = ApiClientId AND actoken.Expiration > current_timestamp at time zone 'utc');
-    IF (MaxTokenCount < 1) OR (ActiveTokenCount < MaxTokenCount)  THEN
-        INSERT INTO dbo.ClientAccessTokens(id, expiration, scope, apiclient_apiclientid) VALUES (Id, Expiration, Scope, ApiClientId);
+    active_token_count := (SELECT COUNT(1)
+                           FROM dbo.clientaccesstokens actoken
+                           WHERE apiclient_apiclientid = ApiClientId
+                             AND actoken.expiration > current_timestamp at time zone 'utc');
+    IF (maxtokencount < 1) OR (active_token_count < maxtokencount) THEN
+        INSERT INTO dbo.ClientAccessTokens(id, expiration, scope, apiclient_apiclientid)
+        VALUES (CreateClientAccessToken.id, CreateClientAccessToken.expiration, CreateClientAccessToken.scope,
+                apiclientid);
     ELSE
-        RAISE EXCEPTION 'Token limit reached';
+        RAISE EXCEPTION USING MESSAGE = 'Token limit reached';
     END IF;
 END
 $BODY$
-LANGUAGE plpgsql;
+    LANGUAGE plpgsql;


### PR DESCRIPTION
### Summary of changes:
- Added a configuration setting to limit the number of valid bearer tokens issued per client
- Added a new custom exception for handling instances where clients attempt to exceed the token limit
- Added stored procedures in SQL and PostgreSQL to manage client access token creation and enforce the token limit
