### PR TITLE
[  ODS-6837] Remove lingering .NET 8 references after migration to .NET 10

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -92,7 +92,7 @@
 
     <!-- Authentication -->
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.80.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.22" />    
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2" />
 
     <!-- OpenAPI -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.3.4" />

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -271,7 +271,7 @@ function InstallCredentialHandler {
 
     $downloadPath = Join-Path ([IO.Path]::GetTempPath()) 'cred-provider.zip'
     
-    $credProviderUrl = 'https://github.com/microsoft/artifacts-credprovider/releases/download/v1.4.1/Microsoft.Net6.NuGet.CredentialProvider.zip'
+    $credProviderUrl = 'https://github.com/microsoft/artifacts-credprovider/releases/download/v2.0.1/Microsoft.Net8.NuGet.CredentialProvider.zip'
     Write-Host "Downloading artifacts-credprovider from $credProviderUrl ..."
     $webClient = New-Object System.Net.WebClient
     $webClient.DownloadFile($credProviderUrl, $downloadPath)


### PR DESCRIPTION
- Bump Microsoft.AspNetCore.Authentication.JwtBearer from 8.0.22 to 10.0.2 to match the target framework
- Upgrade the NuGet artifacts credential provider from v1.4.1/Net6 to v2.0.1/Net8 (.NET 6 is EOL; no Net10 variant exists yet)