### PR TITLE
[ODS-5622] Make the ODSStartup configurable

### DIFF
--- a/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
+++ b/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
@@ -87,7 +87,7 @@ namespace EdFi.Ods.Api.Startup
 
         private ILifetimeScope Container { get; set; }
 
-        public void ConfigureServices(IServiceCollection services)
+        public virtual void ConfigureServices(IServiceCollection services)
         {
             // Provide access to the web host environment through the container
             services.AddSingleton(_webHostEnvironment);
@@ -270,7 +270,7 @@ namespace EdFi.Ods.Api.Startup
         // with Autofac. This runs after ConfigureServices so the things
         // here will override registrations made in ConfigureServices.
         // Don't build the container; that gets done for you by the factory.
-        public void ConfigureContainer(ContainerBuilder builder)
+        public virtual void ConfigureContainer(ContainerBuilder builder)
         {
             _logger.Debug("Building Autofac container");
 
@@ -314,7 +314,7 @@ namespace EdFi.Ods.Api.Startup
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(
+        public virtual void Configure(
             IApplicationBuilder app,
             IWebHostEnvironment env,
             IOptions<ApiSettings> apiSettingsOptions,


### PR DESCRIPTION
Update EdFi.Ods.WebApi  project Appsettings as  :"StartUpClassName": "CustomStartup"

Add below CustomStartup  class for testing this change 

 using Autofac;
using EdFi.Ods.Api.Startup;
using EdFi.Ods.Common.Configuration;
using Microsoft.AspNetCore.Builder;
using Microsoft.AspNetCore.Hosting;
using Microsoft.Extensions.Configuration;
using Microsoft.Extensions.DependencyInjection;
using Microsoft.Extensions.Options;

namespace EdFi.Ods.WebApi
{
    public class CustomStartup : OdsStartupBase
    {
        public CustomStartup(IWebHostEnvironment env, IConfiguration configuration) : base(env, configuration)
        {
        }

        public override void ConfigureServices(IServiceCollection services)
        {
            base.ConfigureServices(services);

        }

        public override void ConfigureContainer(ContainerBuilder builder)
        {
            base.ConfigureContainer(builder);
        }
        
        public override void Configure(
            IApplicationBuilder app,
            IWebHostEnvironment env,
            IOptions<ApiSettings> apiSettingsOptions,
            IApplicationConfigurationActivity[] configurationActivities)
        {
            base.Configure(app, env, apiSettingsOptions, configurationActivities);
        }
    }
}