### PR TITLE
[ODS-6828] IdentityManagement Feature is returning 403 when JWT is enabled

### DIFF
--- a/Application/EdFi.Ods.Api/Middleware/EdFiApiAuthenticationMiddleware.cs
+++ b/Application/EdFi.Ods.Api/Middleware/EdFiApiAuthenticationMiddleware.cs
@@ -95,6 +95,13 @@ namespace EdFi.Ods.Api.Middleware
                             // Authenticate using the unwrapped token
                             var edfiAuthenticateResult = await _oauthTokenAuthenticator.AuthenticateAsync(guidToken, "Bearer");
                             apiClientContext = (ApiClientContext) edfiAuthenticateResult.Ticket?.Properties.Parameters[nameof(ApiClientContext)];
+
+                            // Merge service claims from the GUID auth (loaded from the security DB) into the JWT principal
+                            // so that claim-based policies (e.g. IdentityManagement) work the same way as the GUID flow.
+                            if (edfiAuthenticateResult.Principal?.Identity is System.Security.Claims.ClaimsIdentity serviceClaimsIdentity)
+                            {
+                                context.User.AddIdentity(serviceClaimsIdentity);
+                            }
                         }
                     }
                     else // "OAuth" is used as the scheme for GUID-based token


### PR DESCRIPTION
In the GUID-based OAuth flow, context.User is populated with a ClaimsIdentity built from the security database (via ClaimsIdentityProvider), which includes service claims such as the IdentityManagement claim. In the JWT flow, context.User was set solely from the decoded JWT principal, so security DB service claims were never present, causing claim-based authorization policies (e.g. IdentityManagement) to fail even for clients whose claim set grants access.

After the JWT is validated and the embedded GUID token (jti claim) is used to resolve the ApiClientContext, the resulting ClaimsIdentity from the GUID auth is now merged into context.User so that both flows behave consistently.