### PR TITLE
[ODS-6697] Add Fallback Option for Whitespace Validation in Required String Fields

### DIFF
--- a/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
+++ b/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
@@ -441,6 +441,7 @@ namespace EdFi.Ods.Api.Startup
                 GeneratedArtifactStaticDependencies.Resolvers.Set(() => Container.Resolve<IDescriptorResolver>());
                 GeneratedArtifactStaticDependencies.Resolvers.Set(() => Container.Resolve<IContextProvider<DataPolicyException>>());
                 GeneratedArtifactStaticDependencies.Resolvers.Set(() => Container.Resolve<ISessionFactoryImplementor>());
+                GeneratedArtifactStaticDependencies.Resolvers.Set(() => Container.Resolve<ApiSettings>().Behaviors);
 
                 // netcore has removed the claims principal from the thread, to be on the controller.
                 // as a workaround for our current application we can resolve the IHttpContextAccessor.

--- a/Application/EdFi.Ods.Common/Attributes/RequiredWithNonDefaultAttribute.cs
+++ b/Application/EdFi.Ods.Common/Attributes/RequiredWithNonDefaultAttribute.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.ComponentModel.DataAnnotations;
+using EdFi.Ods.Common.Dependencies;
 using EdFi.Ods.Common.Extensions;
 
 namespace EdFi.Ods.Common.Attributes
@@ -20,7 +21,7 @@ namespace EdFi.Ods.Common.Attributes
         {
             if (value is string s)
             {
-                if (s.Equals(string.Empty) || IsWhiteSpace(s))
+                if (s.Equals(string.Empty) || (!GeneratedArtifactStaticDependencies.Behaviors.AllowWhitespaceOnlyValues && IsWhiteSpace(s)))
                 {
                     return BuildValidationResult($"{validationContext.DisplayName} is required and should not be left empty.");
                 }
@@ -37,7 +38,7 @@ namespace EdFi.Ods.Common.Attributes
                 // In case of decimal types, accept default values
                 return ValidationResult.Success;
             }
-            else if (value is DateTime dt && dt.Equals(value.GetType().GetDefaultValue()))
+            else if (value is DateTime dt && dt == default)
             {
                 // DateTime default value is very specific (1/1/0001 12:00:00 AM), so it can be confusing for users
                 // if they didn't used that value; no need to inform more than "the field is required"

--- a/Application/EdFi.Ods.Common/Configuration/ApiSettings.cs
+++ b/Application/EdFi.Ods.Common/Configuration/ApiSettings.cs
@@ -74,6 +74,8 @@ namespace EdFi.Ods.Common.Configuration
 
         public CacheSettings Caching { get; set; } = new();
 
+        public Behaviors Behaviors { get; set; } = new();
+
         public ServiceSettings Services { get; set; } = new();
 
         public string OdsConnectionStringEncryptionKey

--- a/Application/EdFi.Ods.Common/Configuration/Behaviors.cs
+++ b/Application/EdFi.Ods.Common/Configuration/Behaviors.cs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.Ods.Common.Configuration;
+
+/// <summary>
+/// Provides configuration settings for overriding certain API behaviors via configuration.
+/// </summary>
+public class Behaviors
+{
+    /// <summary>
+    /// Overrides the default behavior changed in v7.3 of not allowing whitespace-only values in (non-key) properties.
+    /// </summary>
+    public bool AllowWhitespaceOnlyValues { get; set; }
+}

--- a/Application/EdFi.Ods.Common/Dependencies/GeneratedArtifactStaticDependencies.cs
+++ b/Application/EdFi.Ods.Common/Dependencies/GeneratedArtifactStaticDependencies.cs
@@ -5,6 +5,7 @@
 
 using System;
 using EdFi.Ods.Common.Caching;
+using EdFi.Ods.Common.Configuration;
 using EdFi.Ods.Common.Context;
 using EdFi.Ods.Common.Descriptors;
 using EdFi.Ods.Common.Exceptions;
@@ -38,6 +39,7 @@ namespace EdFi.Ods.Common.Dependencies
         private static Lazy<IEntityExtensionRegistrar> _entityExtensionRegistrar;
         private static Lazy<IEntityExtensionsFactory> _entityExtensionsFactory;
         private static Lazy<ISessionFactoryImplementor> _sessionFactory;
+        private static Lazy<Behaviors> _behaviors;
 
         private static bool _serializedDataEnabled;
         private static bool _resourceLinksEnabled;
@@ -58,6 +60,7 @@ namespace EdFi.Ods.Common.Dependencies
         public static IEntityExtensionRegistrar EntityExtensionRegistrar => _entityExtensionRegistrar?.Value;
         public static IEntityExtensionsFactory EntityExtensionsFactory => _entityExtensionsFactory?.Value;
         public static ISessionFactoryImplementor SessionFactory => _sessionFactory?.Value;
+        public static Behaviors Behaviors => _behaviors?.Value;
         public static bool SerializedDataEnabled => _serializedDataEnabled;
         public static bool ResourceLinksEnabled => _resourceLinksEnabled;
 
@@ -145,6 +148,11 @@ namespace EdFi.Ods.Common.Dependencies
             public static void Set(Func<ISessionFactoryImplementor> resolver)
             {
                 _sessionFactory = new Lazy<ISessionFactoryImplementor>(resolver);
+            }
+
+            public static void Set(Func<Behaviors> resolver)
+            {
+                _behaviors = new Lazy<Behaviors>(resolver);
             }
 
             public static void SetEnabledFeatures(bool? serializedDataEnabled = null, bool? resourceLinksEnabled = null)

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Attributes/RequiredWithNonDefaultAttributeTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Attributes/RequiredWithNonDefaultAttributeTests.cs
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using NUnit.Framework;
+using FakeItEasy;
+using Shouldly;
+using System;
+using System.ComponentModel.DataAnnotations;
+using EdFi.Ods.Common.Attributes;
+using EdFi.Ods.Common.Configuration;
+using EdFi.Ods.Common.Dependencies;
+
+namespace EdFi.Ods.Tests.EdFi.Ods.Common.Attributes;
+
+[TestFixture]
+public class RequiredWithNonDefaultAttributeTests
+{
+    private RequiredWithNonDefaultAttribute _attribute;
+    private Behaviors _behaviors;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _attribute = new RequiredWithNonDefaultAttribute();
+        _behaviors = new Behaviors() { AllowWhitespaceOnlyValues = false };
+        GeneratedArtifactStaticDependencies.Resolvers.Set(() => _behaviors);
+    }
+
+    [Test]
+    public void Should_FailValidation_When_StringIsEmpty()
+    {
+        // Arrange
+        var context = CreateValidationContext("MyProperty");
+
+        // Act
+        var result = ValidationAttributeHelper.InvokeIsValid(_attribute, string.Empty, context);
+
+        // Assert
+        result.ShouldNotBe(null);
+        result.ErrorMessage.ShouldBe("MyProperty is required and should not be left empty.");
+    }
+
+    [Test]
+    public void Should_FailValidation_When_StringIsWhitespaceOnly_And_AllowWhitespaceOnlyValuesIsDisabled()
+    {
+        // Arrange
+        var context = CreateValidationContext("MyProperty");
+        _behaviors.AllowWhitespaceOnlyValues = false;
+
+        // Act
+        var result = ValidationAttributeHelper.InvokeIsValid(_attribute, "    ", context);
+
+        // Assert
+        result.ShouldNotBe(null);
+        result.ErrorMessage.ShouldBe("MyProperty is required and should not be left empty.");
+    }
+
+    [Test]
+    public void Should_PassValidation_When_StringIsWhitespaceOnly_And_AllowWhitespaceOnlyValuesIsEnabled()
+    {
+        // Arrange
+        var context = CreateValidationContext("MyProperty");
+        _behaviors.AllowWhitespaceOnlyValues = true;
+
+        // Act
+        var result = ValidationAttributeHelper.InvokeIsValid(_attribute, "    ", context);
+
+        // Assert
+        result.ShouldBe(ValidationResult.Success);
+    }
+
+    [Test]
+    public void Should_PassValidation_When_StringIsNotEmpty()
+    {
+        // Arrange
+        var context = CreateValidationContext("MyProperty");
+
+        // Act
+        var result = ValidationAttributeHelper.InvokeIsValid(_attribute, "Some Value", context);
+
+        // Assert
+        result.ShouldBe(ValidationResult.Success);
+    }
+
+    [Test]
+    public void Should_PassValidation_When_BooleanIsFalseOrTrue()
+    {
+        // Arrange
+        var context = CreateValidationContext("MyBoolean");
+
+        // Act & Assert
+        ValidationAttributeHelper.InvokeIsValid(_attribute, false, context).ShouldBe(ValidationResult.Success);
+        ValidationAttributeHelper.InvokeIsValid(_attribute, true, context).ShouldBe(ValidationResult.Success);
+    }
+
+    [Test]
+    public void Should_PassValidation_When_DecimalIsDefaultValue()
+    {
+        // Arrange
+        var context = CreateValidationContext("MyDecimal");
+
+        // Act
+        var result = ValidationAttributeHelper.InvokeIsValid(_attribute, 0m, context);
+
+        // Assert
+        result.ShouldBe(ValidationResult.Success);
+    }
+
+    [Test]
+    public void Should_FailValidation_When_DateTimeIsDefaultValue()
+    {
+        // Arrange
+        var context = CreateValidationContext("MyDateTime");
+
+        // Act
+        var result = ValidationAttributeHelper.InvokeIsValid(_attribute, default(DateTime), context);
+
+        // Assert
+        result.ShouldNotBe(null);
+        result.ErrorMessage.ShouldBe("MyDateTime is required.");
+    }
+
+    [Test]
+    public void Should_PassValidation_When_DateTimeIsNonDefault()
+    {
+        // Arrange
+        var context = CreateValidationContext("MyDateTime");
+
+        // Act
+        var result = ValidationAttributeHelper.InvokeIsValid(_attribute, new DateTime(2023, 1, 1), context);
+
+        // Assert
+        result.ShouldBe(ValidationResult.Success);
+    }
+
+    [Test]
+    public void Should_FailValidation_When_ValueIsTypeDefaultValue()
+    {
+        // Arrange
+        var context = CreateValidationContext("MyInt");
+
+        // Act
+        var result = ValidationAttributeHelper.InvokeIsValid(_attribute, 0, context);
+
+        // Assert
+        result.ShouldNotBe(null);
+        result.ErrorMessage.ShouldBe("MyInt value must be different than 0.");
+    }
+
+    [Test]
+    public void Should_PassValidation_When_ValueHasNonDefaultValue()
+    {
+        // Arrange
+        var context = CreateValidationContext("MyInt");
+
+        // Act
+        var result = ValidationAttributeHelper.InvokeIsValid(_attribute, 50, context);
+
+        // Assert
+        result.ShouldBe(ValidationResult.Success);
+    }
+
+    [Test]
+    public void Should_FailValidation_When_NullReferenceTypeIsProvided()
+    {
+        // Arrange
+        var context = CreateValidationContext("MyObject");
+
+        // Act
+        var result = ValidationAttributeHelper.InvokeIsValid(_attribute, null, context);
+
+        // Assert
+        result.ShouldNotBe(null);
+        result.ErrorMessage.ShouldBe("MyObject is required.");
+    }
+
+    [Test]
+    public void Should_PassValidation_When_ReferenceTypeIsNonNull()
+    {
+        // Arrange
+        var context = CreateValidationContext("MyObject");
+
+        // Act
+        var result = ValidationAttributeHelper.InvokeIsValid(_attribute, new object(), context);
+
+        // Assert
+        result.ShouldBe(ValidationResult.Success);
+    }
+
+    private ValidationContext CreateValidationContext(string memberName)
+    {
+        var fakeServiceProvider = A.Fake<IServiceProvider>();
+
+        return new ValidationContext(new object(), fakeServiceProvider, null) { MemberName = memberName };
+    }
+}

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Attributes/ValidationAttributeInvoker.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Attributes/ValidationAttributeInvoker.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+public static class ValidationAttributeHelper
+{
+    /// <summary>
+    /// Invokes the protected IsValid method (with ValidationContext) using reflection.
+    /// </summary>
+    /// <param name="attribute">The ValidationAttribute to invoke.</param>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="validationContext">The ValidationContext to provide.</param>
+    /// <returns>The ValidationResult returned by the IsValid method.</returns>
+    public static ValidationResult InvokeIsValid(
+        ValidationAttribute attribute, 
+        object value, 
+        ValidationContext validationContext)
+    {
+        if (attribute == null)
+        {
+            throw new ArgumentNullException(nameof(attribute));
+        }
+
+        // Find the protected IsValid method using reflection
+        var isValidMethod = attribute.GetType()
+            .GetMethod("IsValid", BindingFlags.NonPublic | BindingFlags.Instance, 
+                null, 
+                new Type[] { typeof(object), typeof(ValidationContext) }, 
+                null);
+        
+        if (isValidMethod == null)
+        {
+            throw new InvalidOperationException(
+                "Could not find the protected IsValid(object, ValidationContext) method.");
+        }
+
+        // Invoke the IsValid method and return the result
+        return isValidMethod.Invoke(attribute, new object[] { value, validationContext })
+            as ValidationResult;
+    }
+}


### PR DESCRIPTION
Added support for configuring Behaviors that can be used to override certain API behaviors as necessary for specific deployment environments.