### PR TITLE
[ODS-6663] API rejects EdOrgId with leading zero

### DIFF
--- a/Application/EdFi.Ods.Common/Serialization/Int64Converter.cs
+++ b/Application/EdFi.Ods.Common/Serialization/Int64Converter.cs
@@ -56,7 +56,7 @@ namespace EdFi.Ods.Common.Serialization
             }
 
             // Treat any string of digits (even with leading 0s) as decimal
-            if (long.TryParse(rawValue, NumberStyles.None, CultureInfo.InvariantCulture, out long result))
+            if (long.TryParse(rawValue.Trim(), NumberStyles.None, CultureInfo.InvariantCulture, out long result))
             {
                 return BoxedLong(result);
             }

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Serialization/Int64ConverterTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Serialization/Int64ConverterTests.cs
@@ -43,6 +43,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Common.Serialization
         [TestCase("42", 42L)]
         [TestCase("0123", 83L)]         // non-string with leading zeros, interpreted as Octal by JSON .NET and arrives at the converter as "83" typed as long
         [TestCase("\"0123\"", 123L)]     // string with leading zeros
+        [TestCase("\"0123 \"", 123L)]     // string with leading zeros, trailing space
         [TestCase("\"0000000005\"", 5L)]
         [TestCase("\"0xA\"", 10L)]       // hex string
         [TestCase("\"0XfF\"", 255L)]     // hex uppercase


### PR DESCRIPTION
Updated Int64 converter to be tolerant of trailing spaces in string values.