### PR TITLE
Add cache stampede protection to Descriptors

### DIFF
--- a/Application/EdFi.Ods.Api/Caching/ExpiringConcurrentDictionaryCacheProvider.cs
+++ b/Application/EdFi.Ods.Api/Caching/ExpiringConcurrentDictionaryCacheProvider.cs
@@ -51,7 +51,6 @@ namespace EdFi.Ods.Api.Caching
         public ExpiringConcurrentDictionaryCacheProvider(string description, TimeSpan expirationPeriod, Action expirationCallback)
         {
             _description = description;
-            _expirationPeriod = expirationPeriod;
 
             // If expiration period is less than 0 disable caching behavior.
             if (expirationPeriod.TotalSeconds < 0)
@@ -59,12 +58,13 @@ namespace EdFi.Ods.Api.Caching
                 _logger.Debug($"Cache '{description}' is disabled...");
                 _cacheEnabled = false;
             }
-            // Set expiration period only if expiration period is not the default (0)
-            else if (expirationPeriod.TotalSeconds > 0)
-            {
-                _timer = new Timer(CacheExpired, null, expirationPeriod, expirationPeriod);
-                _expirationCallback = expirationCallback;
-            }
+
+            _expirationPeriod = expirationPeriod.TotalSeconds <= 0
+                ? Timeout.InfiniteTimeSpan
+                : expirationPeriod;
+
+            _expirationCallback = expirationCallback;
+            _timer = new Timer(CacheExpired, null, _expirationPeriod, _expirationPeriod);
         }
 
         public bool TryGetCachedObject(TKey key, out object value)

--- a/Application/EdFi.Ods.Common/Descriptors/DescriptorMapsProvider.cs
+++ b/Application/EdFi.Ods.Common/Descriptors/DescriptorMapsProvider.cs
@@ -5,6 +5,10 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using EdFi.Ods.Common.Configuration;
+using EdFi.Ods.Common.Context;
 using EdFi.Ods.Common.Database;
 
 namespace EdFi.Ods.Common.Descriptors;
@@ -15,14 +19,55 @@ namespace EdFi.Ods.Common.Descriptors;
 public class DescriptorMapsProvider : IDescriptorMapsProvider
 {
     private readonly IDescriptorDetailsProvider _descriptorDetailsProvider;
+    private readonly IContextProvider<OdsInstanceConfiguration> _contextProvider;
 
-    public DescriptorMapsProvider(IDescriptorDetailsProvider descriptorDetailsProvider)
+    // Cache stampede protection keyed by OdsInstance. The Interceptor still provides the
+    // long-lived caching; this dictionary holds the Lazy only for the duration of a single
+    // in-flight load.
+    private readonly ConcurrentDictionary<ulong, Lazy<DescriptorMaps>> _flights = new();
+
+    public DescriptorMapsProvider(
+        IDescriptorDetailsProvider descriptorDetailsProvider,
+        IContextProvider<OdsInstanceConfiguration> contextProvider)
     {
         _descriptorDetailsProvider = descriptorDetailsProvider;
+        _contextProvider = contextProvider;
     }
 
     /// <inheritdoc cref="IDescriptorMapsProvider.GetMaps" />
     public DescriptorMaps GetMaps()
+    {
+        ulong key = ComputeFlightKey();
+
+        var flight = _flights.GetOrAdd(
+            key,
+            _ => new Lazy<DescriptorMaps>(LoadMaps, LazyThreadSafetyMode.ExecutionAndPublication));
+
+        try
+        {
+            return flight.Value;
+        }
+        finally
+        {
+            _flights.TryRemove(new KeyValuePair<ulong, Lazy<DescriptorMaps>>(key, flight));
+        }
+    }
+
+    private ulong ComputeFlightKey()
+    {
+        var context = _contextProvider.Get();
+
+        // Without context, we cannot generate a key
+        if (context == null)
+        {
+            throw new InvalidOperationException(
+                $"No context has been set for value of type '{nameof(OdsInstanceConfiguration)}'.");
+        }
+
+        return context.OdsInstanceHashId;
+    }
+
+    private DescriptorMaps LoadMaps()
     {
         var allDescriptors = _descriptorDetailsProvider.GetAllDescriptorDetails();
 

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/ExpiringConcurrentDictionaryCacheProviderTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/ExpiringConcurrentDictionaryCacheProviderTests.cs
@@ -141,5 +141,58 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
             result.ShouldBeFalse();
             value.ShouldBeNull();
         }
+
+        [Test]
+        public void Clear_ShouldNotThrow_WhenCacheDisabled()
+        {
+            // Arrange
+            var provider = new ExpiringConcurrentDictionaryCacheProvider<string>("TestCache", TimeSpan.FromSeconds(-1));
+
+            // Act + Assert
+            Should.NotThrow(() => provider.Clear());
+
+            // Cache remains disabled after Clear
+            provider.SetCachedObject("TestKey", "TestValue");
+            provider.TryGetCachedObject("TestKey", out var value).ShouldBeFalse();
+            value.ShouldBeNull();
+        }
+
+        [Test]
+        public void Clear_ShouldClearDictionary_WhenExpirationIsZero()
+        {
+            // Arrange
+            var expirationCallback = A.Fake<Action>();
+            var provider = new ExpiringConcurrentDictionaryCacheProvider<string>("TestCache", TimeSpan.Zero, expirationCallback);
+            provider.SetCachedObject("TestKey1", "TestValue1");
+            provider.SetCachedObject("TestKey2", "TestValue2");
+
+            // Act
+            provider.Clear();
+
+            // Assert: prior entries gone, callback not fired, cache still usable.
+            provider.TryGetCachedObject("TestKey1", out _).ShouldBeFalse();
+            provider.TryGetCachedObject("TestKey2", out _).ShouldBeFalse();
+            A.CallTo(() => expirationCallback.Invoke()).MustNotHaveHappened();
+
+            provider.SetCachedObject("AfterClear", "Value");
+            provider.TryGetCachedObject("AfterClear", out var value).ShouldBeTrue();
+            value.ShouldBe("Value");
+        }
+
+        [Test]
+        public void Clear_ShouldClearDictionary_WhenExpirationIsPositive()
+        {
+            // Arrange. Use a long expiration so the timer cannot fire during the test.
+            var provider = new ExpiringConcurrentDictionaryCacheProvider<string>("TestCache", TimeSpan.FromMinutes(10));
+            provider.SetCachedObject("TestKey1", "TestValue1");
+            provider.SetCachedObject("TestKey2", "TestValue2");
+
+            // Act
+            provider.Clear();
+
+            // Assert
+            provider.TryGetCachedObject("TestKey1", out _).ShouldBeFalse();
+            provider.TryGetCachedObject("TestKey2", out _).ShouldBeFalse();
+        }
     }
 }

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Descriptors/DescriptorMapsProviderTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Descriptors/DescriptorMapsProviderTests.cs
@@ -4,15 +4,16 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using EdFi.Ods.Common.Configuration;
+using EdFi.Ods.Common.Context;
 using EdFi.Ods.Common.Database;
 using EdFi.Ods.Common.Descriptors;
+using FakeItEasy;
+using NUnit.Framework;
 using Shouldly;
 
 namespace EdFi.Ods.Tests.EdFi.Ods.Common.Descriptors;
-
-using System.Collections.Generic;
-using FakeItEasy;
-using NUnit.Framework;
 
 [TestFixture]
 public class DescriptorMapsProviderTests
@@ -24,8 +25,10 @@ public class DescriptorMapsProviderTests
         var descriptorDetailsProvider = A.Fake<IDescriptorDetailsProvider>();
         
         A.CallTo(() => descriptorDetailsProvider.GetAllDescriptorDetails()).Returns(GetSampleDescriptorDetails());
-        
-        var provider = new DescriptorMapsProvider(descriptorDetailsProvider);
+
+        var contextProvider = FakeContextProvider();
+
+        var provider = new DescriptorMapsProvider(descriptorDetailsProvider, contextProvider);
 
         // Act
         var maps = provider.GetMaps();
@@ -47,6 +50,219 @@ public class DescriptorMapsProviderTests
         
         maps.UriByDescriptorId[1].ShouldBe(("AbcDescriptor", "http://ed-fi.org/TestDescriptor#1"));
         maps.UriByDescriptorId[2].ShouldBe(("AbcDescriptor", "http://ed-fi.org/TestDescriptor#2"));
+    }
+
+    [Test]
+    public void GetMaps_ConcurrentCallers_InvokeLoaderOnce_AndReturnSameInstance()
+    {
+        // Arrange
+        const int concurrentCallers = 3;
+
+        var loaderInvocations = 0;
+        var gate = new System.Threading.ManualResetEventSlim(initialState: false);
+
+        var descriptorDetailsProvider = A.Fake<IDescriptorDetailsProvider>();
+
+        A.CallTo(() => descriptorDetailsProvider.GetAllDescriptorDetails())
+            .ReturnsLazily(() =>
+            {
+                System.Threading.Interlocked.Increment(ref loaderInvocations);
+                gate.Wait();
+                return GetSampleDescriptorDetails();
+            });
+
+        var provider = new DescriptorMapsProvider(
+            descriptorDetailsProvider,
+            FakeContextProvider());
+
+        var tasks = new System.Threading.Tasks.Task<DescriptorMaps>[concurrentCallers];
+        var started = new System.Threading.CountdownEvent(concurrentCallers);
+
+        // Act
+        for (int i = 0; i < concurrentCallers; i++)
+        {
+            tasks[i] = System.Threading.Tasks.Task.Run(() =>
+            {
+                started.Signal();
+                return provider.GetMaps();
+            });
+        }
+
+        // Wait for all callers to be in flight before releasing the loader
+        started.Wait(TimeSpan.FromSeconds(15)).ShouldBeTrue("callers did not all start");
+        gate.Set();
+
+        System.Threading.Tasks.Task.WaitAll(tasks, TimeSpan.FromSeconds(10)).ShouldBeTrue("tasks did not complete");
+
+        // Assert
+        loaderInvocations.ShouldBe(1);
+
+        var first = tasks[0].Result;
+        first.ShouldNotBeNull();
+
+        for (int i = 1; i < concurrentCallers; i++)
+        {
+            tasks[i].Result.ShouldBeSameAs(first);
+        }
+    }
+
+    [Test]
+    public void GetMaps_LoaderException_PropagatesToWaiters_AndDoesNotPoisonFutureCalls()
+    {
+        // Arrange
+        const int concurrentCallers = 3;
+
+        var loaderInvocations = 0;
+        var gate = new System.Threading.ManualResetEventSlim(initialState: false);
+        var shouldThrow = true;
+
+        var descriptorDetailsProvider = A.Fake<IDescriptorDetailsProvider>();
+
+        A.CallTo(() => descriptorDetailsProvider.GetAllDescriptorDetails())
+            .ReturnsLazily(() =>
+            {
+                System.Threading.Interlocked.Increment(ref loaderInvocations);
+                gate.Wait();
+
+                if (shouldThrow)
+                {
+                    throw new InvalidOperationException("boom");
+                }
+
+                return GetSampleDescriptorDetails();
+            });
+
+        var provider = new DescriptorMapsProvider(
+            descriptorDetailsProvider,
+            FakeContextProvider());
+
+        var tasks = new System.Threading.Tasks.Task<DescriptorMaps>[concurrentCallers];
+        var started = new System.Threading.CountdownEvent(concurrentCallers);
+
+        // Act — first wave: loader throws
+        for (int i = 0; i < concurrentCallers; i++)
+        {
+            tasks[i] = System.Threading.Tasks.Task.Run(() =>
+            {
+                started.Signal();
+                return provider.GetMaps();
+            });
+        }
+
+        started.Wait(TimeSpan.FromSeconds(15)).ShouldBeTrue("callers did not all start");
+        gate.Set();
+
+        // Assert — all waiters observe the same exception, loader ran once
+        foreach (var task in tasks)
+        {
+            var ex = Should.Throw<AggregateException>(() => task.Wait());
+            ex.InnerException.ShouldBeOfType<InvalidOperationException>();
+            ex.InnerException!.Message.ShouldBe("boom");
+        }
+
+        loaderInvocations.ShouldBe(1);
+
+        // Act — second wave: loader should be re-invoked (no poisoning)
+        shouldThrow = false;
+        gate.Set(); // loader proceeds immediately this time
+
+        var result = provider.GetMaps();
+
+        // Assert — the loader ran a second time and a fresh result was produced
+        loaderInvocations.ShouldBe(2);
+        result.ShouldNotBeNull();
+        result.DescriptorIdByUri.Count.ShouldBe(2);
+    }
+
+    [Test]
+    public void GetMaps_DifferentContexts_DoNotSerializeAgainstEachOther()
+    {
+        // Arrange
+        var gateA = new System.Threading.ManualResetEventSlim(initialState: false);
+        var gateB = new System.Threading.ManualResetEventSlim(initialState: false);
+        var loaderAEntered = new System.Threading.ManualResetEventSlim(initialState: false);
+        var loaderBEntered = new System.Threading.ManualResetEventSlim(initialState: false);
+
+        OdsInstanceConfiguration currentContext = null;
+        var contextProvider = A.Fake<IContextProvider<OdsInstanceConfiguration>>();
+        A.CallTo(() => contextProvider.Get()).ReturnsLazily(() => currentContext);
+
+        var contextA = BuildContext(odsInstanceId: 1);
+        var contextB = BuildContext(odsInstanceId: 2);
+
+        var descriptorDetailsProvider = A.Fake<IDescriptorDetailsProvider>();
+
+        // Each loader signals entry and waits for its dedicated gate before returning.
+        // If the single-flight were NOT keyed by context, the second caller would block
+        // on the first's Lazy and we would never observe BOTH loaders entered concurrently.
+        A.CallTo(() => descriptorDetailsProvider.GetAllDescriptorDetails())
+            .ReturnsLazily(() =>
+            {
+                if (ReferenceEquals(currentContext, contextA))
+                {
+                    loaderAEntered.Set();
+                    gateA.Wait();
+                }
+                else
+                {
+                    loaderBEntered.Set();
+                    gateB.Wait();
+                }
+
+                return GetSampleDescriptorDetails();
+            });
+
+        var provider = new DescriptorMapsProvider(descriptorDetailsProvider, contextProvider);
+
+        // Act
+        var taskA = System.Threading.Tasks.Task.Run(() =>
+        {
+            currentContext = contextA;
+            return provider.GetMaps();
+        });
+
+        // Wait for loader A to be in flight before starting B so we can observe concurrency
+        loaderAEntered.Wait(TimeSpan.FromSeconds(15)).ShouldBeTrue("loader A did not enter");
+
+        var taskB = System.Threading.Tasks.Task.Run(() =>
+        {
+            currentContext = contextB;
+            return provider.GetMaps();
+        });
+
+        loaderBEntered.Wait(TimeSpan.FromSeconds(15))
+            .ShouldBeTrue("loader B was blocked on loader A — single-flight is not context-keyed");
+
+        // Release both loaders
+        gateA.Set();
+        gateB.Set();
+
+        System.Threading.Tasks.Task.WaitAll(new[] { taskA, taskB }, TimeSpan.FromSeconds(10))
+            .ShouldBeTrue("tasks did not complete");
+
+        // Assert — both succeeded
+        taskA.Result.ShouldNotBeNull();
+        taskB.Result.ShouldNotBeNull();
+    }
+
+    private static OdsInstanceConfiguration BuildContext(int odsInstanceId)
+    {
+        return new OdsInstanceConfiguration(
+            odsInstanceId: odsInstanceId,
+            odsInstanceHashId: (ulong)odsInstanceId,
+            connectionString: string.Empty,
+            contextValueByKey: new Dictionary<string, string>(),
+            connectionStringByDerivativeType: new Dictionary<DerivativeType, string>());
+    }
+    
+    private static IContextProvider<OdsInstanceConfiguration> FakeContextProvider(int odsInstanceId = 1)
+    {
+        var config = BuildContext(odsInstanceId);
+
+        var contextProvider = A.Fake<IContextProvider<OdsInstanceConfiguration>>();
+        A.CallTo(() => contextProvider.Get()).Returns(config);
+
+        return contextProvider;
     }
 
     private static List<DescriptorDetails> GetSampleDescriptorDetails()


### PR DESCRIPTION
This is a minimal fix that only protects the Descriptor cache, it's a simplified version of https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/pull/1269. 

Ideally, we should move the protection to the [CachingInterceptor](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/blob/main/Application/EdFi.Ods.Common/Caching/CachingInterceptor.cs) level, so that all other expiring caches (such as Profiles) benefit from the fix. Consider using [Microsoft.Extensions.Caching.Hybrid](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Hybrid) that provides stampede protection out of the box.