### PR TITLE
[ODS-6638] Updated Scripts to use CREATE OR ALTER TRIGGER instead of CREATE TRIGGER

### DIFF
--- a/Application/EdFi.Ods.Standard/Standard/4.0.0/Artifacts/MsSql/Structure/Ods/Changes/0230-CreateIndirectUpdateCascadeTriggers.sql
+++ b/Application/EdFi.Ods.Standard/Standard/4.0.0/Artifacts/MsSql/Structure/Ods/Changes/0230-CreateIndirectUpdateCascadeTriggers.sql
@@ -28,7 +28,7 @@ BEGIN
 END;
 GO
 
-CREATE TRIGGER [edfi].[edfi_BellScheduleClassPeriod_TR_BellSchedule_Update]
+CREATE OR ALTER TRIGGER [edfi].[edfi_BellScheduleClassPeriod_TR_BellSchedule_Update]
 ON [edfi].[BellScheduleClassPeriod]
 AFTER UPDATE
 AS
@@ -50,7 +50,7 @@ BEGIN
 END;
 GO
 
-CREATE TRIGGER [edfi].[edfi_ReportCardGrade_TR_ReportCard_Update]
+CREATE OR ALTER TRIGGER [edfi].[edfi_ReportCardGrade_TR_ReportCard_Update]
 ON [edfi].[ReportCardGrade]
 AFTER UPDATE
 AS
@@ -85,7 +85,7 @@ BEGIN
 END;
 GO
 
-CREATE TRIGGER [edfi].[edfi_SectionClassPeriod_TR_Section_Update]
+CREATE OR ALTER TRIGGER [edfi].[edfi_SectionClassPeriod_TR_Section_Update]
 ON [edfi].[SectionClassPeriod]
 AFTER UPDATE
 AS
@@ -110,7 +110,7 @@ BEGIN
 END;
 GO
 
-CREATE TRIGGER [edfi].[edfi_StudentCohortAssociationSection_TR_StudentCohortAssociation_Update]
+CREATE OR ALTER TRIGGER [edfi].[edfi_StudentCohortAssociationSection_TR_StudentCohortAssociation_Update]
 ON [edfi].[StudentCohortAssociationSection]
 AFTER UPDATE
 AS
@@ -137,7 +137,7 @@ BEGIN
 END;
 GO
 
-CREATE TRIGGER [edfi].[edfi_StudentCompetencyObjectiveStudentSectionAssociation_TR_StudentCompetencyObjective_Update]
+CREATE OR ALTER TRIGGER [edfi].[edfi_StudentCompetencyObjectiveStudentSectionAssociation_TR_StudentCompetencyObjective_Update]
 ON [edfi].[StudentCompetencyObjectiveStudentSectionAssociation]
 AFTER UPDATE
 AS
@@ -170,7 +170,7 @@ BEGIN
 END;
 GO
 
-CREATE TRIGGER [edfi].[edfi_StudentLearningObjectiveStudentSectionAssociation_TR_StudentLearningObjective_Update]
+CREATE OR ALTER TRIGGER [edfi].[edfi_StudentLearningObjectiveStudentSectionAssociation_TR_StudentLearningObjective_Update]
 ON [edfi].[StudentLearningObjectiveStudentSectionAssociation]
 AFTER UPDATE
 AS
@@ -202,7 +202,7 @@ BEGIN
 END;
 GO
 
-CREATE TRIGGER [edfi].[edfi_StudentSectionAttendanceEventClassPeriod_TR_StudentSectionAttendanceEvent_Update]
+CREATE OR ALTER TRIGGER [edfi].[edfi_StudentSectionAttendanceEventClassPeriod_TR_StudentSectionAttendanceEvent_Update]
 ON [edfi].[StudentSectionAttendanceEventClassPeriod]
 AFTER UPDATE
 AS

--- a/Application/EdFi.Ods.Standard/Standard/4.0.0/Artifacts/MsSql/Structure/Ods/Changes/0230-CreateIndirectUpdateCascadeTriggers.sql
+++ b/Application/EdFi.Ods.Standard/Standard/4.0.0/Artifacts/MsSql/Structure/Ods/Changes/0230-CreateIndirectUpdateCascadeTriggers.sql
@@ -3,7 +3,7 @@
 -- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 -- See the LICENSE and NOTICES files in the project root for more information.
 
-CREATE TRIGGER [edfi].[edfi_AssessmentSection_TR_Assessment_Update]
+CREATE OR ALTER TRIGGER [edfi].[edfi_AssessmentSection_TR_Assessment_Update]
 ON [edfi].[AssessmentSection]
 AFTER UPDATE
 AS

--- a/Application/EdFi.Ods.Standard/Standard/4.0.0/Artifacts/PgSql/Structure/Ods/Changes/0230-CreateIndirectUpdateCascadeTriggers.sql
+++ b/Application/EdFi.Ods.Standard/Standard/4.0.0/Artifacts/PgSql/Structure/Ods/Changes/0230-CreateIndirectUpdateCascadeTriggers.sql
@@ -23,7 +23,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trg_edfi_AssessmentSection_afterupdate
+CREATE OR REPLACE TRIGGER trg_edfi_AssessmentSection_afterupdate
 AFTER UPDATE ON edfi.AssessmentSection
 FOR EACH ROW
 EXECUTE FUNCTION edfi.update_Assessment_lastmodifieddate();
@@ -45,7 +45,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trg_edfi_BellScheduleClassPeriod_afterupdate
+CREATE OR REPLACE TRIGGER trg_edfi_BellScheduleClassPeriod_afterupdate
 AFTER UPDATE ON edfi.BellScheduleClassPeriod
 FOR EACH ROW
 EXECUTE FUNCTION edfi.update_BellSchedule_lastmodifieddate();
@@ -80,7 +80,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trg_edfi_ReportCardGrade_afterupdate
+CREATE OR REPLACE TRIGGER trg_edfi_ReportCardGrade_afterupdate
 AFTER UPDATE ON edfi.ReportCardGrade
 FOR EACH ROW
 EXECUTE FUNCTION edfi.update_ReportCard_lastmodifieddate();
@@ -105,7 +105,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trg_edfi_SectionClassPeriod_afterupdate
+CREATE OR REPLACE TRIGGER trg_edfi_SectionClassPeriod_afterupdate
 AFTER UPDATE ON edfi.SectionClassPeriod
 FOR EACH ROW
 EXECUTE FUNCTION edfi.update_Section_lastmodifieddate();
@@ -132,7 +132,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trg_edfi_StudentCohortAssociationSection_afterupdate
+CREATE OR REPLACE TRIGGER trg_edfi_StudentCohortAssociationSection_afterupdate
 AFTER UPDATE ON edfi.StudentCohortAssociationSection
 FOR EACH ROW
 EXECUTE FUNCTION edfi.update_StudentCohortAssociation_lastmodifieddate();
@@ -165,7 +165,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trg_edfi_StudentCompetencyObjectiveStudentSectionAssociation_afterupdate
+CREATE OR REPLACE TRIGGER trg_edfi_StudentCompetencyObjectiveStudentSectionAssociation_afterupdate
 AFTER UPDATE ON edfi.StudentCompetencyObjectiveStudentSectionAssociation
 FOR EACH ROW
 EXECUTE FUNCTION edfi.update_StudentCompetencyObjective_lastmodifieddate();
@@ -197,7 +197,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trg_edfi_StudentLearningObjectiveStudentSectionAssociation_afterupdate
+CREATE OR REPLACE TRIGGER trg_edfi_StudentLearningObjectiveStudentSectionAssociation_afterupdate
 AFTER UPDATE ON edfi.StudentLearningObjectiveStudentSectionAssociation
 FOR EACH ROW
 EXECUTE FUNCTION edfi.update_StudentLearningObjective_lastmodifieddate();
@@ -225,7 +225,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trg_edfi_StudentSectionAttendanceEventClassPeriod_afterupdate
+CREATE OR REPLACE TRIGGER trg_edfi_StudentSectionAttendanceEventClassPeriod_afterupdate
 AFTER UPDATE ON edfi.StudentSectionAttendanceEventClassPeriod
 FOR EACH ROW
 EXECUTE FUNCTION edfi.update_StudentSectionAttendanceEvent_lastmodifieddate();

--- a/Application/EdFi.Ods.Standard/Standard/5.2.0/Artifacts/MsSql/Structure/Ods/Changes/0230-CreateIndirectUpdateCascadeTriggers.sql
+++ b/Application/EdFi.Ods.Standard/Standard/5.2.0/Artifacts/MsSql/Structure/Ods/Changes/0230-CreateIndirectUpdateCascadeTriggers.sql
@@ -28,7 +28,7 @@ BEGIN
 END;
 GO
 
-CREATE TRIGGER [edfi].[edfi_BellScheduleClassPeriod_TR_BellSchedule_Update]
+CREATE OR ALTER TRIGGER [edfi].[edfi_BellScheduleClassPeriod_TR_BellSchedule_Update]
 ON [edfi].[BellScheduleClassPeriod]
 AFTER UPDATE
 AS
@@ -50,7 +50,7 @@ BEGIN
 END;
 GO
 
-CREATE TRIGGER [edfi].[edfi_CourseTranscriptSection_TR_CourseTranscript_Update]
+CREATE OR ALTER TRIGGER [edfi].[edfi_CourseTranscriptSection_TR_CourseTranscript_Update]
 ON [edfi].[CourseTranscriptSection]
 AFTER UPDATE
 AS
@@ -80,7 +80,7 @@ BEGIN
 END;
 GO
 
-CREATE TRIGGER [edfi].[edfi_ReportCardGrade_TR_ReportCard_Update]
+CREATE OR ALTER TRIGGER [edfi].[edfi_ReportCardGrade_TR_ReportCard_Update]
 ON [edfi].[ReportCardGrade]
 AFTER UPDATE
 AS
@@ -115,7 +115,7 @@ BEGIN
 END;
 GO
 
-CREATE TRIGGER [edfi].[edfi_SectionClassPeriod_TR_Section_Update]
+CREATE OR ALTER TRIGGER [edfi].[edfi_SectionClassPeriod_TR_Section_Update]
 ON [edfi].[SectionClassPeriod]
 AFTER UPDATE
 AS
@@ -140,7 +140,7 @@ BEGIN
 END;
 GO
 
-CREATE TRIGGER [edfi].[edfi_StudentCohortAssociationSection_TR_StudentCohortAssociation_Update]
+CREATE OR ALTER TRIGGER [edfi].[edfi_StudentCohortAssociationSection_TR_StudentCohortAssociation_Update]
 ON [edfi].[StudentCohortAssociationSection]
 AFTER UPDATE
 AS
@@ -167,7 +167,7 @@ BEGIN
 END;
 GO
 
-CREATE TRIGGER [edfi].[edfi_StudentCompetencyObjectiveStudentSectionAssociation_TR_StudentCompetencyObjective_Update]
+CREATE OR ALTER TRIGGER [edfi].[edfi_StudentCompetencyObjectiveStudentSectionAssociation_TR_StudentCompetencyObjective_Update]
 ON [edfi].[StudentCompetencyObjectiveStudentSectionAssociation]
 AFTER UPDATE
 AS
@@ -200,7 +200,7 @@ BEGIN
 END;
 GO
 
-CREATE TRIGGER [edfi].[edfi_StudentSectionAttendanceEventClassPeriod_TR_StudentSectionAttendanceEvent_Update]
+CREATE OR ALTER TRIGGER [edfi].[edfi_StudentSectionAttendanceEventClassPeriod_TR_StudentSectionAttendanceEvent_Update]
 ON [edfi].[StudentSectionAttendanceEventClassPeriod]
 AFTER UPDATE
 AS

--- a/Application/EdFi.Ods.Standard/Standard/5.2.0/Artifacts/MsSql/Structure/Ods/Changes/0230-CreateIndirectUpdateCascadeTriggers.sql
+++ b/Application/EdFi.Ods.Standard/Standard/5.2.0/Artifacts/MsSql/Structure/Ods/Changes/0230-CreateIndirectUpdateCascadeTriggers.sql
@@ -3,7 +3,7 @@
 -- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 -- See the LICENSE and NOTICES files in the project root for more information.
 
-CREATE TRIGGER [edfi].[edfi_AssessmentSection_TR_Assessment_Update]
+CREATE OR ALTER TRIGGER [edfi].[edfi_AssessmentSection_TR_Assessment_Update]
 ON [edfi].[AssessmentSection]
 AFTER UPDATE
 AS

--- a/Application/EdFi.Ods.Standard/Standard/5.2.0/Artifacts/PgSql/Structure/Ods/Changes/0230-CreateIndirectUpdateCascadeTriggers.sql
+++ b/Application/EdFi.Ods.Standard/Standard/5.2.0/Artifacts/PgSql/Structure/Ods/Changes/0230-CreateIndirectUpdateCascadeTriggers.sql
@@ -23,7 +23,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trg_edfi_AssessmentSection_afterupdate
+CREATE OR REPLACE TRIGGER trg_edfi_AssessmentSection_afterupdate
 AFTER UPDATE ON edfi.AssessmentSection
 FOR EACH ROW
 EXECUTE FUNCTION edfi.update_Assessment_lastmodifieddate();
@@ -45,7 +45,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trg_edfi_BellScheduleClassPeriod_afterupdate
+CREATE OR REPLACE TRIGGER trg_edfi_BellScheduleClassPeriod_afterupdate
 AFTER UPDATE ON edfi.BellScheduleClassPeriod
 FOR EACH ROW
 EXECUTE FUNCTION edfi.update_BellSchedule_lastmodifieddate();
@@ -75,7 +75,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trg_edfi_CourseTranscriptSection_afterupdate
+CREATE OR REPLACE TRIGGER trg_edfi_CourseTranscriptSection_afterupdate
 AFTER UPDATE ON edfi.CourseTranscriptSection
 FOR EACH ROW
 EXECUTE FUNCTION edfi.update_CourseTranscript_lastmodifieddate();
@@ -110,7 +110,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trg_edfi_ReportCardGrade_afterupdate
+CREATE OR REPLACE TRIGGER trg_edfi_ReportCardGrade_afterupdate
 AFTER UPDATE ON edfi.ReportCardGrade
 FOR EACH ROW
 EXECUTE FUNCTION edfi.update_ReportCard_lastmodifieddate();
@@ -135,7 +135,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trg_edfi_SectionClassPeriod_afterupdate
+CREATE OR REPLACE TRIGGER trg_edfi_SectionClassPeriod_afterupdate
 AFTER UPDATE ON edfi.SectionClassPeriod
 FOR EACH ROW
 EXECUTE FUNCTION edfi.update_Section_lastmodifieddate();
@@ -162,7 +162,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trg_edfi_StudentCohortAssociationSection_afterupdate
+CREATE OR REPLACE TRIGGER trg_edfi_StudentCohortAssociationSection_afterupdate
 AFTER UPDATE ON edfi.StudentCohortAssociationSection
 FOR EACH ROW
 EXECUTE FUNCTION edfi.update_StudentCohortAssociation_lastmodifieddate();
@@ -195,7 +195,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trg_edfi_StudentCompetencyObjectiveStudentSectionAssociation_afterupdate
+CREATE OR REPLACE TRIGGER trg_edfi_StudentCompetencyObjectiveStudentSectionAssociation_afterupdate
 AFTER UPDATE ON edfi.StudentCompetencyObjectiveStudentSectionAssociation
 FOR EACH ROW
 EXECUTE FUNCTION edfi.update_StudentCompetencyObjective_lastmodifieddate();
@@ -223,7 +223,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trg_edfi_StudentSectionAttendanceEventClassPeriod_afterupdate
+CREATE OR REPLACE TRIGGER trg_edfi_StudentSectionAttendanceEventClassPeriod_afterupdate
 AFTER UPDATE ON edfi.StudentSectionAttendanceEventClassPeriod
 FOR EACH ROW
 EXECUTE FUNCTION edfi.update_StudentSectionAttendanceEvent_lastmodifieddate();


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e6db9908-4bf2-4861-b5b8-c9c66c6ccf97)

Application/EdFi.Ods.Standard/Standard/4.0.0/Artifacts/MsSql/Structure/Ods/Changes/0230-CreateIndirectUpdateCascadeTriggers.sql is not coming from MetaEd Artifacts 
