### PR TITLE
Add cache stampede protection to Descriptors

### DIFF
--- a/Application/EdFi.Ods.Api/Caching/ExpiringConcurrentDictionaryCacheProvider.cs
+++ b/Application/EdFi.Ods.Api/Caching/ExpiringConcurrentDictionaryCacheProvider.cs
@@ -51,7 +51,6 @@ namespace EdFi.Ods.Api.Caching
         public ExpiringConcurrentDictionaryCacheProvider(string description, TimeSpan expirationPeriod, Action expirationCallback)
         {
             _description = description;
-            _expirationPeriod = expirationPeriod;
 
             // If expiration period is less than 0 disable caching behavior.
             if (expirationPeriod.TotalSeconds < 0)
@@ -59,12 +58,13 @@ namespace EdFi.Ods.Api.Caching
                 _logger.Debug($"Cache '{description}' is disabled...");
                 _cacheEnabled = false;
             }
-            // Set expiration period only if expiration period is not the default (0)
-            else if (expirationPeriod.TotalSeconds > 0)
-            {
-                _timer = new Timer(CacheExpired, null, expirationPeriod, expirationPeriod);
-                _expirationCallback = expirationCallback;
-            }
+
+            _expirationPeriod = expirationPeriod.TotalSeconds <= 0
+                ? Timeout.InfiniteTimeSpan
+                : expirationPeriod;
+
+            _expirationCallback = expirationCallback;
+            _timer = new Timer(CacheExpired, null, _expirationPeriod, _expirationPeriod);
         }
 
         public bool TryGetCachedObject(TKey key, out object value)

--- a/Application/EdFi.Ods.Api/Controllers/DataManagementControllerBase.cs
+++ b/Application/EdFi.Ods.Api/Controllers/DataManagementControllerBase.cs
@@ -25,6 +25,7 @@ using EdFi.Ods.Common.Extensions;
 using EdFi.Ods.Common.Infrastructure.Pipelines.Delete;
 using EdFi.Ods.Common.Infrastructure.Pipelines.GetMany;
 using EdFi.Ods.Common.Logging;
+using EdFi.Ods.Common.Metadata.Profiles;
 using EdFi.Ods.Common.Models.Queries;
 using EdFi.Ods.Common.Models.Resource;
 using EdFi.Ods.Common.ProblemDetails;
@@ -36,6 +37,7 @@ using log4net;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Net.Http.Headers;
+using Newtonsoft.Json;
 
 namespace EdFi.Ods.Api.Controllers
 {
@@ -356,6 +358,43 @@ namespace EdFi.Ods.Api.Controllers
             }
 
             var validationState = new ValidationState();
+
+            if (typeof(TPostRequest).FullName?.Contains(".StudentAssessments.") == true)
+            {
+                var profileContentTypeContext = _profileContentTypeContextProvider.Get();
+
+                string requestBody = JsonConvert.SerializeObject(request);
+
+                Logger.Warn(
+                    $"POST request context for '{typeof(TPostRequest).FullName}': ContentType='{Request.ContentType}', Accept='{Request.Headers.Accept}', "
+                    + $"Profile='{profileContentTypeContext?.ProfileName}', ProfileUsage='{profileContentTypeContext?.ContentTypeUsage}', "
+                    + $"ProfileDefinition='{GetProfileDefinition(profileContentTypeContext)}',"
+                    + $"RequestBody='{requestBody}'.");
+
+                string GetProfileDefinition(ProfileContentTypeContext profileContentTypeContext)
+                {
+                    if (string.IsNullOrWhiteSpace(profileContentTypeContext?.ProfileName))
+                    {
+                        return null;
+                    }
+
+                    var profileMetadataProvider = HttpContext?.RequestServices?.GetService(typeof(IProfileMetadataProvider))
+                        as IProfileMetadataProvider;
+
+                    var profileDefinitionsByName = profileMetadataProvider?.GetProfileDefinitionsByName();
+
+                    if (profileDefinitionsByName == null)
+                    {
+                        return null;
+                    }
+
+                    return profileDefinitionsByName.TryGetValue(
+                            profileContentTypeContext.ProfileName,
+                            out var profileDefinition)
+                        ? profileDefinition.ToString()
+                        : null;
+                }
+            }
 
             // Make sure Id is not already set (no client-assigned Ids)
             if (request.Id != default)

--- a/Application/EdFi.Ods.Api/Infrastructure/Pipelines/Steps/MapResourceModelToEntityModel.cs
+++ b/Application/EdFi.Ods.Api/Infrastructure/Pipelines/Steps/MapResourceModelToEntityModel.cs
@@ -13,7 +13,9 @@ using EdFi.Ods.Common.Context;
 using EdFi.Ods.Common.Infrastructure.Pipelines;
 using EdFi.Ods.Common.Repositories;
 using EdFi.Ods.Common.Security.Claims;
+using log4net;
 using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
 
 namespace EdFi.Ods.Api.Infrastructure.Pipelines.Steps
 {
@@ -23,6 +25,14 @@ namespace EdFi.Ods.Api.Infrastructure.Pipelines.Steps
         where TResourceModel : class, IMappable, IHasETag
         where TEntityModel : class, new()
     {
+        private static readonly ILog _logger = LogManager.GetLogger(typeof(MapResourceModelToEntityModel<TContext, TResult, TResourceModel, TEntityModel>));
+        private readonly IContextProvider<DataManagementResourceContext> _dataManagementResourceContextProvider;
+
+        public MapResourceModelToEntityModel(IContextProvider<DataManagementResourceContext> dataManagementResourceContextProvider)
+        {
+            _dataManagementResourceContextProvider = dataManagementResourceContextProvider;
+        }
+
         public Task ExecuteAsync(TContext context, TResult result, CancellationToken cancellationToken)
         {
             // NOTE this step will always run synchronously so we are not moving the logic to the async method.
@@ -31,6 +41,13 @@ namespace EdFi.Ods.Api.Infrastructure.Pipelines.Steps
                 if (context.Resource == default(TResourceModel))
                 {
                     return Task.CompletedTask;
+                }
+
+                if (_dataManagementResourceContextProvider.Get()?.HttpMethod == HttpMethods.Post
+                    && context.Resource.GetType().FullName?.Contains(".StudentAssessments.") == true)
+                {
+                    string bodyBeforeMapping = JsonConvert.SerializeObject(context.Resource);
+                    _logger.Warn($"Resource before mapping='{bodyBeforeMapping}'");
                 }
 
                 var entity = new TEntityModel();

--- a/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
+++ b/Application/EdFi.Ods.Api/Startup/OdsStartupBase.cs
@@ -434,6 +434,7 @@ namespace EdFi.Ods.Api.Startup
                 GeneratedArtifactStaticDependencies.Resolvers.Set(() => Container.Resolve<IAuthorizationContextProvider>());
                 GeneratedArtifactStaticDependencies.Resolvers.Set(() => Container.Resolve<IETagProvider>());
                 GeneratedArtifactStaticDependencies.Resolvers.Set(() => Container.Resolve<IMappingContractProvider>());
+                GeneratedArtifactStaticDependencies.Resolvers.Set(() => Container.Resolve<IContextProvider<DataManagementResourceContext>>());
                 GeneratedArtifactStaticDependencies.Resolvers.Set(() => Container.Resolve<IContextProvider<ProfileContentTypeContext>>());
                 GeneratedArtifactStaticDependencies.Resolvers.Set(() => Container.Resolve<IContextProvider<UniqueIdLookupsByUsiContext>>());
                 GeneratedArtifactStaticDependencies.Resolvers.Set(() => Container.Resolve<IContextProvider<UsiLookupsByUniqueIdContext>>());

--- a/Application/EdFi.Ods.Common/Dependencies/GeneratedArtifactStaticDependencies.cs
+++ b/Application/EdFi.Ods.Common/Dependencies/GeneratedArtifactStaticDependencies.cs
@@ -29,6 +29,7 @@ namespace EdFi.Ods.Common.Dependencies
         private static Lazy<IDomainModelProvider> _domainModelProvider;
         private static Lazy<IETagProvider> _etagProvider;
         private static Lazy<IMappingContractProvider> _mappingContractProvider;
+        private static Lazy<IContextProvider<DataManagementResourceContext>> _dataManagementResourceContextProvider;
         private static Lazy<IContextProvider<ProfileContentTypeContext>> _profileContentTypeContextProvider;
         private static Lazy<IContextProvider<UniqueIdLookupsByUsiContext>> _uniqueIdLookupsContextProvider;
         private static Lazy<IContextProvider<UsiLookupsByUniqueIdContext>> _usiLookupsContextProvider;
@@ -50,6 +51,7 @@ namespace EdFi.Ods.Common.Dependencies
         public static IDomainModelProvider DomainModelProvider => _domainModelProvider?.Value;
         public static IETagProvider ETagProvider => _etagProvider?.Value;
         public static IMappingContractProvider MappingContractProvider => _mappingContractProvider?.Value;
+        public static IContextProvider<DataManagementResourceContext> DataManagementResourceContextProvider => _dataManagementResourceContextProvider?.Value;
         public static IContextProvider<ProfileContentTypeContext> ProfileContentTypeContextProvider => _profileContentTypeContextProvider?.Value;
         public static IContextProvider<UniqueIdLookupsByUsiContext> UniqueIdLookupsByUsiContextProvider => _uniqueIdLookupsContextProvider?.Value;
         public static IContextProvider<UsiLookupsByUniqueIdContext> UsiLookupsByUniqueIdContextProvider => _usiLookupsContextProvider?.Value;
@@ -98,6 +100,11 @@ namespace EdFi.Ods.Common.Dependencies
             public static void Set(Func<IMappingContractProvider> resolver)
             {
                 _mappingContractProvider = new Lazy<IMappingContractProvider>(resolver);
+            }
+
+            public static void Set(Func<IContextProvider<DataManagementResourceContext>> resolver)
+            {
+                _dataManagementResourceContextProvider = new Lazy<IContextProvider<DataManagementResourceContext>>(resolver);
             }
 
             public static void Set(Func<IContextProvider<ProfileContentTypeContext>> resolver)

--- a/Application/EdFi.Ods.Common/Descriptors/DescriptorMapsProvider.cs
+++ b/Application/EdFi.Ods.Common/Descriptors/DescriptorMapsProvider.cs
@@ -5,6 +5,11 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using EdFi.Ods.Common.Caching;
+using EdFi.Ods.Common.Configuration;
+using EdFi.Ods.Common.Context;
 using EdFi.Ods.Common.Database;
 
 namespace EdFi.Ods.Common.Descriptors;
@@ -15,14 +20,55 @@ namespace EdFi.Ods.Common.Descriptors;
 public class DescriptorMapsProvider : IDescriptorMapsProvider
 {
     private readonly IDescriptorDetailsProvider _descriptorDetailsProvider;
+    private readonly IContextProvider<OdsInstanceConfiguration> _contextProvider;
 
-    public DescriptorMapsProvider(IDescriptorDetailsProvider descriptorDetailsProvider)
+    // Cache stampede protection keyed by OdsInstance. The Interceptor still provides the
+    // long-lived caching; this dictionary holds the Lazy only for the duration of a single
+    // in-flight load.
+    private readonly ConcurrentDictionary<ulong, Lazy<DescriptorMaps>> _flights = new();
+
+    public DescriptorMapsProvider(
+        IDescriptorDetailsProvider descriptorDetailsProvider,
+        IContextProvider<OdsInstanceConfiguration> contextProvider)
     {
         _descriptorDetailsProvider = descriptorDetailsProvider;
+        _contextProvider = contextProvider;
     }
 
     /// <inheritdoc cref="IDescriptorMapsProvider.GetMaps" />
     public DescriptorMaps GetMaps()
+    {
+        ulong key = ComputeFlightKey();
+
+        var flight = _flights.GetOrAdd(
+            key,
+            _ => new Lazy<DescriptorMaps>(LoadMaps, LazyThreadSafetyMode.ExecutionAndPublication));
+
+        try
+        {
+            return flight.Value;
+        }
+        finally
+        {
+            _flights.TryRemove(new KeyValuePair<ulong, Lazy<DescriptorMaps>>(key, flight));
+        }
+    }
+
+    private ulong ComputeFlightKey()
+    {
+        var context = _contextProvider.Get();
+
+        // Without context, we cannot generate a key
+        if (context == null)
+        {
+            throw new InvalidOperationException(
+                $"No context has been set for value of type '{nameof(OdsInstanceConfiguration)}'.");
+        }
+
+        return context.OdsInstanceHashId;
+    }
+
+    private DescriptorMaps LoadMaps()
     {
         var allDescriptors = _descriptorDetailsProvider.GetAllDescriptorDetails();
 

--- a/Application/EdFi.Ods.Common/Descriptors/DescriptorResolver.cs
+++ b/Application/EdFi.Ods.Common/Descriptors/DescriptorResolver.cs
@@ -3,12 +3,16 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using log4net;
+
 namespace EdFi.Ods.Common.Descriptors;
 
 public class DescriptorResolver : IDescriptorResolver
 {
     private readonly IDescriptorDetailsProvider _descriptorDetailsProvider;
     private readonly IDescriptorMapsProvider _descriptorMapsProvider;
+
+    private readonly ILog _logger = LogManager.GetLogger(typeof(DescriptorResolver));
 
     public DescriptorResolver(
         IDescriptorMapsProvider descriptorMapsProvider,
@@ -22,6 +26,7 @@ public class DescriptorResolver : IDescriptorResolver
     {
         if (uri == null)
         {
+            _logger.Warn($"GetDescriptorId returning default for descriptor '{descriptorName}': supplied uri is null.");
             return default;
         }
         
@@ -37,16 +42,28 @@ public class DescriptorResolver : IDescriptorResolver
                 descriptorMaps.DescriptorIdByUri.TryAdd(descriptorDetails.Uri, (descriptorName, descriptorDetails.DescriptorId));
                 descriptorMaps.UriByDescriptorId.TryAdd(descriptorDetails.DescriptorId, (descriptorName, descriptorDetails.Uri));
 
+                if (descriptorDetails.DescriptorId == default)
+                {
+                    _logger.Warn($"GetDescriptorId resolved descriptor '{descriptorName}' uri '{uri}' to a default DescriptorId (0) via database lookup. DescriptorMaps count: {descriptorMaps.DescriptorIdByUri.Count}.");
+                }
+
                 return descriptorDetails.DescriptorId;
             }
 
+            _logger.Warn($"GetDescriptorId returning default for descriptor '{descriptorName}': uri '{uri}' was not found in the DescriptorMaps or the database. DescriptorMaps count: {descriptorMaps.DescriptorIdByUri.Count}.");
             return default;
         }
 
         if (descriptorBrief.descriptorName != descriptorName)
         {
             // This is a descriptor uri for a different descriptor type
+            _logger.Warn($"GetDescriptorId returning default for descriptor '{descriptorName}': uri '{uri}' is registered for a different descriptor type ('{descriptorBrief.descriptorName}'). DescriptorMaps count: {descriptorMaps.DescriptorIdByUri.Count}.");
             return default;
+        }
+
+        if (descriptorBrief.descriptorId == default)
+        {
+            _logger.Warn($"GetDescriptorId resolved descriptor '{descriptorName}' uri '{uri}' to a default DescriptorId (0) from the DescriptorMaps. DescriptorMaps count: {descriptorMaps.DescriptorIdByUri.Count}.");
         }
 
         return descriptorBrief.descriptorId;

--- a/Application/EdFi.Ods.Common/Models/MappingContractProvider.cs
+++ b/Application/EdFi.Ods.Common/Models/MappingContractProvider.cs
@@ -268,6 +268,36 @@ public class MappingContractProvider : IMappingContractProvider
                         })
                     .ToArray();
 
+                if (key.ResourceClassName.Name == "StudentAssessmentStudentObjectiveAssessmentScoreResult")
+                {
+                    var constructorParameters = constructorInfo.GetParameters();
+
+                    var argumentDetails = string.Join(
+                        ", ",
+                        constructorParameters.Select(
+                            (parameter, index) => $"{parameter.Name}='{FormatMappingContractArgument(arguments[index])}'"));
+
+                    @this._logger.Warn(
+                        $"Mapping contract created: profile='{key.ProfileName}', usage='{key.ContentTypeUsage}', "
+                        + $"profileResource='{key.ProfileResourceName}', resourceClass='{key.ResourceClassName}', arguments='{argumentDetails}'.");
+
+
+                    string FormatMappingContractArgument(object argument)
+                    {
+                        if (argument == null)
+                        {
+                            return "null";
+                        }
+
+                        if (argument is Array values)
+                        {
+                            return $"[{string.Join(",", values.Cast<object>())}]";
+                        }
+
+                        return argument.ToString();
+                    }
+                }
+
                 // Create the synchronization context
                 return (IMappingContract)constructorInfo.Invoke(arguments);
             }, 

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/ExpiringConcurrentDictionaryCacheProviderTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/ExpiringConcurrentDictionaryCacheProviderTests.cs
@@ -141,5 +141,58 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
             result.ShouldBeFalse();
             value.ShouldBeNull();
         }
+
+        [Test]
+        public void Clear_ShouldNotThrow_WhenCacheDisabled()
+        {
+            // Arrange
+            var provider = new ExpiringConcurrentDictionaryCacheProvider<string>("TestCache", TimeSpan.FromSeconds(-1));
+
+            // Act + Assert
+            Should.NotThrow(() => provider.Clear());
+
+            // Cache remains disabled after Clear
+            provider.SetCachedObject("TestKey", "TestValue");
+            provider.TryGetCachedObject("TestKey", out var value).ShouldBeFalse();
+            value.ShouldBeNull();
+        }
+
+        [Test]
+        public void Clear_ShouldClearDictionary_WhenExpirationIsZero()
+        {
+            // Arrange
+            var expirationCallback = A.Fake<Action>();
+            var provider = new ExpiringConcurrentDictionaryCacheProvider<string>("TestCache", TimeSpan.Zero, expirationCallback);
+            provider.SetCachedObject("TestKey1", "TestValue1");
+            provider.SetCachedObject("TestKey2", "TestValue2");
+
+            // Act
+            provider.Clear();
+
+            // Assert: prior entries gone, callback not fired, cache still usable.
+            provider.TryGetCachedObject("TestKey1", out _).ShouldBeFalse();
+            provider.TryGetCachedObject("TestKey2", out _).ShouldBeFalse();
+            A.CallTo(() => expirationCallback.Invoke()).MustNotHaveHappened();
+
+            provider.SetCachedObject("AfterClear", "Value");
+            provider.TryGetCachedObject("AfterClear", out var value).ShouldBeTrue();
+            value.ShouldBe("Value");
+        }
+
+        [Test]
+        public void Clear_ShouldClearDictionary_WhenExpirationIsPositive()
+        {
+            // Arrange. Use a long expiration so the timer cannot fire during the test.
+            var provider = new ExpiringConcurrentDictionaryCacheProvider<string>("TestCache", TimeSpan.FromMinutes(10));
+            provider.SetCachedObject("TestKey1", "TestValue1");
+            provider.SetCachedObject("TestKey2", "TestValue2");
+
+            // Act
+            provider.Clear();
+
+            // Assert
+            provider.TryGetCachedObject("TestKey1", out _).ShouldBeFalse();
+            provider.TryGetCachedObject("TestKey2", out _).ShouldBeFalse();
+        }
     }
 }

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Descriptors/DescriptorMapsProviderTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Descriptors/DescriptorMapsProviderTests.cs
@@ -4,15 +4,16 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using EdFi.Ods.Common.Configuration;
+using EdFi.Ods.Common.Context;
 using EdFi.Ods.Common.Database;
 using EdFi.Ods.Common.Descriptors;
+using FakeItEasy;
+using NUnit.Framework;
 using Shouldly;
 
 namespace EdFi.Ods.Tests.EdFi.Ods.Common.Descriptors;
-
-using System.Collections.Generic;
-using FakeItEasy;
-using NUnit.Framework;
 
 [TestFixture]
 public class DescriptorMapsProviderTests
@@ -24,8 +25,10 @@ public class DescriptorMapsProviderTests
         var descriptorDetailsProvider = A.Fake<IDescriptorDetailsProvider>();
         
         A.CallTo(() => descriptorDetailsProvider.GetAllDescriptorDetails()).Returns(GetSampleDescriptorDetails());
-        
-        var provider = new DescriptorMapsProvider(descriptorDetailsProvider);
+
+        var contextProvider = FakeContextProvider();
+
+        var provider = new DescriptorMapsProvider(descriptorDetailsProvider, contextProvider);
 
         // Act
         var maps = provider.GetMaps();
@@ -47,6 +50,219 @@ public class DescriptorMapsProviderTests
         
         maps.UriByDescriptorId[1].ShouldBe(("AbcDescriptor", "http://ed-fi.org/TestDescriptor#1"));
         maps.UriByDescriptorId[2].ShouldBe(("AbcDescriptor", "http://ed-fi.org/TestDescriptor#2"));
+    }
+
+    [Test]
+    public void GetMaps_ConcurrentCallers_InvokeLoaderOnce_AndReturnSameInstance()
+    {
+        // Arrange
+        const int concurrentCallers = 3;
+
+        var loaderInvocations = 0;
+        var gate = new System.Threading.ManualResetEventSlim(initialState: false);
+
+        var descriptorDetailsProvider = A.Fake<IDescriptorDetailsProvider>();
+
+        A.CallTo(() => descriptorDetailsProvider.GetAllDescriptorDetails())
+            .ReturnsLazily(() =>
+            {
+                System.Threading.Interlocked.Increment(ref loaderInvocations);
+                gate.Wait();
+                return GetSampleDescriptorDetails();
+            });
+
+        var provider = new DescriptorMapsProvider(
+            descriptorDetailsProvider,
+            FakeContextProvider());
+
+        var tasks = new System.Threading.Tasks.Task<DescriptorMaps>[concurrentCallers];
+        var started = new System.Threading.CountdownEvent(concurrentCallers);
+
+        // Act
+        for (int i = 0; i < concurrentCallers; i++)
+        {
+            tasks[i] = System.Threading.Tasks.Task.Run(() =>
+            {
+                started.Signal();
+                return provider.GetMaps();
+            });
+        }
+
+        // Wait for all callers to be in flight before releasing the loader
+        started.Wait(TimeSpan.FromSeconds(15)).ShouldBeTrue("callers did not all start");
+        gate.Set();
+
+        System.Threading.Tasks.Task.WaitAll(tasks, TimeSpan.FromSeconds(10)).ShouldBeTrue("tasks did not complete");
+
+        // Assert
+        loaderInvocations.ShouldBe(1);
+
+        var first = tasks[0].Result;
+        first.ShouldNotBeNull();
+
+        for (int i = 1; i < concurrentCallers; i++)
+        {
+            tasks[i].Result.ShouldBeSameAs(first);
+        }
+    }
+
+    [Test]
+    public void GetMaps_LoaderException_PropagatesToWaiters_AndDoesNotPoisonFutureCalls()
+    {
+        // Arrange
+        const int concurrentCallers = 3;
+
+        var loaderInvocations = 0;
+        var gate = new System.Threading.ManualResetEventSlim(initialState: false);
+        var shouldThrow = true;
+
+        var descriptorDetailsProvider = A.Fake<IDescriptorDetailsProvider>();
+
+        A.CallTo(() => descriptorDetailsProvider.GetAllDescriptorDetails())
+            .ReturnsLazily(() =>
+            {
+                System.Threading.Interlocked.Increment(ref loaderInvocations);
+                gate.Wait();
+
+                if (shouldThrow)
+                {
+                    throw new InvalidOperationException("boom");
+                }
+
+                return GetSampleDescriptorDetails();
+            });
+
+        var provider = new DescriptorMapsProvider(
+            descriptorDetailsProvider,
+            FakeContextProvider());
+
+        var tasks = new System.Threading.Tasks.Task<DescriptorMaps>[concurrentCallers];
+        var started = new System.Threading.CountdownEvent(concurrentCallers);
+
+        // Act — first wave: loader throws
+        for (int i = 0; i < concurrentCallers; i++)
+        {
+            tasks[i] = System.Threading.Tasks.Task.Run(() =>
+            {
+                started.Signal();
+                return provider.GetMaps();
+            });
+        }
+
+        started.Wait(TimeSpan.FromSeconds(15)).ShouldBeTrue("callers did not all start");
+        gate.Set();
+
+        // Assert — all waiters observe the same exception, loader ran once
+        foreach (var task in tasks)
+        {
+            var ex = Should.Throw<AggregateException>(() => task.Wait());
+            ex.InnerException.ShouldBeOfType<InvalidOperationException>();
+            ex.InnerException!.Message.ShouldBe("boom");
+        }
+
+        loaderInvocations.ShouldBe(1);
+
+        // Act — second wave: loader should be re-invoked (no poisoning)
+        shouldThrow = false;
+        gate.Set(); // loader proceeds immediately this time
+
+        var result = provider.GetMaps();
+
+        // Assert — the loader ran a second time and a fresh result was produced
+        loaderInvocations.ShouldBe(2);
+        result.ShouldNotBeNull();
+        result.DescriptorIdByUri.Count.ShouldBe(2);
+    }
+
+    [Test]
+    public void GetMaps_DifferentContexts_DoNotSerializeAgainstEachOther()
+    {
+        // Arrange
+        var gateA = new System.Threading.ManualResetEventSlim(initialState: false);
+        var gateB = new System.Threading.ManualResetEventSlim(initialState: false);
+        var loaderAEntered = new System.Threading.ManualResetEventSlim(initialState: false);
+        var loaderBEntered = new System.Threading.ManualResetEventSlim(initialState: false);
+
+        OdsInstanceConfiguration currentContext = null;
+        var contextProvider = A.Fake<IContextProvider<OdsInstanceConfiguration>>();
+        A.CallTo(() => contextProvider.Get()).ReturnsLazily(() => currentContext);
+
+        var contextA = BuildContext(odsInstanceId: 1);
+        var contextB = BuildContext(odsInstanceId: 2);
+
+        var descriptorDetailsProvider = A.Fake<IDescriptorDetailsProvider>();
+
+        // Each loader signals entry and waits for its dedicated gate before returning.
+        // If the single-flight were NOT keyed by context, the second caller would block
+        // on the first's Lazy and we would never observe BOTH loaders entered concurrently.
+        A.CallTo(() => descriptorDetailsProvider.GetAllDescriptorDetails())
+            .ReturnsLazily(() =>
+            {
+                if (ReferenceEquals(currentContext, contextA))
+                {
+                    loaderAEntered.Set();
+                    gateA.Wait();
+                }
+                else
+                {
+                    loaderBEntered.Set();
+                    gateB.Wait();
+                }
+
+                return GetSampleDescriptorDetails();
+            });
+
+        var provider = new DescriptorMapsProvider(descriptorDetailsProvider, contextProvider);
+
+        // Act
+        var taskA = System.Threading.Tasks.Task.Run(() =>
+        {
+            currentContext = contextA;
+            return provider.GetMaps();
+        });
+
+        // Wait for loader A to be in flight before starting B so we can observe concurrency
+        loaderAEntered.Wait(TimeSpan.FromSeconds(15)).ShouldBeTrue("loader A did not enter");
+
+        var taskB = System.Threading.Tasks.Task.Run(() =>
+        {
+            currentContext = contextB;
+            return provider.GetMaps();
+        });
+
+        loaderBEntered.Wait(TimeSpan.FromSeconds(15))
+            .ShouldBeTrue("loader B was blocked on loader A — single-flight is not context-keyed");
+
+        // Release both loaders
+        gateA.Set();
+        gateB.Set();
+
+        System.Threading.Tasks.Task.WaitAll(new[] { taskA, taskB }, TimeSpan.FromSeconds(10))
+            .ShouldBeTrue("tasks did not complete");
+
+        // Assert — both succeeded
+        taskA.Result.ShouldNotBeNull();
+        taskB.Result.ShouldNotBeNull();
+    }
+
+    private static OdsInstanceConfiguration BuildContext(int odsInstanceId)
+    {
+        return new OdsInstanceConfiguration(
+            odsInstanceId: odsInstanceId,
+            odsInstanceHashId: (ulong)odsInstanceId,
+            connectionString: string.Empty,
+            contextValueByKey: new Dictionary<string, string>(),
+            connectionStringByDerivativeType: new Dictionary<DerivativeType, string>());
+    }
+    
+    private static IContextProvider<OdsInstanceConfiguration> FakeContextProvider(int odsInstanceId = 1)
+    {
+        var config = BuildContext(odsInstanceId);
+
+        var contextProvider = A.Fake<IContextProvider<OdsInstanceConfiguration>>();
+        A.CallTo(() => contextProvider.Get()).Returns(config);
+
+        return contextProvider;
     }
 
     private static List<DescriptorDetails> GetSampleDescriptorDetails()

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/4.0.0/DataStandard_400_ApprovalTests.Verify.Extensions.Homograph.1.0.0_Std_4.0.0_Models_Mappers_EntityMapper.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/4.0.0/DataStandard_400_ApprovalTests.Verify.Extensions.Homograph.1.0.0_Std_4.0.0_Models_Mappers_EntityMapper.generated.approved.cs
@@ -11,6 +11,8 @@ using EdFi.Ods.Common.Exceptions;
 using EdFi.Ods.Common.Extensions;
 using EdFi.Ods.Common.Models;
 using EdFi.Ods.Common.Models.Domain;
+using log4net;
+using Microsoft.AspNetCore.Http;
 using EdFi.Ods.Entities.Common.EdFi;
 // Aggregate: Name
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/4.0.0/DataStandard_400_ApprovalTests.Verify.Extensions.Sample.1.0.0_Std_4.0.0_Models_Mappers_EntityMapper.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/4.0.0/DataStandard_400_ApprovalTests.Verify.Extensions.Sample.1.0.0_Std_4.0.0_Models_Mappers_EntityMapper.generated.approved.cs
@@ -11,6 +11,8 @@ using EdFi.Ods.Common.Exceptions;
 using EdFi.Ods.Common.Extensions;
 using EdFi.Ods.Common.Models;
 using EdFi.Ods.Common.Models.Domain;
+using log4net;
+using Microsoft.AspNetCore.Http;
 using EdFi.Ods.Entities.Common.EdFi;
 // Aggregate: ArtMediumDescriptor
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/4.0.0/DataStandard_400_ApprovalTests.Verify.Extensions.SampleAlternativeEducationProgram.1.0.0_Std_4.0.0_Models_Mappers_EntityMapper.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/4.0.0/DataStandard_400_ApprovalTests.Verify.Extensions.SampleAlternativeEducationProgram.1.0.0_Std_4.0.0_Models_Mappers_EntityMapper.generated.approved.cs
@@ -11,6 +11,8 @@ using EdFi.Ods.Common.Exceptions;
 using EdFi.Ods.Common.Extensions;
 using EdFi.Ods.Common.Models;
 using EdFi.Ods.Common.Models.Domain;
+using log4net;
+using Microsoft.AspNetCore.Http;
 using EdFi.Ods.Entities.Common.EdFi;
 // Aggregate: AlternativeEducationEligibilityReasonDescriptor
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/4.0.0/DataStandard_400_ApprovalTests.Verify.Extensions.SampleStudentTranscript.1.0.0_Std_4.0.0_Models_Mappers_EntityMapper.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/4.0.0/DataStandard_400_ApprovalTests.Verify.Extensions.SampleStudentTranscript.1.0.0_Std_4.0.0_Models_Mappers_EntityMapper.generated.approved.cs
@@ -11,6 +11,8 @@ using EdFi.Ods.Common.Exceptions;
 using EdFi.Ods.Common.Extensions;
 using EdFi.Ods.Common.Models;
 using EdFi.Ods.Common.Models.Domain;
+using log4net;
+using Microsoft.AspNetCore.Http;
 using EdFi.Ods.Entities.Common.EdFi;
 // Aggregate: InstitutionControlDescriptor
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/4.0.0/DataStandard_400_ApprovalTests.Verify.Extensions.TPDM.1.1.0_Std_4.0.0_Models_Mappers_EntityMapper.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/4.0.0/DataStandard_400_ApprovalTests.Verify.Extensions.TPDM.1.1.0_Std_4.0.0_Models_Mappers_EntityMapper.generated.approved.cs
@@ -11,6 +11,8 @@ using EdFi.Ods.Common.Exceptions;
 using EdFi.Ods.Common.Extensions;
 using EdFi.Ods.Common.Models;
 using EdFi.Ods.Common.Models.Domain;
+using log4net;
+using Microsoft.AspNetCore.Http;
 using EdFi.Ods.Entities.Common.EdFi;
 // Aggregate: AccreditationStatusDescriptor
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/4.0.0/DataStandard_400_ApprovalTests.Verify.Standard_Std_4.0.0_Models_Mappers_EntityMapper.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/4.0.0/DataStandard_400_ApprovalTests.Verify.Standard_Std_4.0.0_Models_Mappers_EntityMapper.generated.approved.cs
@@ -11,6 +11,8 @@ using EdFi.Ods.Common.Exceptions;
 using EdFi.Ods.Common.Extensions;
 using EdFi.Ods.Common.Models;
 using EdFi.Ods.Common.Models.Domain;
+using log4net;
+using Microsoft.AspNetCore.Http;
 using EdFi.Ods.Entities.Common.EdFi;
 // Aggregate: AbsenceEventCategoryDescriptor
 
@@ -63921,6 +63923,8 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentAssessmentAggregate
     public static class StudentAssessmentStudentObjectiveAssessmentScoreResultMapper
     {
         private static readonly FullName _fullName_edfi_StudentAssessmentStudentObjectiveAssessmentScoreResult = new FullName("edfi", "StudentAssessmentStudentObjectiveAssessmentScoreResult");
+        private static readonly ILog _logger = LogManager.GetLogger(typeof(StudentAssessmentStudentObjectiveAssessmentScoreResultMapper));
+
     
         public static bool SynchronizeTo(this IStudentAssessmentStudentObjectiveAssessmentScoreResult source, IStudentAssessmentStudentObjectiveAssessmentScoreResult target)
         {
@@ -63941,8 +63945,20 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentAssessmentAggregate
                 isModified = true;
             }
 
-            if ((mappingContract?.IsResultDatatypeTypeDescriptorSupported != false)
-                && target.ResultDatatypeTypeDescriptor != source.ResultDatatypeTypeDescriptor)
+            var sourceValue = source.ResultDatatypeTypeDescriptor;
+            var targetValue = target.ResultDatatypeTypeDescriptor;
+            var shouldSynchronize = (mappingContract?.IsResultDatatypeTypeDescriptorSupported != false)
+                && targetValue != sourceValue;
+
+            if (GeneratedArtifactStaticDependencies.DataManagementResourceContextProvider?.Get()?.HttpMethod == HttpMethods.Post)
+            {
+                _logger.Warn(
+                    "StudentAssessmentStudentObjectiveAssessmentScoreResult.ResultDatatypeTypeDescriptor SynchronizeTo decision: "
+                    + $"shouldSynchronize='{shouldSynchronize}', supported='{mappingContract?.IsResultDatatypeTypeDescriptorSupported}', "
+                    + $"source='{sourceValue}', target='{targetValue}'.");
+            }
+
+            if (shouldSynchronize)
             {
                 target.ResultDatatypeTypeDescriptor = source.ResultDatatypeTypeDescriptor;
                 isModified = true;
@@ -63972,7 +63988,18 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentAssessmentAggregate
             if (mappingContract?.IsResultSupported != false)
                 target.Result = source.Result;
 
-            if (mappingContract?.IsResultDatatypeTypeDescriptorSupported != false)
+            var sourceValue = source.ResultDatatypeTypeDescriptor;
+            var shouldMap = mappingContract?.IsResultDatatypeTypeDescriptorSupported != false;
+
+            if (GeneratedArtifactStaticDependencies.DataManagementResourceContextProvider?.Get()?.HttpMethod == HttpMethods.Post)
+            {
+                _logger.Warn(
+                    "StudentAssessmentStudentObjectiveAssessmentScoreResult.ResultDatatypeTypeDescriptor MapTo decision: "
+                    + $"shouldMap='{shouldMap}', supported='{mappingContract?.IsResultDatatypeTypeDescriptorSupported}', "
+                    + $"source='{sourceValue}'.");
+            }
+
+            if (shouldMap)
                 target.ResultDatatypeTypeDescriptor = source.ResultDatatypeTypeDescriptor;
 
             // Copy Aggregate Reference Data

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/5.2.0/DataStandard_520_ApprovalTests.Verify.Extensions.Homograph.1.0.0_Std_5.2.0_Models_Mappers_EntityMapper.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/5.2.0/DataStandard_520_ApprovalTests.Verify.Extensions.Homograph.1.0.0_Std_5.2.0_Models_Mappers_EntityMapper.generated.approved.cs
@@ -11,6 +11,8 @@ using EdFi.Ods.Common.Exceptions;
 using EdFi.Ods.Common.Extensions;
 using EdFi.Ods.Common.Models;
 using EdFi.Ods.Common.Models.Domain;
+using log4net;
+using Microsoft.AspNetCore.Http;
 using EdFi.Ods.Entities.Common.EdFi;
 // Aggregate: Contact
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/5.2.0/DataStandard_520_ApprovalTests.Verify.Extensions.Sample.1.0.0_Std_5.2.0_Models_Mappers_EntityMapper.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/5.2.0/DataStandard_520_ApprovalTests.Verify.Extensions.Sample.1.0.0_Std_5.2.0_Models_Mappers_EntityMapper.generated.approved.cs
@@ -11,6 +11,8 @@ using EdFi.Ods.Common.Exceptions;
 using EdFi.Ods.Common.Extensions;
 using EdFi.Ods.Common.Models;
 using EdFi.Ods.Common.Models.Domain;
+using log4net;
+using Microsoft.AspNetCore.Http;
 using EdFi.Ods.Entities.Common.EdFi;
 // Aggregate: ArtMediumDescriptor
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/5.2.0/DataStandard_520_ApprovalTests.Verify.Extensions.SampleAlternativeEducationProgram.1.0.0_Std_5.2.0_Models_Mappers_EntityMapper.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/5.2.0/DataStandard_520_ApprovalTests.Verify.Extensions.SampleAlternativeEducationProgram.1.0.0_Std_5.2.0_Models_Mappers_EntityMapper.generated.approved.cs
@@ -11,6 +11,8 @@ using EdFi.Ods.Common.Exceptions;
 using EdFi.Ods.Common.Extensions;
 using EdFi.Ods.Common.Models;
 using EdFi.Ods.Common.Models.Domain;
+using log4net;
+using Microsoft.AspNetCore.Http;
 using EdFi.Ods.Entities.Common.EdFi;
 // Aggregate: AlternativeEducationEligibilityReasonDescriptor
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/5.2.0/DataStandard_520_ApprovalTests.Verify.Extensions.SampleStudentTranscript.1.0.0_Std_5.2.0_Models_Mappers_EntityMapper.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/5.2.0/DataStandard_520_ApprovalTests.Verify.Extensions.SampleStudentTranscript.1.0.0_Std_5.2.0_Models_Mappers_EntityMapper.generated.approved.cs
@@ -11,6 +11,8 @@ using EdFi.Ods.Common.Exceptions;
 using EdFi.Ods.Common.Extensions;
 using EdFi.Ods.Common.Models;
 using EdFi.Ods.Common.Models.Domain;
+using log4net;
+using Microsoft.AspNetCore.Http;
 using EdFi.Ods.Entities.Common.EdFi;
 // Aggregate: InstitutionControlDescriptor
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/5.2.0/DataStandard_520_ApprovalTests.Verify.Extensions.TPDM.1.1.0_Std_5.2.0_Models_Mappers_EntityMapper.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/5.2.0/DataStandard_520_ApprovalTests.Verify.Extensions.TPDM.1.1.0_Std_5.2.0_Models_Mappers_EntityMapper.generated.approved.cs
@@ -11,6 +11,8 @@ using EdFi.Ods.Common.Exceptions;
 using EdFi.Ods.Common.Extensions;
 using EdFi.Ods.Common.Models;
 using EdFi.Ods.Common.Models.Domain;
+using log4net;
+using Microsoft.AspNetCore.Http;
 using EdFi.Ods.Entities.Common.EdFi;
 // Aggregate: AccreditationStatusDescriptor
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/5.2.0/DataStandard_520_ApprovalTests.Verify.Standard_Std_5.2.0_Models_Mappers_EntityMapper.generated.approved.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen.Tests/Approval/5.2.0/DataStandard_520_ApprovalTests.Verify.Standard_Std_5.2.0_Models_Mappers_EntityMapper.generated.approved.cs
@@ -11,6 +11,8 @@ using EdFi.Ods.Common.Exceptions;
 using EdFi.Ods.Common.Extensions;
 using EdFi.Ods.Common.Models;
 using EdFi.Ods.Common.Models.Domain;
+using log4net;
+using Microsoft.AspNetCore.Http;
 using EdFi.Ods.Entities.Common.EdFi;
 // Aggregate: AbsenceEventCategoryDescriptor
 
@@ -67311,6 +67313,8 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentAssessmentAggregate
     public static class StudentAssessmentStudentObjectiveAssessmentScoreResultMapper
     {
         private static readonly FullName _fullName_edfi_StudentAssessmentStudentObjectiveAssessmentScoreResult = new FullName("edfi", "StudentAssessmentStudentObjectiveAssessmentScoreResult");
+        private static readonly ILog _logger = LogManager.GetLogger(typeof(StudentAssessmentStudentObjectiveAssessmentScoreResultMapper));
+
     
         public static bool SynchronizeTo(this IStudentAssessmentStudentObjectiveAssessmentScoreResult source, IStudentAssessmentStudentObjectiveAssessmentScoreResult target)
         {
@@ -67331,8 +67335,20 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentAssessmentAggregate
                 isModified = true;
             }
 
-            if ((mappingContract?.IsResultDatatypeTypeDescriptorSupported != false)
-                && target.ResultDatatypeTypeDescriptor != source.ResultDatatypeTypeDescriptor)
+            var sourceValue = source.ResultDatatypeTypeDescriptor;
+            var targetValue = target.ResultDatatypeTypeDescriptor;
+            var shouldSynchronize = (mappingContract?.IsResultDatatypeTypeDescriptorSupported != false)
+                && targetValue != sourceValue;
+
+            if (GeneratedArtifactStaticDependencies.DataManagementResourceContextProvider?.Get()?.HttpMethod == HttpMethods.Post)
+            {
+                _logger.Warn(
+                    "StudentAssessmentStudentObjectiveAssessmentScoreResult.ResultDatatypeTypeDescriptor SynchronizeTo decision: "
+                    + $"shouldSynchronize='{shouldSynchronize}', supported='{mappingContract?.IsResultDatatypeTypeDescriptorSupported}', "
+                    + $"source='{sourceValue}', target='{targetValue}'.");
+            }
+
+            if (shouldSynchronize)
             {
                 target.ResultDatatypeTypeDescriptor = source.ResultDatatypeTypeDescriptor;
                 isModified = true;
@@ -67362,7 +67378,18 @@ namespace EdFi.Ods.Entities.Common.EdFi //.StudentAssessmentAggregate
             if (mappingContract?.IsResultSupported != false)
                 target.Result = source.Result;
 
-            if (mappingContract?.IsResultDatatypeTypeDescriptorSupported != false)
+            var sourceValue = source.ResultDatatypeTypeDescriptor;
+            var shouldMap = mappingContract?.IsResultDatatypeTypeDescriptorSupported != false;
+
+            if (GeneratedArtifactStaticDependencies.DataManagementResourceContextProvider?.Get()?.HttpMethod == HttpMethods.Post)
+            {
+                _logger.Warn(
+                    "StudentAssessmentStudentObjectiveAssessmentScoreResult.ResultDatatypeTypeDescriptor MapTo decision: "
+                    + $"shouldMap='{shouldMap}', supported='{mappingContract?.IsResultDatatypeTypeDescriptorSupported}', "
+                    + $"source='{sourceValue}'.");
+            }
+
+            if (shouldMap)
                 target.ResultDatatypeTypeDescriptor = source.ResultDatatypeTypeDescriptor;
 
             // Copy Aggregate Reference Data

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Generators/Entities.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Generators/Entities.cs
@@ -28,6 +28,12 @@ namespace EdFi.Ods.CodeGen.Generators
         
         private static readonly object _notRendered = null;
 
+        private const string PostDescriptorAccessorDiagnosticEntityName =
+            "StudentAssessmentStudentObjectiveAssessmentScoreResult";
+
+        private const string PostDescriptorAccessorDiagnosticLookupValuePropertyName =
+            "ResultDatatypeTypeDescriptor";
+
         private Func<Entity, bool> _shouldRenderEntityForSchema;
 
         private IPersonEntitySpecification _personEntitySpecification;
@@ -79,7 +85,11 @@ namespace EdFi.Ods.CodeGen.Generators
                     }).ToList(),
                 TemplateContext.SchemaProperCaseName,
                 HasExtensionDerivedFromEdFiBaseEntity = orderedAggregates.SelectMany(a => a.Members)
-                    .Any(m => !m.IsEdFiStandardEntity && m.IsDerived && m.BaseEntity.IsEdFiStandardEntity)
+                    .Any(m => !m.IsEdFiStandardEntity && m.IsDerived && m.BaseEntity.IsEdFiStandardEntity),
+                HasPostDescriptorAccessorDiagnostics =
+                    orderedAggregates
+                       .SelectMany(a => a.Members)
+                       .Any(HasPostDescriptorAccessorDiagnosticTarget)
             };
         }
 
@@ -170,6 +180,7 @@ namespace EdFi.Ods.CodeGen.Generators
                     AggregateName = aggregate.Name,
                     ClassName = entity.Name,
                     ReferenceDataClassName = entity.Name + "ReferenceData",
+                    HasPostDescriptorAccessorDiagnostics = HasPostDescriptorAccessorDiagnosticTarget(entity),
                     HasReferenceDataClass = entity.IsReferenceable() && entity.TypeHierarchyRootEntity == entity,
                     ReferenceDataMessagePackIndexer = new MessagePackIndexer(),
                     TableName = entity.Name,
@@ -582,6 +593,22 @@ namespace EdFi.Ods.CodeGen.Generators
                    && property.PropertyName != "LastModifiedDate";
         }
 
+        private static bool HasPostDescriptorAccessorDiagnosticTarget(Entity entity)
+        {
+            return entity.Name.Equals(PostDescriptorAccessorDiagnosticEntityName, StringComparison.Ordinal)
+                   && entity.Identifier.Properties
+                            .Concat(entity.NonIdentifyingProperties)
+                            .Any(p => IsPostDescriptorAccessorDiagnosticTarget(entity, p));
+        }
+
+        private static bool IsPostDescriptorAccessorDiagnosticTarget(Entity entity, EntityProperty property)
+        {
+            return entity.Name.Equals(PostDescriptorAccessorDiagnosticEntityName, StringComparison.Ordinal)
+                   && property.IsDescriptorUsage
+                   && property.GetLookupValuePropertyName()
+                              .Equals(PostDescriptorAccessorDiagnosticLookupValuePropertyName, StringComparison.Ordinal);
+        }
+
         private static string GetEntityParentClassName(Entity entity)
         {
             if (entity.IsAggregateRoot)
@@ -650,7 +677,8 @@ namespace EdFi.Ods.CodeGen.Generators
                                      "_" + p.GetLookupValuePropertyName()
                                             .ToCamelCase(),
                                  CSharpDeclaredType = p.PropertyType.ToCSharp(includeNullability: true),
-                                 NeedsOverride = entity.IsDerived && p.IsIdentifying && !p.IsInheritedIdentifyingRenamed
+                                 NeedsOverride = entity.IsDerived && p.IsIdentifying && !p.IsInheritedIdentifyingRenamed,
+                                 LogPostDescriptorAccessorDiagnostics = IsPostDescriptorAccessorDiagnosticTarget(entity, p)
                              }
                            : _notRendered,
                        UsiProperty = UniqueIdConventions.IsUSI(p.PropertyName)

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Generators/EntityMapper.cs
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Generators/EntityMapper.cs
@@ -21,6 +21,8 @@ namespace EdFi.Ods.CodeGen.Generators
     public class EntityMapper : GeneratorBase
     {
         private IPersonEntitySpecification _personEntitySpecification;
+        private const string PostMappingDiagnosticResourceClassName = "StudentAssessmentStudentObjectiveAssessmentScoreResult";
+        private const string PostMappingDiagnosticPropertyName = "ResultDatatypeTypeDescriptor";
 
         protected override object Build()
         {
@@ -80,6 +82,22 @@ namespace EdFi.Ods.CodeGen.Generators
 
         private object BuildMapper(ResourceClassBase resourceClass)
         {
+            var nonPrimaryKeyList = resourceClass.NonIdentifyingProperties
+                .Where(p => !p.IsInherited && p.IsSynchronizedProperty())
+
+                // Add mappings for UniqueId values defined on Person resources
+                .Concat(resourceClass.IdentifyingProperties.Where(p => _personEntitySpecification.IsDefiningUniqueId(resourceClass, p)))
+                .OrderBy(p => p.PropertyName)
+                .Select(
+                    p => new
+                    {
+                        PropertyName = p.PropertyName,
+                        CSharpSafePropertyName =
+                            p.PropertyName.MakeSafeForCSharpClass(resourceClass.Name),
+                        LogPostMappingDecision = IsPostMappingDiagnosticTarget(resourceClass, p.PropertyName)
+                    })
+                .ToList();
+
             return new
             {
                 ModelName = resourceClass.Name,
@@ -111,19 +129,8 @@ namespace EdFi.Ods.CodeGen.Generators
                     .Where(p => p.IsInherited && p.IsSynchronizedProperty())
                     .OrderBy(p => p.PropertyName)
                     .Select(p => new {BasePropertyName = p.PropertyName}),
-                NonPrimaryKeyList = resourceClass.NonIdentifyingProperties
-                    .Where(p => !p.IsInherited && p.IsSynchronizedProperty())
-
-                    // Add mappings for UniqueId values defined on Person resources
-                    .Concat(resourceClass.IdentifyingProperties.Where(p => _personEntitySpecification.IsDefiningUniqueId(resourceClass, p)))
-                    .OrderBy(p => p.PropertyName)
-                    .Select(
-                        p => new
-                        {
-                            PropertyName = p.PropertyName,
-                            CSharpSafePropertyName =
-                                p.PropertyName.MakeSafeForCSharpClass(resourceClass.Name)
-                        }),
+                NonPrimaryKeyList = nonPrimaryKeyList,
+                HasPostMappingDiagnostics = nonPrimaryKeyList.Any(p => p.LogPostMappingDecision),
                 HasOneToOneRelationships = resourceClass.EmbeddedObjects.Any(),
                 OneToOneClassList = resourceClass.EmbeddedObjects
                     .Select(
@@ -179,6 +186,12 @@ namespace EdFi.Ods.CodeGen.Generators
                                 MappedReferenceDataHasDiscriminator = a.OtherEntity.HasDiscriminator()
                             })
             };
+        }
+        
+        private static bool IsPostMappingDiagnosticTarget(ResourceClassBase resourceClass, string propertyName)
+        {
+            return resourceClass.Name.Equals(PostMappingDiagnosticResourceClassName, StringComparison.Ordinal)
+                   && propertyName.Equals(PostMappingDiagnosticPropertyName, StringComparison.Ordinal);
         }
 
         private bool IsBaseClassConcrete(ResourceClassBase resourceClass)

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Mustache/Entities.mustache
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Mustache/Entities.mustache
@@ -21,6 +21,10 @@ using EdFi.Ods.Common.Serialization;
 using EdFi.Ods.Entities.Common.EdFi;
 {{/HasExtensionDerivedFromEdFiBaseEntity}}
 using EdFi.Ods.Entities.Common.{{SchemaProperCaseName}};
+{{#HasPostDescriptorAccessorDiagnostics}}
+using log4net;
+using Microsoft.AspNetCore.Http;
+{{/HasPostDescriptorAccessorDiagnostics}}
 using Newtonsoft.Json;
 using MessagePack;
 using KeyAttribute = MessagePack.KeyAttribute;
@@ -249,6 +253,10 @@ namespace {{AggregateNamespace}}
     public {{#IsAbstract}}abstract {{/IsAbstract}}class {{ClassName}}{{#IsConcreteEntityBaseClass}}Base{{/IsConcreteEntityBaseClass}}{{#IsConcreteEntityChildClassForBase}}ForBase{{/IsConcreteEntityChildClassForBase}} : {{#IsDerived}}{{BaseAggregateRootRelativeNamespace}}{{#IsConcreteEntityBaseClass}}Base{{/IsConcreteEntityBaseClass}}{{/IsDerived}}{{^IsDerived}}{{#IsAggregateRoot}}AggregateRootWithCompositeKey{{/IsAggregateRoot}}{{^IsAggregateRoot}}EntityWithCompositeKey{{/IsAggregateRoot}}{{/IsDerived}},{{^IsAggregateRoot}} IChildEntity,{{/IsAggregateRoot}}{{#AllowsPrimaryKeyUpdates}} IHasCascadableKeyValues,{{/AllowsPrimaryKeyUpdates}}
         {{NamespacePrefix}}I{{ClassName}}, IHasPrimaryKeyValues{{#HasAlternateKeyValues}}, IHasAlternateKeyValues{{/HasAlternateKeyValues}}, IHasLookupColumnPropertyMap{{#IsDescriptor}}, IEdFiDescriptor{{/IsDescriptor}}{{#IsPersonEntity}}, IPersonUsiMutator{{/IsPersonEntity}}{{#IsExtendable}}{{^ExtendableConcreteBase}}, IHasExtensions{{/ExtendableConcreteBase}}{{/IsExtendable}}
     {
+        {{#HasPostDescriptorAccessorDiagnostics}}
+        private static readonly ILog _logger = LogManager.GetLogger(typeof({{ClassName}}));
+
+        {{/HasPostDescriptorAccessorDiagnostics}}
         {{^IsDerived}}
         public virtual void SuspendReferenceAssignmentCheck() { }
 

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Mustache/Entities_PropertyAccessors.mustache
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Mustache/Entities_PropertyAccessors.mustache
@@ -57,8 +57,24 @@
             } 
             set
             {
+                {{#LogPostDescriptorAccessorDiagnostics}}
+                var isPostRequest = GeneratedArtifactStaticDependencies.DataManagementResourceContextProvider?.Get()?.HttpMethod == HttpMethods.Post;
+                var oldDescriptorId = {{IdFieldName}};
+                var oldDescriptorUri = {{ValueFieldName}};
+
+                {{/LogPostDescriptorAccessorDiagnostics}}
                 {{IdFieldName}} = value;
                 {{ValueFieldName}} = null;
+                {{#LogPostDescriptorAccessorDiagnostics}}
+
+                if (isPostRequest)
+                {
+                    _logger.Warn(
+                        "{{LookupValuePropertyName}}Id setter: "
+                        + $"oldId='{oldDescriptorId}', newId='{value}', oldUri='{oldDescriptorUri}', "
+                        + $"stackTrace='{Environment.StackTrace}'.");
+                }
+                {{/LogPostDescriptorAccessorDiagnostics}}
         {{#HasSerializedReferenceDataMappings}}
         
                 if (value != default && GeneratedArtifactStaticDependencies.SerializedDataEnabled && GeneratedArtifactStaticDependencies.ResourceLinksEnabled)
@@ -80,15 +96,48 @@
         {
             get
             {
+                {{#LogPostDescriptorAccessorDiagnostics}}
+                var descriptorUriWasNull = {{ValueFieldName}} == null;
+                var descriptorId = {{IdFieldName}};
+
+                {{/LogPostDescriptorAccessorDiagnostics}}
                 if ({{ValueFieldName}} == null)
                     {{ValueFieldName}} = {{#IsNullable}}{{IdFieldName}} == null ? null : {{/IsNullable}}GeneratedArtifactStaticDependencies.DescriptorResolver.GetUri("{{LookupEntityName}}", {{IdFieldname}}{{#IsNullable}}.Value{{/IsNullable}});
+                {{#LogPostDescriptorAccessorDiagnostics}}
+
+                if (descriptorUriWasNull && GeneratedArtifactStaticDependencies.DataManagementResourceContextProvider?.Get()?.HttpMethod == HttpMethods.Post)
+                {
+                    _logger.Warn(
+                        "{{LookupValuePropertyName}} getter: "
+                        + $"descriptorId='{descriptorId}', returnedUri='"
+                        + {{ValueFieldName}}
+                        + $"', "
+                        + $"stackTrace='{Environment.StackTrace}'.");
+                }
+                {{/LogPostDescriptorAccessorDiagnostics}}
                     
                 return {{ValueFieldName}};
             }
             set
             {
+                {{#LogPostDescriptorAccessorDiagnostics}}
+                var isPostRequest = GeneratedArtifactStaticDependencies.DataManagementResourceContextProvider?.Get()?.HttpMethod == HttpMethods.Post;
+                var oldDescriptorUri = {{ValueFieldName}};
+                var oldDescriptorId = {{IdFieldName}};
+
+                {{/LogPostDescriptorAccessorDiagnostics}}
                 {{ValueFieldName}} = value;
                 {{IdFieldName}} = default({{CSharpDeclaredType}});
+                {{#LogPostDescriptorAccessorDiagnostics}}
+
+                if (isPostRequest)
+                {
+                    _logger.Warn(
+                        "{{LookupValuePropertyName}} setter: "
+                        + $"oldUri='{oldDescriptorUri}', newUri='{value}', oldId='{oldDescriptorId}', "
+                        + $"stackTrace='{Environment.StackTrace}'.");
+                }
+                {{/LogPostDescriptorAccessorDiagnostics}}
         {{#HasSerializedReferenceDataMappings}}
 
                 if (value != null && GeneratedArtifactStaticDependencies.SerializedDataEnabled && GeneratedArtifactStaticDependencies.ResourceLinksEnabled)

--- a/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Mustache/EntityMapper.mustache
+++ b/Utilities/CodeGeneration/EdFi.Ods.CodeGen/Mustache/EntityMapper.mustache
@@ -11,6 +11,8 @@ using EdFi.Ods.Common.Exceptions;
 using EdFi.Ods.Common.Extensions;
 using EdFi.Ods.Common.Models;
 using EdFi.Ods.Common.Models.Domain;
+using log4net;
+using Microsoft.AspNetCore.Http;
 {{#HasDerivedResources}}
 using EdFi.Ods.Entities.Common.EdFi;
 {{/HasDerivedResources}}
@@ -24,6 +26,10 @@ namespace {{NamespaceName}} //.{{AggregateName}}Aggregate
     public static class {{ModelName}}Mapper
     {
         private static readonly FullName _fullName_{{ModelSchema}}_{{ModelName}} = new FullName("{{ModelSchema}}", "{{ModelName}}");
+        {{#HasPostMappingDiagnostics}}
+        private static readonly ILog _logger = LogManager.GetLogger(typeof({{ModelName}}Mapper));
+
+        {{/HasPostMappingDiagnostics}}
     
         public static bool SynchronizeTo(this I{{ModelName}} source, I{{ModelName}} target)
         {
@@ -101,8 +107,26 @@ namespace {{NamespaceName}} //.{{AggregateName}}Aggregate
             // Copy non-PK properties
             {{#NonPrimaryKeyList}}
 
+            {{#LogPostMappingDecision}}
+            var sourceValue = source.{{CSharpSafePropertyName}};
+            var targetValue = target.{{CSharpSafePropertyName}};
+            var shouldSynchronize = (mappingContract?.Is{{PropertyName}}Supported != false)
+                && targetValue != sourceValue;
+
+            if (GeneratedArtifactStaticDependencies.DataManagementResourceContextProvider?.Get()?.HttpMethod == HttpMethods.Post)
+            {
+                _logger.Warn(
+                    "{{ModelName}}.{{PropertyName}} SynchronizeTo decision: "
+                    + $"shouldSynchronize='{shouldSynchronize}', supported='{mappingContract?.Is{{PropertyName}}Supported}', "
+                    + $"source='{sourceValue}', target='{targetValue}'.");
+            }
+
+            if (shouldSynchronize)
+            {{/LogPostMappingDecision}}
+            {{^LogPostMappingDecision}}
             if ((mappingContract?.Is{{PropertyName}}Supported != false)
                 && target.{{CSharpSafePropertyName}} != source.{{CSharpSafePropertyName}})
+            {{/LogPostMappingDecision}}
             {
                 target.{{CSharpSafePropertyName}} = source.{{CSharpSafePropertyName}};
                 isModified = true;
@@ -262,7 +286,23 @@ namespace {{NamespaceName}} //.{{AggregateName}}Aggregate
             // Copy non-PK properties
             {{#NonPrimaryKeyList}}
 
+            {{#LogPostMappingDecision}}
+            var sourceValue = source.{{CSharpSafePropertyName}};
+            var shouldMap = mappingContract?.Is{{PropertyName}}Supported != false;
+
+            if (GeneratedArtifactStaticDependencies.DataManagementResourceContextProvider?.Get()?.HttpMethod == HttpMethods.Post)
+            {
+                _logger.Warn(
+                    "{{ModelName}}.{{PropertyName}} MapTo decision: "
+                    + $"shouldMap='{shouldMap}', supported='{mappingContract?.Is{{PropertyName}}Supported}', "
+                    + $"source='{sourceValue}'.");
+            }
+
+            if (shouldMap)
+            {{/LogPostMappingDecision}}
+            {{^LogPostMappingDecision}}
             if (mappingContract?.Is{{PropertyName}}Supported != false)
+            {{/LogPostMappingDecision}}
                 target.{{CSharpSafePropertyName}} = source.{{CSharpSafePropertyName}};
             {{/NonPrimaryKeyList}}
 


### PR DESCRIPTION
This is a minimal fix that only protects the Descriptor cache, it's a simplified version of https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/pull/1269. 

Ideally, we should move the protection to the [CachingInterceptor](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/blob/main/Application/EdFi.Ods.Common/Caching/CachingInterceptor.cs) level, so that all other expiring caches (such as Profiles) benefit from the fix. Consider using [Microsoft.Extensions.Caching.Hybrid](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Hybrid) that provides stampede protection out of the box.