### PR TITLE
[ODS-6847] Redis Refactors: Improved Configuration, Resilience, Async Usage

### DIFF
--- a/Application/EdFi.Ods.Api/Caching/Person/IDistributedLockProvider.cs
+++ b/Application/EdFi.Ods.Api/Caching/Person/IDistributedLockProvider.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace EdFi.Ods.Api.Caching.Person;
+
+/// <summary>
+/// Defines methods for coordinating distributed access to background cache initialization.
+/// </summary>
+public interface IDistributedLockProvider
+{
+    /// <summary>
+    /// Attempts to acquire a distributed lock with the specified key.
+    /// </summary>
+    /// <param name="lockKey">The lock key.</param>
+    /// <param name="expiration">The lock expiration period.</param>
+    /// <returns><see langword="true"/> if the lock was acquired; otherwise, <see langword="false"/>.</returns>
+    Task<bool> TryAcquireLockAsync(string lockKey, TimeSpan expiration);
+
+    /// <summary>
+    /// Releases a distributed lock.
+    /// </summary>
+    /// <param name="lockKey">The lock key.</param>
+    Task ReleaseLockAsync(string lockKey);
+}

--- a/Application/EdFi.Ods.Api/Caching/Person/IPersonMapCacheInitializer.cs
+++ b/Application/EdFi.Ods.Api/Caching/Person/IPersonMapCacheInitializer.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace EdFi.Ods.Api.Caching.Person;
@@ -17,6 +18,8 @@ public interface IPersonMapCacheInitializer
     /// </summary>
     /// <param name="odsInstanceHashId">The unique hashId of the ODS instance.</param>
     /// <param name="personType">The person type for the cache initialization.</param>
-    /// <returns>A <see cref="Task" /> that is suitable for background execution (i.e. created using the <see cref="Task.Run" /> method).</returns>
-    Task InitializePersonMapAsync(ulong odsInstanceHashId, string personType);
+    /// <param name="lockKey">The distributed lock key to release when initialization completes.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A <see cref="Task" /> that is suitable for background execution.</returns>
+    Task InitializePersonMapAsync(ulong odsInstanceHashId, string personType, string lockKey, CancellationToken cancellationToken = default);
 }

--- a/Application/EdFi.Ods.Api/Caching/Person/InMemoryDistributedLockProvider.cs
+++ b/Application/EdFi.Ods.Api/Caching/Person/InMemoryDistributedLockProvider.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace EdFi.Ods.Api.Caching.Person;
+
+/// <summary>
+/// Provides an in-memory distributed lock provider for single-process cache initialization coordination.
+/// </summary>
+public class InMemoryDistributedLockProvider : IDistributedLockProvider
+{
+    private readonly ConcurrentDictionary<string, DateTimeOffset> _lockExpirations = new();
+
+    /// <inheritdoc />
+    public Task<bool> TryAcquireLockAsync(string lockKey, TimeSpan expiration)
+    {
+        ArgumentNullException.ThrowIfNull(lockKey);
+
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        DateTimeOffset newExpiration = now.Add(expiration);
+
+        while (true)
+        {
+            if (_lockExpirations.TryAdd(lockKey, newExpiration))
+            {
+                return Task.FromResult(true);
+            }
+
+            if (!_lockExpirations.TryGetValue(lockKey, out DateTimeOffset existingExpiration))
+            {
+                continue;
+            }
+
+            if (existingExpiration > now)
+            {
+                return Task.FromResult(false);
+            }
+
+            if (_lockExpirations.TryUpdate(lockKey, newExpiration, existingExpiration))
+            {
+                return Task.FromResult(true);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public Task ReleaseLockAsync(string lockKey)
+    {
+        ArgumentNullException.ThrowIfNull(lockKey);
+        _lockExpirations.TryRemove(lockKey, out _);
+        return Task.CompletedTask;
+    }
+}

--- a/Application/EdFi.Ods.Api/Caching/Person/PersonIdentifierResolverBase.cs
+++ b/Application/EdFi.Ods.Api/Caching/Person/PersonIdentifierResolverBase.cs
@@ -41,7 +41,6 @@ public abstract class PersonIdentifierResolverBase<TLookup, TResolved>
         IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), TLookup, TResolved> mapCache,
         IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), TResolved, TLookup> reverseMapCache,
         ICacheInitializationMarkerKeyProvider<TLookup> cacheInitializationMarkerKeyForLookupProvider,
-        ICacheInitializationMarkerKeyProvider<TResolved> cacheInitializationMarkerKeyForResolvedProvider,
         Dictionary<string, bool> cacheSuppressionByPersonType,
         bool useProgressiveLoading)
     {
@@ -53,7 +52,7 @@ public abstract class PersonIdentifierResolverBase<TLookup, TResolved>
         _reverseMapCache = reverseMapCache;
         _cacheSuppressionByPersonType = cacheSuppressionByPersonType;
         _performBackgroundInitialization = !useProgressiveLoading;
-        _cacheInitializationMarkerKeyForLookup = new[] { cacheInitializationMarkerKeyForLookupProvider.CacheKey };
+        _cacheInitializationMarkerKeyForLookup = [cacheInitializationMarkerKeyForLookupProvider.CacheKey];
     }
 
     protected abstract PersonMapType MapType { get; }
@@ -92,7 +91,7 @@ public abstract class PersonIdentifierResolverBase<TLookup, TResolved>
                 loadedIdentifierMappings),
             _reverseMapCache.SetMapEntriesAsync(
                 (odsInstanceHashId, personType, MapType.Inverse()),
-                loadedIdentifierMappings.Select(x => (x.value, x.key)).ToArray()));
+                [.. loadedIdentifierMappings.Select(x => (x.value, x.key))]));
         // Note: While we may want to validate that all values have been resolved, the behavior of the API when the resolution
         // fails (primarily for UniqueId values passed in PUT/POST requests) is appropriate without this extra validation. 
 
@@ -100,8 +99,8 @@ public abstract class PersonIdentifierResolverBase<TLookup, TResolved>
         {
             ulong odsInstanceHashId = _odsInstanceConfigurationContextProvider.Get().OdsInstanceHashId;
             TLookup[] cacheLookupIdentifiers = _performBackgroundInitialization
-                ? suppliedLookupIdentifiers.Concat(_cacheInitializationMarkerKeyForLookup).ToArray()
-                : suppliedLookupIdentifiers.ToArray();
+                ? [.. suppliedLookupIdentifiers, .. _cacheInitializationMarkerKeyForLookup]
+                : [.. suppliedLookupIdentifiers];
 
             // Resolve uniqueIds from the map cache
             TResolved[] resolvedIdentifiers = await _mapCache.GetMapEntriesAsync((odsInstanceHashId, personType, MapType), cacheLookupIdentifiers);

--- a/Application/EdFi.Ods.Api/Caching/Person/PersonIdentifierResolverBase.cs
+++ b/Application/EdFi.Ods.Api/Caching/Person/PersonIdentifierResolverBase.cs
@@ -6,8 +6,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
-using EdFi.Common.Utils.Extensions;
 using EdFi.Ods.Api.IdentityValueMappers;
 using EdFi.Ods.Common.Caching;
 using EdFi.Ods.Common.Configuration;
@@ -27,169 +27,161 @@ public abstract class PersonIdentifierResolverBase<TLookup, TResolved>
     private readonly IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), TLookup, TResolved> _mapCache;
     private readonly IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), TResolved, TLookup> _reverseMapCache;
     private readonly Dictionary<string, bool> _cacheSuppressionByPersonType;
-
     private readonly IPersonMapCacheInitializer _personMapCacheInitializer;
-
+    private readonly IDistributedLockProvider _distributedLockProvider;
     private readonly IContextProvider<OdsInstanceConfiguration> _odsInstanceConfigurationContextProvider;
-
     private readonly TLookup[] _cacheInitializationMarkerKeyForLookup;
-    private readonly TResolved[] _cacheInitializationMarkerKeyForResolved;
-
     private readonly ILog _logger;
     private readonly bool _performBackgroundInitialization;
 
     protected PersonIdentifierResolverBase(
         IPersonMapCacheInitializer personMapCacheInitializer,
+        IDistributedLockProvider distributedLockProvider,
         IContextProvider<OdsInstanceConfiguration> odsInstanceConfigurationContextProvider,
         IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), TLookup, TResolved> mapCache,
         IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), TResolved, TLookup> reverseMapCache,
-        ICacheInitializationMarkerKeyProvider<TLookup> cacheInitializationMarkerKeyForLookupProvider, 
-        ICacheInitializationMarkerKeyProvider<TResolved> cacheInitializationMarkerKeyForResolvedProvider, 
+        ICacheInitializationMarkerKeyProvider<TLookup> cacheInitializationMarkerKeyForLookupProvider,
+        ICacheInitializationMarkerKeyProvider<TResolved> cacheInitializationMarkerKeyForResolvedProvider,
         Dictionary<string, bool> cacheSuppressionByPersonType,
         bool useProgressiveLoading)
     {
         _logger = LogManager.GetLogger(GetType());
-
         _personMapCacheInitializer = personMapCacheInitializer;
+        _distributedLockProvider = distributedLockProvider;
         _odsInstanceConfigurationContextProvider = odsInstanceConfigurationContextProvider;
         _mapCache = mapCache;
         _reverseMapCache = reverseMapCache;
         _cacheSuppressionByPersonType = cacheSuppressionByPersonType;
-
         _performBackgroundInitialization = !useProgressiveLoading;
-        
         _cacheInitializationMarkerKeyForLookup = new[] { cacheInitializationMarkerKeyForLookupProvider.CacheKey };
-        _cacheInitializationMarkerKeyForResolved = new [] { cacheInitializationMarkerKeyForResolvedProvider.CacheKey };
     }
 
     protected abstract PersonMapType MapType { get; }
-    
+
     protected async Task ResolveIdentifiersAsync(string personType, IDictionary<TLookup, TResolved> lookups)
     {
-        ICollection<TLookup> identifiersToLoad = null;
-        var suppliedLookupIdentifiers = lookups.Keys;
+        TLookup[] suppliedLookupIdentifiers = [.. lookups.Keys];
 
         // All lookup values in current context must be loaded from the ODS since cached map initialization isn't yet complete
-        identifiersToLoad = IsCacheSuppressed(personType)
+        ICollection<TLookup> identifiersToLoad = IsCacheSuppressed(personType)
             ? suppliedLookupIdentifiers
-            : await ResolveIdentifiersFromCache();
+            : await ResolveIdentifiersFromCacheAsync();
 
-        // If there are any values that still need to be loaded directly from the ODS...
-        if (identifiersToLoad != null)
+        if (identifiersToLoad is null || identifiersToLoad.Count == 0)
         {
-            var loadedIdentifierMappings = (await LoadUnresolvedPersonIdentifiersAsync(personType, identifiersToLoad))
-                .Select(ExtractKeyValueTuple)
-                .ToArray();
-
-            // Update the contextual dictionary for the current request
-            foreach (var loadedIdentifierMapping in loadedIdentifierMappings)
-            {
-                lookups[loadedIdentifierMapping.key] = loadedIdentifierMapping.value;
-            }
-
-            // Update the underlying caches with the key/value pairs it doesn't have
-            ulong odsInstanceHashId = _odsInstanceConfigurationContextProvider.Get().OdsInstanceHashId;
-
-            await Task.WhenAll(
-                _mapCache.SetMapEntriesAsync(
-                    (odsInstanceHashId, personType, MapType),
-                    loadedIdentifierMappings),
-
-                _reverseMapCache.SetMapEntriesAsync(
-                    (odsInstanceHashId, personType, MapType.Inverse()),
-                    loadedIdentifierMappings.Select(x => (x.value, x.key)).ToArray()));
-
-            // Note: While we may want to validate that all values have been resolved, the behavior of the API when the resolution
-            // fails (primarily for UniqueId values passed in PUT/POST requests) is appropriate without this extra validation. 
+            return;
         }
 
-        async Task<ICollection<TLookup>> ResolveIdentifiersFromCache()
+        // There are any values that still need to be loaded directly from the ODS...
+        var loadedIdentifierMappings = (await LoadUnresolvedPersonIdentifiersAsync(personType, identifiersToLoad))
+            .Select(ExtractKeyValueTuple)
+            .ToArray();
+
+        // Update the contextual dictionary for the current request
+        foreach (var loadedIdentifierMapping in loadedIdentifierMappings)
+        {
+            lookups[loadedIdentifierMapping.key] = loadedIdentifierMapping.value;
+        }
+
+        // Update the underlying caches with the key/value pairs it doesn't have
+        ulong odsInstanceHashId = _odsInstanceConfigurationContextProvider.Get().OdsInstanceHashId;
+
+        await Task.WhenAll(
+            _mapCache.SetMapEntriesAsync(
+                (odsInstanceHashId, personType, MapType),
+                loadedIdentifierMappings),
+            _reverseMapCache.SetMapEntriesAsync(
+                (odsInstanceHashId, personType, MapType.Inverse()),
+                loadedIdentifierMappings.Select(x => (x.value, x.key)).ToArray()));
+        // Note: While we may want to validate that all values have been resolved, the behavior of the API when the resolution
+        // fails (primarily for UniqueId values passed in PUT/POST requests) is appropriate without this extra validation. 
+
+        async Task<ICollection<TLookup>> ResolveIdentifiersFromCacheAsync()
         {
             ulong odsInstanceHashId = _odsInstanceConfigurationContextProvider.Get().OdsInstanceHashId;
-
-            TLookup[] cacheLookupIdentifiers;
-
-            if (_performBackgroundInitialization)
-            {
-                cacheLookupIdentifiers = suppliedLookupIdentifiers.Concat(_cacheInitializationMarkerKeyForLookup).ToArray();
-            }
-            else
-            {
-                cacheLookupIdentifiers = suppliedLookupIdentifiers.ToArray();
-            }
+            TLookup[] cacheLookupIdentifiers = _performBackgroundInitialization
+                ? suppliedLookupIdentifiers.Concat(_cacheInitializationMarkerKeyForLookup).ToArray()
+                : suppliedLookupIdentifiers.ToArray();
 
             // Resolve uniqueIds from the map cache
-            var resolvedIdentifiers = await _mapCache.GetMapEntriesAsync((odsInstanceHashId, personType, MapType), cacheLookupIdentifiers);
+            TResolved[] resolvedIdentifiers = await _mapCache.GetMapEntriesAsync((odsInstanceHashId, personType, MapType), cacheLookupIdentifiers);
+            List<TLookup> unresolvedIdentifiers = null;
+
+            // The last entry is always the check to see if cache value has been background initialized -- don't process that entry normally
+            int lookupsToProcess = _performBackgroundInitialization ? resolvedIdentifiers.Length - 1 : resolvedIdentifiers.Length;
 
             // Assign resolved values to the supplied dictionary
-            resolvedIdentifiers.ForEach(
-                (resolvedIdentifier, i, args) =>
-                {
-                    // The last entry is always the check to see if cache value has been background initialized -- don't process that entry normally
-                    if (args.performBackgroundInitialization && i == args.resolvedIdentifiersLength - 1)
-                    {
-                        return;
-                    }
-                    
-                    if (resolvedIdentifier == null || resolvedIdentifier.Equals(default(TResolved)))
-                    {
-                        // Need to load unresolved entries from the ODS
-                        AddUniqueIdToLoad(args.cacheLookupIdentifiers[i]);
-                    }
-                    else
-                    {
-                        // Record the resolved identifier
-                        args.lookups[args.cacheLookupIdentifiers[i]] = resolvedIdentifier;
-                    }
-                    
-                    void AddUniqueIdToLoad(TLookup lookupValue)
-                    {
-                        identifiersToLoad ??= new List<TLookup>();
-                        identifiersToLoad.Add(lookupValue);
-                    }
-                },
-                // Args to avoid closure
-                (cacheLookupIdentifiers, 
-                    lookups, 
-                    identifiersToLoad, 
-                    resolvedIdentifiersLength: resolvedIdentifiers.Length,
-                    performBackgroundInitialization: _performBackgroundInitialization));
-
-            // Check to see if cache needs to be initialized by checking the resolution of the marker value
-            if (_performBackgroundInitialization && resolvedIdentifiers[^1] == null)
+            for (int i = 0; i < lookupsToProcess; i++)
             {
-                try
+                if (IsUnresolved(resolvedIdentifiers[i]))
                 {
-                    // Add the entries indicating that background initialization has been initiated/performed
-                    await Task.WhenAll(
-                        _mapCache.SetMapEntriesAsync(
-                            (odsInstanceHashId, personType, MapType),
-                            new[] { (_cacheInitializationMarkerKeyForLookup[0], _cacheInitializationMarkerKeyForResolved[0]) }),
-                        _reverseMapCache.SetMapEntriesAsync(
-                            (odsInstanceHashId, personType, MapType.Inverse()),
-                            new[] { (_cacheInitializationMarkerKeyForResolved[0], _cacheInitializationMarkerKeyForLookup[0]) }));
+                    unresolvedIdentifiers ??= [];
+                    unresolvedIdentifiers.Add(cacheLookupIdentifiers[i]);
                 }
-                catch (Exception ex)
+                else
                 {
-                    _logger.Error("An error occurred while attempting to add the 'initialization' marker cache entry to the cache.", ex);
+                    // Record the resolved identifier
+                    lookups[cacheLookupIdentifiers[i]] = resolvedIdentifiers[i];
                 }
-
-                // NOTE: Do NOT await this Task -- let it run in the background
-                #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                // Initiate cache initialization of the entire UniqueId/USI map for the ODS
-                _personMapCacheInitializer.InitializePersonMapAsync(odsInstanceHashId, personType);
-                #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             }
 
-            return identifiersToLoad;
+            // Check to see if cache needs to be initialized by checking the resolution of the marker value
+            if (_performBackgroundInitialization && IsUnresolved(resolvedIdentifiers[^1]))
+            {
+                string lockKey = $"cache-init-lock:{odsInstanceHashId}:{personType}:{MapType}";
+
+                if (await _distributedLockProvider.TryAcquireLockAsync(lockKey, TimeSpan.FromMinutes(5)))
+                {
+                    try
+                    {
+                        // NOTE: Do NOT await this Task -- let it run in the background
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                        // Initiate cache initialization of the entire UniqueId/USI map for the ODS
+                        var initializationTask = _personMapCacheInitializer.InitializePersonMapAsync(
+                            odsInstanceHashId,
+                            personType,
+                            lockKey,
+                            CancellationToken.None);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+
+                        _ = initializationTask.ContinueWith(
+                            t => _logger.Error(
+                                $"An error occurred while initializing the '{personType}' cache in the background for ODS instance '{odsInstanceHashId}'.",
+                                t.Exception),
+                            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Error(
+                            $"Unable to start background cache initialization for '{personType}' in ODS instance '{odsInstanceHashId}'.",
+                            ex);
+
+                        try
+                        {
+                            await _distributedLockProvider.ReleaseLockAsync(lockKey);
+                        }
+                        catch (Exception releaseEx)
+                        {
+                            _logger.Error(
+                                $"An error occurred while releasing the Redis initialization lock '{lockKey}' after failed start.",
+                                releaseEx);
+                        }
+                    }
+                }
+            }
+
+            return unresolvedIdentifiers;
         }
+
+        static bool IsUnresolved(TResolved resolvedIdentifier)
+            => resolvedIdentifier is null || EqualityComparer<TResolved>.Default.Equals(resolvedIdentifier, default);
     }
 
     private bool IsCacheSuppressed(string personType)
         => _cacheSuppressionByPersonType.TryGetValue(personType, out bool isSuppressed) && isSuppressed;
 
     /// <summary>
-    /// Gets the key/value tuple from the <see cref="PersonIdentifiersValueMap" /> appropriately for the <see cref="MapType" />.  
+    /// Gets the key/value tuple from the <see cref="PersonIdentifiersValueMap" /> appropriately for the <see cref="MapType" />.
     /// </summary>
     /// <param name="personIdentifiers">The UniqueId/USI values for a person in the ODS to be converted to a key/value tuple.</param>
     protected abstract (TLookup key, TResolved value) ExtractKeyValueTuple(PersonIdentifiersValueMap personIdentifiers);

--- a/Application/EdFi.Ods.Api/Caching/Person/PersonMapCacheInitializer.cs
+++ b/Application/EdFi.Ods.Api/Caching/Person/PersonMapCacheInitializer.cs
@@ -4,121 +4,154 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using EdFi.Ods.Api.IdentityValueMappers;
+using EdFi.Ods.Common.Caching;
 using log4net;
 
 namespace EdFi.Ods.Api.Caching.Person;
 
 public class PersonMapCacheInitializer : IPersonMapCacheInitializer
 {
+    private static readonly TimeSpan InitializationTimeout = TimeSpan.FromSeconds(60);
+
     private readonly IPersonIdentifiersProvider _personIdentifiersProvider;
     private readonly IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), string, int> _usiByUniqueIdMapCache;
     private readonly IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), int, string> _uniqueIdByUsiMapCache;
-
+    private readonly IDistributedLockProvider _distributedLockProvider;
     private readonly ILog _logger = LogManager.GetLogger(typeof(PersonMapCacheInitializer));
 
     public PersonMapCacheInitializer(
         IPersonIdentifiersProvider personIdentifiersProvider,
         IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), int, string> uniqueIdByUsiMapCache,
-        IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), string, int> usiByUniqueIdMapCache)
+        IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), string, int> usiByUniqueIdMapCache,
+        IDistributedLockProvider distributedLockProvider)
     {
         _personIdentifiersProvider = personIdentifiersProvider;
         _usiByUniqueIdMapCache = usiByUniqueIdMapCache;
         _uniqueIdByUsiMapCache = uniqueIdByUsiMapCache;
+        _distributedLockProvider = distributedLockProvider;
     }
 
     /// <inheritdoc cref="IPersonMapCacheInitializer.InitializePersonMapAsync" />
-    public Task InitializePersonMapAsync(ulong odsInstanceHashId, string personType)
+    public async Task InitializePersonMapAsync(
+        ulong odsInstanceHashId,
+        string personType,
+        string lockKey,
+        CancellationToken cancellationToken = default)
     {
-        Stopwatch sw = null;
+        Stopwatch stopwatch = null;
+        using var timeoutCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCancellationTokenSource.CancelAfter(InitializationTimeout);
 
-        return Task.Run(async () =>
+        try
+        {
+            if (_logger.IsDebugEnabled)
             {
-                if (_logger.IsDebugEnabled)
-                {
-                    _logger.Debug($"Starting '{personType}' cache initialization for ODS instance '{odsInstanceHashId}'...");
+                _logger.Debug($"Starting '{personType}' cache initialization for ODS instance '{odsInstanceHashId}'...");
+                stopwatch = Stopwatch.StartNew();
+            }
 
-                    sw = new Stopwatch();
-                    sw.Start();
-                }
+            var result = (await _personIdentifiersProvider.GetAllPersonIdentifiersAsync(
+                    personType,
+                    timeoutCancellationTokenSource.Token))
+                .ToArray();
 
-                var result = await _personIdentifiersProvider.GetAllPersonIdentifiersAsync(personType);
+            if (_logger.IsDebugEnabled)
+            {
+                _logger.Debug($"Obtained {result.Length:N0} '{personType}' identifiers after {stopwatch?.ElapsedMilliseconds ?? 0:N0} ms...");
+            }
 
-                if (_logger.IsDebugEnabled)
-                {
-                    if (result is ICollection<PersonIdentifiersValueMap> countableResult)
+            timeoutCancellationTokenSource.Token.ThrowIfCancellationRequested();
+
+            var uniqueIdByUsiCacheEntries = result.Select(v => (v.Usi, v.UniqueId))
+                .Concat(
+                    new[]
                     {
-                        _logger.Debug($"Obtained {countableResult.Count:N0} '{personType}' identifiers after {sw.ElapsedMilliseconds:N0} ms...");
-                    }
-                    else
+                        (InitializedReservedKeyForUsi: CacheInitializationConstants.InitializationMarkerKeyForUsi,
+                            InitializedKeyForUniqueId: CacheInitializationConstants.InitializationMarkerKeyForUniqueId)
+                    })
+                .ToArray();
+
+            var usiByUniqueIdCacheEntries = result.Select(v => (v.UniqueId, v.Usi))
+                .Concat(
+                    new[]
                     {
-                        _logger.Debug($"Obtained all '{personType}' identifiers after {sw.ElapsedMilliseconds:N0} ms...");
-                    }
-                }
+                        (InitializedKeyForUniqueId: CacheInitializationConstants.InitializationMarkerKeyForUniqueId,
+                            InitializedReservedKeyForUsi: CacheInitializationConstants.InitializationMarkerKeyForUsi)
+                    })
+                .ToArray();
 
-                return result;
-            })
-            .ContinueWith(
-                async t =>
-                {
-                    if (t.IsFaulted)
-                    {
-                        _logger.Error(
-                            $"Unable to load '{personType}' mappings from ODS (with OdsInstanceHashId '{odsInstanceHashId}').",
-                            t.Exception);
-                    }
-                    else if (t.IsCompletedSuccessfully)
-                    {
-                        if (_logger.IsDebugEnabled)
-                        {
-                            _logger.Debug($"Setting '{personType}' map entries into cache for ODS instance '{odsInstanceHashId}'...");
-                        }
+            if (_logger.IsDebugEnabled)
+            {
+                _logger.Debug($"Setting '{personType}' map entries into cache for ODS instance '{odsInstanceHashId}'...");
+            }
 
-                        var uniqueIdByUsiCacheEntries = t.Result.Select(v => (v.Usi, v.UniqueId))
-                            .Concat(
-                                new[]
-                                {
-                                    (InitializedReservedKeyForUsi: CacheInitializationConstants.InitializationMarkerKeyForUsi,
-                                        InitializedKeyForUniqueId: CacheInitializationConstants.InitializationMarkerKeyForUniqueId)
-                                })
-                            .ToArray();
+            await Task.WhenAll(
+                _uniqueIdByUsiMapCache.SetMapEntriesAsync(
+                    (odsInstanceHashId, personType, PersonMapType.UniqueIdByUsi),
+                    uniqueIdByUsiCacheEntries),
+                _usiByUniqueIdMapCache.SetMapEntriesAsync(
+                    (odsInstanceHashId, personType, PersonMapType.UsiByUniqueId),
+                    usiByUniqueIdCacheEntries));
 
-                        var usiByUniqueIdCacheEntries = t.Result.Select(v => (v.UniqueId, v.Usi))
-                            .Concat(
-                                new[]
-                                {
-                                    (InitializedKeyForUniqueId: CacheInitializationConstants.InitializationMarkerKeyForUniqueId,
-                                        InitializedReservedKeyForUsi: CacheInitializationConstants.InitializationMarkerKeyForUsi)
-                                })
-                            .ToArray();
+            if (_logger.IsDebugEnabled)
+            {
+                stopwatch?.Stop();
+                _logger.Debug($"Completed background cache initialization of {uniqueIdByUsiCacheEntries.Length:N0} {personType} entries for ODS instance '{odsInstanceHashId}' in {stopwatch?.ElapsedMilliseconds ?? 0:N0} ms...");
+            }
+        }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.Warn(
+                $"Background cache initialization of '{personType}' entries for ODS instance '{odsInstanceHashId}' exceeded the {InitializationTimeout.TotalSeconds:N0}-second timeout.",
+                ex);
 
-                        // Set the retrieved tuples into the cache
-                        try
-                        {
-                            await Task.WhenAll(
-                                _uniqueIdByUsiMapCache.SetMapEntriesAsync(
-                                    (odsInstanceHashId, personType, PersonMapType.UniqueIdByUsi),
-                                    uniqueIdByUsiCacheEntries),
-                                _usiByUniqueIdMapCache.SetMapEntriesAsync(
-                                    (odsInstanceHashId, personType, PersonMapType.UsiByUniqueId),
-                                    usiByUniqueIdCacheEntries));
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.Error("An error occurred while setting UniqueId/USI entries into the cache.", ex);
-                        }
+            await ResetInitializationMarkerAsync(odsInstanceHashId, personType);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(
+                $"Unable to load '{personType}' mappings from ODS (with OdsInstanceHashId '{odsInstanceHashId}').",
+                ex);
 
-                        if (_logger.IsDebugEnabled)
-                        {
-                            sw.Stop();
-                            
-                            _logger.Debug($"Completed background cache initialization of {uniqueIdByUsiCacheEntries.Length:N0} {personType} entries for ODS instance '{odsInstanceHashId}' in {sw.ElapsedMilliseconds:N0} ms...");
-                        }
-                    }
-                });
-    } 
+            await ResetInitializationMarkerAsync(odsInstanceHashId, personType);
+        }
+        finally
+        {
+            try
+            {
+                await _distributedLockProvider.ReleaseLockAsync(lockKey);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(
+                    $"Exception occurred while releasing background initialization lock '{lockKey}' for ODS instance '{odsInstanceHashId}'.",
+                    ex);
+            }
+        }
+    }
+
+    private async Task ResetInitializationMarkerAsync(ulong odsInstanceHashId, string personType)
+    {
+        try
+        {
+            await Task.WhenAll(
+                _uniqueIdByUsiMapCache.SetMapEntriesAsync(
+                    (odsInstanceHashId, personType, PersonMapType.UniqueIdByUsi),
+                    new[] { (CacheInitializationConstants.InitializationMarkerKeyForUsi, default(string)) }),
+                _usiByUniqueIdMapCache.SetMapEntriesAsync(
+                    (odsInstanceHashId, personType, PersonMapType.UsiByUniqueId),
+                    new[] { (CacheInitializationConstants.InitializationMarkerKeyForUniqueId, default(int)) }));
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn(
+                $"Unable to clear cache initialization markers for '{personType}' in ODS instance '{odsInstanceHashId}'.",
+                ex);
+        }
+    }
 }

--- a/Application/EdFi.Ods.Api/Caching/Person/PersonUniqueIdResolver.cs
+++ b/Application/EdFi.Ods.Api/Caching/Person/PersonUniqueIdResolver.cs
@@ -22,16 +22,18 @@ public class PersonUniqueIdResolver : PersonIdentifierResolverBase<int, string>,
 
     public PersonUniqueIdResolver(
         IPersonMapCacheInitializer personMapCacheInitializer,
+        IDistributedLockProvider distributedLockProvider,
         IPersonIdentifiersProvider personIdentifiersProvider,
         IContextProvider<OdsInstanceConfiguration> odsInstanceConfigurationContextProvider,
         IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), int, string> mapCache,
         IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), string, int> reverseMapCache,
-        ICacheInitializationMarkerKeyProvider<int> cacheInitializationMarkerKeyForLookupProvider, 
-        ICacheInitializationMarkerKeyProvider<string> cacheInitializationMarkerKeyForResolvedProvider, 
+        ICacheInitializationMarkerKeyProvider<int> cacheInitializationMarkerKeyForLookupProvider,
+        ICacheInitializationMarkerKeyProvider<string> cacheInitializationMarkerKeyForResolvedProvider,
         Dictionary<string, bool> cacheSuppressionByPersonType,
         bool useProgressiveLoading)
         : base(
             personMapCacheInitializer,
+            distributedLockProvider,
             odsInstanceConfigurationContextProvider,
             mapCache,
             reverseMapCache,
@@ -56,10 +58,7 @@ public class PersonUniqueIdResolver : PersonIdentifierResolverBase<int, string>,
         return await _personIdentifiersProvider.GetPersonUniqueIdsAsync(personType, identifiersToLoad.ToArray());
     }
 
-    protected override PersonMapType MapType
-    {
-        get => PersonMapType.UniqueIdByUsi;
-    }
+    protected override PersonMapType MapType => PersonMapType.UniqueIdByUsi;
 
     protected override (int key, string value) ExtractKeyValueTuple(PersonIdentifiersValueMap personIdentifiers)
     {

--- a/Application/EdFi.Ods.Api/Caching/Person/PersonUniqueIdResolver.cs
+++ b/Application/EdFi.Ods.Api/Caching/Person/PersonUniqueIdResolver.cs
@@ -28,7 +28,6 @@ public class PersonUniqueIdResolver : PersonIdentifierResolverBase<int, string>,
         IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), int, string> mapCache,
         IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), string, int> reverseMapCache,
         ICacheInitializationMarkerKeyProvider<int> cacheInitializationMarkerKeyForLookupProvider,
-        ICacheInitializationMarkerKeyProvider<string> cacheInitializationMarkerKeyForResolvedProvider,
         Dictionary<string, bool> cacheSuppressionByPersonType,
         bool useProgressiveLoading)
         : base(
@@ -38,7 +37,6 @@ public class PersonUniqueIdResolver : PersonIdentifierResolverBase<int, string>,
             mapCache,
             reverseMapCache,
             cacheInitializationMarkerKeyForLookupProvider,
-            cacheInitializationMarkerKeyForResolvedProvider,
             cacheSuppressionByPersonType,
             useProgressiveLoading)
     {

--- a/Application/EdFi.Ods.Api/Caching/Person/PersonUsiResolver.cs
+++ b/Application/EdFi.Ods.Api/Caching/Person/PersonUsiResolver.cs
@@ -22,6 +22,7 @@ public class PersonUsiResolver : PersonIdentifierResolverBase<string, int>, IPer
 
     public PersonUsiResolver(
         IPersonMapCacheInitializer personMapCacheInitializer,
+        IDistributedLockProvider distributedLockProvider,
         IPersonIdentifiersProvider personIdentifiersProvider,
         IContextProvider<OdsInstanceConfiguration> odsInstanceConfigurationContextProvider,
         IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), string, int> mapCache,
@@ -32,6 +33,7 @@ public class PersonUsiResolver : PersonIdentifierResolverBase<string, int>, IPer
         bool useProgressiveLoading)
         : base(
             personMapCacheInitializer,
+            distributedLockProvider,
             odsInstanceConfigurationContextProvider,
             mapCache,
             reverseMapCache,
@@ -43,10 +45,7 @@ public class PersonUsiResolver : PersonIdentifierResolverBase<string, int>, IPer
         _personIdentifiersProvider = personIdentifiersProvider;
     }
 
-    protected override PersonMapType MapType
-    {
-        get => PersonMapType.UsiByUniqueId;
-    }
+    protected override PersonMapType MapType => PersonMapType.UsiByUniqueId;
 
     /// <inheritdoc cref="IPersonUsiResolver.ResolveUsisAsync" />
     public async Task ResolveUsisAsync(string personType, IDictionary<string, int> lookups)

--- a/Application/EdFi.Ods.Api/Caching/Person/PersonUsiResolver.cs
+++ b/Application/EdFi.Ods.Api/Caching/Person/PersonUsiResolver.cs
@@ -28,7 +28,6 @@ public class PersonUsiResolver : PersonIdentifierResolverBase<string, int>, IPer
         IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), string, int> mapCache,
         IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), int, string> reverseMapCache,
         ICacheInitializationMarkerKeyProvider<string> cacheInitializationMarkerKeyForLookupProvider,
-        ICacheInitializationMarkerKeyProvider<int> cacheInitializationMarkerKeyForResolvedProvider,
         Dictionary<string, bool> cacheSuppressionByPersonType,
         bool useProgressiveLoading)
         : base(
@@ -38,7 +37,6 @@ public class PersonUsiResolver : PersonIdentifierResolverBase<string, int>, IPer
             mapCache,
             reverseMapCache,
             cacheInitializationMarkerKeyForLookupProvider,
-            cacheInitializationMarkerKeyForResolvedProvider,
             cacheSuppressionByPersonType,
             useProgressiveLoading)
     {

--- a/Application/EdFi.Ods.Api/Constants/ApiVersionConstants.cs
+++ b/Application/EdFi.Ods.Api/Constants/ApiVersionConstants.cs
@@ -27,7 +27,7 @@ namespace EdFi.Ods.Api.Constants
         /// <summary>
         /// Informational version of the ods api.
         /// </summary>
-        public const string InformationalVersion = "7.3.2";
+        public const string InformationalVersion = "7.3.3";
 
         /// <summary>
         /// Semantic version of the ods api.

--- a/Application/EdFi.Ods.Api/Container/Modules/PersistenceModule.cs
+++ b/Application/EdFi.Ods.Api/Container/Modules/PersistenceModule.cs
@@ -52,9 +52,10 @@ namespace EdFi.Ods.Api.Container.Modules
                 .PreserveExistingDefaults()
                 .SingleInstance();
 
-            builder.Register(c => new MemoryCache(new MemoryCacheOptions()))
-                .As<IMemoryCache>()
-                .SingleInstance();
+            // Note: We do NOT register a singleton IMemoryCache here.
+            // Instead, each tiered cache gets its own dedicated MemoryCache instance
+            // to prevent unintended cross-module eviction when one cache is cleared.
+            // See RegisterPersonIdentifierCaching for the dedicated registrations.
 
             builder.RegisterType<MemoryCacheProvider>()
                 .As<ICacheProvider<string>>()
@@ -80,7 +81,7 @@ namespace EdFi.Ods.Api.Container.Modules
                     ctx =>
                     {
                         var apiSettings = ctx.Resolve<ApiSettings>();
-            
+
                         return (ICacheProvider<ulong>) new ExpiringConcurrentDictionaryCacheProvider<ulong>(
                             "Descriptors",
                             TimeSpan.FromSeconds(apiSettings.Caching.Descriptors.AbsoluteExpirationSeconds));
@@ -275,8 +276,18 @@ namespace EdFi.Ods.Api.Container.Modules
 
         private static void RegisterPersonIdentifierCaching(ContainerBuilder builder)
         {
+            // Register dedicated MemoryCache for UsiByUniqueId map cache
+            builder
+                .Register(c => new MemoryCache(new MemoryCacheOptions()))
+                .Keyed<IMemoryCache>("UsiByUniqueIdMemoryCache")
+                .SingleInstance();
+
             builder
                 .RegisterType<InMemoryMapCache<(ulong odsInstanceHashId, string personType, PersonMapType personMapType), string, int>>()
+                .WithParameter(
+                    new ResolvedParameter(
+                        (p, c) => p.ParameterType == typeof(IMemoryCache),
+                        (p, c) => c.ResolveKeyed<IMemoryCache>("UsiByUniqueIdMemoryCache")))
                 .WithParameter(
                     new ResolvedParameter(
                         (p, c) => p.Name.Equals("slidingExpirationPeriod", StringComparison.InvariantCultureIgnoreCase),
@@ -303,7 +314,17 @@ namespace EdFi.Ods.Api.Container.Modules
                 .As<IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), string, int>>()
                 .SingleInstance();
 
+            // Register dedicated MemoryCache for UniqueIdByUsi map cache
+            builder
+                .Register(c => new MemoryCache(new MemoryCacheOptions()))
+                .Keyed<IMemoryCache>("UniqueIdByUsiMemoryCache")
+                .SingleInstance();
+
             builder.RegisterType<InMemoryMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), int, string>>()
+                .WithParameter(
+                    new ResolvedParameter(
+                        (p, c) => p.ParameterType == typeof(IMemoryCache),
+                        (p, c) => c.ResolveKeyed<IMemoryCache>("UniqueIdByUsiMemoryCache")))
                 .WithParameter(
                     new ResolvedParameter(
                         (p, c) => p.Name.Equals("slidingExpirationPeriod", StringComparison.InvariantCultureIgnoreCase),
@@ -339,7 +360,12 @@ namespace EdFi.Ods.Api.Container.Modules
             builder.RegisterType<UniqueIdCacheInitializationMarkerKeyProvider>()
                 .As<ICacheInitializationMarkerKeyProvider<string>>()
                 .SingleInstance();
-            
+
+            builder.RegisterType<InMemoryDistributedLockProvider>()
+                .As<IDistributedLockProvider>()
+                .SingleInstance()
+                .PreserveExistingDefaults();
+
             builder.RegisterType<PersonUniqueIdResolver>()
                 .WithParameter(
                     new ResolvedParameter(

--- a/Application/EdFi.Ods.Api/IdentityValueMappers/IPersonIdentifiersProvider.cs
+++ b/Application/EdFi.Ods.Api/IdentityValueMappers/IPersonIdentifiersProvider.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace EdFi.Ods.Api.IdentityValueMappers
@@ -17,33 +18,34 @@ namespace EdFi.Ods.Api.IdentityValueMappers
         /// Gets the identifier values available for all members of the specified Person type.
         /// </summary>
         /// <param name="personType">The type of person whose UniqueId is being requested (e.g. Student, Staff or Parent/Contact).</param>
-        /// <returns>An enumerable collection of <see cref="PersonIdentifiersValueMap"/> instances containing the available identifiers 
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>An enumerable collection of <see cref="PersonIdentifiersValueMap"/> instances containing the available identifiers
         /// for UniqueId and the corresponding Id and/or USI values (depending on the implementation).</returns>
-        /// <remarks>Consumers should read all the data immediately because implementations may "stream" the 
+        /// <remarks>Consumers should read all the data immediately because implementations may "stream" the
         /// data back for efficiency reasons, holding onto resources such as a database connection until reading is
         /// complete.
         /// </remarks>
-        Task<IEnumerable<PersonIdentifiersValueMap>> GetAllPersonIdentifiersAsync(string personType);
+        Task<IEnumerable<PersonIdentifiersValueMap>> GetAllPersonIdentifiersAsync(string personType, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the identifier values available for all members of the specified Person type matching the supplied array of USI values.
         /// </summary>
         /// <param name="personType">The type of person whose UniqueId is being requested (e.g. Student, Staff or Parent/Contact).</param>
-        /// <returns>An enumerable collection of <see cref="PersonIdentifiersValueMap"/> instances containing the available identifiers 
+        /// <returns>An enumerable collection of <see cref="PersonIdentifiersValueMap"/> instances containing the available identifiers
         /// for UniqueId and the corresponding Id and/or USI values (depending on the implementation).</returns>
-        /// <remarks>Consumers should read all the data immediately because implementations may "stream" the 
+        /// <remarks>Consumers should read all the data immediately because implementations may "stream" the
         /// data back for efficiency reasons, holding onto resources such as a database connection until reading is
         /// complete.
         /// </remarks>
         Task<IEnumerable<PersonIdentifiersValueMap>> GetPersonUniqueIdsAsync(string personType, int[] usis);
-        
+
         /// <summary>
         /// Gets the identifier values available for all members of the specified Person type matching the supplied array of UniqueId values.
         /// </summary>
         /// <param name="personType">The type of person whose UniqueId is being requested (e.g. Student, Staff or Parent/Contact).</param>
-        /// <returns>An enumerable collection of <see cref="PersonIdentifiersValueMap"/> instances containing the available identifiers 
+        /// <returns>An enumerable collection of <see cref="PersonIdentifiersValueMap"/> instances containing the available identifiers
         /// for UniqueId and the corresponding Id and/or USI values (depending on the implementation).</returns>
-        /// <remarks>Consumers should read all the data immediately because implementations may "stream" the 
+        /// <remarks>Consumers should read all the data immediately because implementations may "stream" the
         /// data back for efficiency reasons, holding onto resources such as a database connection until reading is
         /// complete.
         /// </remarks>

--- a/Application/EdFi.Ods.Api/IdentityValueMappers/PersonIdentifiersProvider.cs
+++ b/Application/EdFi.Ods.Api/IdentityValueMappers/PersonIdentifiersProvider.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using EdFi.Common;
 using EdFi.Common.Extensions;
@@ -61,15 +62,16 @@ namespace EdFi.Ods.Api.IdentityValueMappers
         /// Gets the identifier values available for all members of the specified Person type as a streaming enumerable.
         /// </summary>
         /// <param name="personType">The type of person whose UniqueId is being requested (e.g. Student, Staff or Parent).</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>An enumerable collection of <see cref="PersonIdentifiersValueMap"/> instances containing the available identifiers
         /// for UniqueId and the corresponding Id and/or USI values (depending on the implementation).</returns>
         /// <remarks>Consumers should read all the data immediately because implementations should "stream" the
         /// data back for efficiency reasons, holding on resources such as a database connection until reading is
         /// complete.
         /// </remarks>
-        public async Task<IEnumerable<PersonIdentifiersValueMap>> GetAllPersonIdentifiersAsync(string personType)
+        public async Task<IEnumerable<PersonIdentifiersValueMap>> GetAllPersonIdentifiersAsync(string personType, CancellationToken cancellationToken = default)
         {
-            return await GetPersonIdentifiers(personType);
+            return await GetPersonIdentifiers(personType, cancellationToken: cancellationToken);
         }
 
         public async Task<IEnumerable<PersonIdentifiersValueMap>> GetPersonUniqueIdsAsync(string personType, int[] usis)
@@ -85,7 +87,8 @@ namespace EdFi.Ods.Api.IdentityValueMappers
         private async Task<IEnumerable<PersonIdentifiersValueMap>> GetPersonIdentifiers(
             string personType,
             string[] uniqueIds = null,
-            int[] usis = null)
+            int[] usis = null,
+            CancellationToken cancellationToken = default)
         {
             ValidateArguments();
 
@@ -97,13 +100,13 @@ namespace EdFi.Ods.Api.IdentityValueMappers
 
                 IQuery query = null;
 
-                if (uniqueIds != null)
+                if (uniqueIds is not null)
                 {
                     // Load USIs for specified UniqueIds
                     query = session.CreateQuery(GetHql(PersonMapType.UsiByUniqueId));
                     _parameterListSetter.SetParameterList(query, "ids", uniqueIds);
                 }
-                else if (usis != null)
+                else if (usis is not null)
                 {
                     // Load UniqueIds for specified USIs
                     query = session.CreateQuery(GetHql(PersonMapType.UniqueIdByUsi));
@@ -117,13 +120,13 @@ namespace EdFi.Ods.Api.IdentityValueMappers
 
                 query.SetResultTransformer(Transformers.AliasToBean<PersonIdentifiersValueMap>());
 
-                return await query.ListAsync<PersonIdentifiersValueMap>();
+                return await query.ListAsync<PersonIdentifiersValueMap>(cancellationToken);
             }
             finally
             {
                 _contextStorage.SetValue(NHibernateOdsConnectionProvider.UseReadWriteConnectionCacheKey, null);
             }
-            
+
             string GetHql(PersonMapType? mapType = null)
             {
                 return _hqlByPersonType.GetOrAdd(
@@ -131,7 +134,7 @@ namespace EdFi.Ods.Api.IdentityValueMappers
                     static (key, args) =>
                     {
                         var (pt, mt) = key;
-                        
+
                         string aggregateNamespace = Namespaces.Entities.NHibernate.GetAggregateNamespace(
                             pt,
                             EdFiConventions.ProperCaseName);
@@ -149,8 +152,7 @@ namespace EdFi.Ods.Api.IdentityValueMappers
                             whereClause = $" where p.{args._uniqueIdNameByPersonType.Value[pt]} in (:ids)";
                         }
 
-                        var hql = $"select p.{args._usiNameByPersonType.Value[pt]} as Usi, p.{args._uniqueIdNameByPersonType.Value[pt]} as UniqueId from {entityName} p{whereClause}";
-                        return hql;
+                        return $"select p.{args._usiNameByPersonType.Value[pt]} as Usi, p.{args._uniqueIdNameByPersonType.Value[pt]} as UniqueId from {entityName} p{whereClause}";
                     },
                     (_usiNameByPersonType, _uniqueIdNameByPersonType));
             }
@@ -159,11 +161,11 @@ namespace EdFi.Ods.Api.IdentityValueMappers
             {
                 ArgumentNullException.ThrowIfNull(personType, nameof(personType));
 
-                bool UsisSupplied() => !(usis == null || usis.Length == 0);
-                bool UniqueIdsSupplied() => !(uniqueIds == null || uniqueIds.Length == 0);
+                bool usisSupplied() => !(usis is null || usis.Length == 0);
+                bool uniqueIdsSupplied() => !(uniqueIds is null || uniqueIds.Length == 0);
 
                 // Ensure both sets of identifiers are not provided
-                if (UniqueIdsSupplied() && UsisSupplied())
+                if (uniqueIdsSupplied() && usisSupplied())
                 {
                     throw new ArgumentException($"Both '{nameof(uniqueIds)}' and '{nameof(usis)}' cannot be provided.");
                 }
@@ -172,7 +174,6 @@ namespace EdFi.Ods.Api.IdentityValueMappers
                 if (!_personEntitySpecification.IsPersonEntity(personType))
                 {
                     string validPersonTypes = string.Join("','", _personTypesProvider.PersonTypes).SingleQuoted();
-
                     throw new ArgumentException($"Invalid person type '{personType}'. Valid person types are: {validPersonTypes}");
                 }
             }

--- a/Application/EdFi.Ods.Common/Caching/AsyncCachingInterceptor.cs
+++ b/Application/EdFi.Ods.Common/Caching/AsyncCachingInterceptor.cs
@@ -61,7 +61,9 @@ public class AsyncCachingInterceptor(IAsyncCacheProvider<ulong> asyncCacheProvid
             return;
         }
 
-        if (_localCacheProvider.TryGetCachedObject(cacheKey, out var cachedValue))
+        // Reference equality check avoids making synchronous Redis call if Redis is setup as both L1 and L2 cache
+        if (!ReferenceEquals(_localCacheProvider, _asyncCacheProvider)
+             && _localCacheProvider.TryGetCachedObject(cacheKey, out var cachedValue))
         {
             invocation.ReturnValue = cachedValue;
             return;

--- a/Application/EdFi.Ods.Common/Caching/AsyncCachingInterceptor.cs
+++ b/Application/EdFi.Ods.Common/Caching/AsyncCachingInterceptor.cs
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Castle.DynamicProxy;
+
+namespace EdFi.Ods.Common.Caching;
+
+/// <summary>
+/// Provides caching interception that can use asynchronous cache providers while preserving support for synchronous methods.
+/// </summary>
+public class AsyncCachingInterceptor(IAsyncCacheProvider<ulong> asyncCacheProvider, ICacheProvider<ulong> localCacheProvider) : IInterceptor, IClearable
+{
+    private static readonly MethodInfo InterceptAsyncWithResultMethod = typeof(AsyncCachingInterceptor)
+        .GetMethod(nameof(InterceptAsyncWithResultAsync), BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static readonly object CompletedTaskValue = 1;
+
+    private readonly IAsyncCacheProvider<ulong> _asyncCacheProvider = asyncCacheProvider;
+    private readonly ICacheProvider<ulong> _localCacheProvider = localCacheProvider;
+
+    public void Intercept(IInvocation invocation)
+    {
+        ulong cacheKey;
+
+        try
+        {
+            if (invocation.Method.DeclaringType is null)
+            {
+                throw new NotSupportedException($"Unable to generate a cache key for method '{invocation.Method.Name}' because it has no DeclaringType.");
+            }
+
+            cacheKey = GenerateCacheKey(invocation.Method, invocation.Arguments);
+        }
+        catch (Exception ex)
+        {
+            throw new CachingInterceptorCacheKeyGenerationException(
+                $"Cache key generation failed for invocation of method '{invocation.Method.Name}' of declaring type '{invocation.Method.DeclaringType?.FullName}'.",
+                ex);
+        }
+
+        var returnType = invocation.Method.ReturnType;
+
+        if (returnType == typeof(Task))
+        {
+            invocation.ReturnValue = InterceptAsyncWithoutResultAsync(invocation, cacheKey);
+            return;
+        }
+
+        if (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(Task<>))
+        {
+            var resultType = returnType.GetGenericArguments()[0];
+
+            invocation.ReturnValue = InterceptAsyncWithResultMethod.MakeGenericMethod(resultType)
+                .Invoke(this, [invocation, cacheKey])!;
+
+            return;
+        }
+
+        if (_localCacheProvider.TryGetCachedObject(cacheKey, out var cachedValue))
+        {
+            invocation.ReturnValue = cachedValue;
+            return;
+        }
+
+        var (found, value) = _asyncCacheProvider.TryGetCachedObjectAsync(cacheKey).GetAwaiter().GetResult();
+
+        if (found)
+        {
+            invocation.ReturnValue = value;
+            return;
+        }
+
+        invocation.Proceed();
+        _asyncCacheProvider.SetCachedObjectAsync(cacheKey, invocation.ReturnValue).GetAwaiter().GetResult();
+    }
+
+    protected virtual ulong GenerateCacheKey(MethodInfo method, object[] arguments)
+    {
+        return CachingInterceptorKeyGenerator.GenerateCacheKey(method, arguments);
+    }
+
+    public void Clear()
+    {
+        var cleared = false;
+
+        if (_localCacheProvider is IClearable localClearable)
+        {
+            localClearable.Clear();
+            cleared = true;
+        }
+
+        if (!ReferenceEquals(_localCacheProvider, _asyncCacheProvider)
+            && _asyncCacheProvider is IClearable asyncClearable)
+        {
+            asyncClearable.Clear();
+            cleared = true;
+        }
+
+        if (!cleared)
+        {
+            throw new NotSupportedException($"Unable to clear the underlying data associated with the {nameof(AsyncCachingInterceptor)}.");
+        }
+    }
+
+    private async Task InterceptAsyncWithoutResultAsync(IInvocation invocation, ulong cacheKey)
+    {
+        var (found, _) = await _asyncCacheProvider.TryGetCachedObjectAsync(cacheKey).ConfigureAwait(false);
+
+        if (found)
+        {
+            return;
+        }
+
+        invocation.Proceed();
+
+        var task = (Task) invocation.ReturnValue;
+        await task.ConfigureAwait(false);
+        await _asyncCacheProvider.SetCachedObjectAsync(cacheKey, CompletedTaskValue).ConfigureAwait(false);
+    }
+
+    private async Task<T> InterceptAsyncWithResultAsync<T>(IInvocation invocation, ulong cacheKey)
+    {
+        var (found, value) = await _asyncCacheProvider.TryGetCachedObjectAsync(cacheKey).ConfigureAwait(false);
+
+        if (found)
+        {
+            return ConvertCachedValue<T>(value);
+        }
+
+        invocation.Proceed();
+
+        var task = (Task<T>) invocation.ReturnValue;
+        var result = await task.ConfigureAwait(false);
+
+        await _asyncCacheProvider.SetCachedObjectAsync(cacheKey, result).ConfigureAwait(false);
+
+        return result;
+    }
+
+    private static T ConvertCachedValue<T>(object value)
+    {
+        if (value is null)
+        {
+            return default!;
+        }
+
+        return value is T typedValue
+            ? typedValue
+            : (T) value;
+    }
+}

--- a/Application/EdFi.Ods.Common/Caching/AsyncContextualCachingInterceptor.cs
+++ b/Application/EdFi.Ods.Common/Caching/AsyncContextualCachingInterceptor.cs
@@ -13,30 +13,28 @@ namespace EdFi.Ods.Common.Caching;
 /// Provides contextual cache interception that can use asynchronous cache providers.
 /// </summary>
 /// <typeparam name="TContext">The type of contextual data used to generate the cache key.</typeparam>
-public class AsyncContextualCachingInterceptor<TContext> : AsyncCachingInterceptor
+public class AsyncContextualCachingInterceptor<TContext>(
+    IAsyncCacheProvider<ulong> asyncCacheProvider,
+    ICacheProvider<ulong> localCacheProvider,
+    IContextProvider<TContext> contextProvider
+) : AsyncCachingInterceptor(asyncCacheProvider, localCacheProvider)
     where TContext : IContextHashBytesSource
 {
-    private readonly IContextProvider<TContext> _contextProvider;
-
-    public AsyncContextualCachingInterceptor(
-        IAsyncCacheProvider<ulong> asyncCacheProvider,
-        ICacheProvider<ulong> localCacheProvider,
-        IContextProvider<TContext> contextProvider)
-        : base(asyncCacheProvider, localCacheProvider) => _contextProvider = contextProvider;
+    private readonly IContextProvider<TContext> _contextProvider = contextProvider;
 
     protected override ulong GenerateCacheKey(MethodInfo method, object[] arguments)
     {
-        var context = _contextProvider.Get() ?? throw new InvalidOperationException(
-                $"No context has been set for value of type '{typeof(TContext).Name}'.");
+        // Without context, we cannot generate a key here
+        var context =
+            _contextProvider.Get()
+            ?? throw new InvalidOperationException(
+                $"No context has been set for value of type '{typeof(TContext).Name}'."
+            );
 
-        return arguments.Length switch
-        {
-            0 => XxHash3Code.Combine(context.HashBytes, method.DeclaringType!.FullName, method.Name),
-            1 => XxHash3Code.Combine(context.HashBytes, method.DeclaringType!.FullName, method.Name, arguments[0]),
-            2 => XxHash3Code.Combine(context.HashBytes, method.DeclaringType!.FullName, method.Name, arguments[0], arguments[1]),
-            3 => XxHash3Code.Combine(context.HashBytes, method.DeclaringType!.FullName, method.Name, arguments[0], arguments[1], arguments[2]),
-            _ => throw new NotImplementedException(
-                                "Support for generating contextual cache keys with more than 3 arguments has not been implemented."),
-        };
+        return CachingInterceptorKeyGenerator.GenerateContextualCacheKey(
+            context.HashBytes,
+            method,
+            arguments
+        );
     }
 }

--- a/Application/EdFi.Ods.Common/Caching/AsyncContextualCachingInterceptor.cs
+++ b/Application/EdFi.Ods.Common/Caching/AsyncContextualCachingInterceptor.cs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Reflection;
+using EdFi.Ods.Common.Context;
+
+namespace EdFi.Ods.Common.Caching;
+
+/// <summary>
+/// Provides contextual cache interception that can use asynchronous cache providers.
+/// </summary>
+/// <typeparam name="TContext">The type of contextual data used to generate the cache key.</typeparam>
+public class AsyncContextualCachingInterceptor<TContext> : AsyncCachingInterceptor
+    where TContext : IContextHashBytesSource
+{
+    private readonly IContextProvider<TContext> _contextProvider;
+
+    public AsyncContextualCachingInterceptor(
+        IAsyncCacheProvider<ulong> asyncCacheProvider,
+        ICacheProvider<ulong> localCacheProvider,
+        IContextProvider<TContext> contextProvider)
+        : base(asyncCacheProvider, localCacheProvider) => _contextProvider = contextProvider;
+
+    protected override ulong GenerateCacheKey(MethodInfo method, object[] arguments)
+    {
+        var context = _contextProvider.Get() ?? throw new InvalidOperationException(
+                $"No context has been set for value of type '{typeof(TContext).Name}'.");
+
+        return arguments.Length switch
+        {
+            0 => XxHash3Code.Combine(context.HashBytes, method.DeclaringType!.FullName, method.Name),
+            1 => XxHash3Code.Combine(context.HashBytes, method.DeclaringType!.FullName, method.Name, arguments[0]),
+            2 => XxHash3Code.Combine(context.HashBytes, method.DeclaringType!.FullName, method.Name, arguments[0], arguments[1]),
+            3 => XxHash3Code.Combine(context.HashBytes, method.DeclaringType!.FullName, method.Name, arguments[0], arguments[1], arguments[2]),
+            _ => throw new NotImplementedException(
+                                "Support for generating contextual cache keys with more than 3 arguments has not been implemented."),
+        };
+    }
+}

--- a/Application/EdFi.Ods.Common/Caching/CachingInterceptor.cs
+++ b/Application/EdFi.Ods.Common/Caching/CachingInterceptor.cs
@@ -56,24 +56,7 @@ public class CachingInterceptor : IInterceptor, IClearable
 
     protected virtual ulong GenerateCacheKey(MethodInfo method, object[] arguments)
     {
-        switch (arguments.Length)
-        {
-            case 0:
-                return XxHash3Code.Combine(method.DeclaringType!.FullName, method.Name);
-
-            case 1:
-                return XxHash3Code.Combine(method.DeclaringType!.FullName, method.Name, arguments[0]);
-
-            case 2:
-                return XxHash3Code.Combine(method.DeclaringType!.FullName, method.Name, arguments[0], arguments[1]);
-
-            case 3:
-                return XxHash3Code.Combine(method.DeclaringType!.FullName, method.Name, arguments[0], arguments[1], arguments[2]);
-
-            default:
-                throw new NotImplementedException(
-                    "Support for generating cache keys for more than 3 arguments has not been implemented.");
-        }
+        return CachingInterceptorKeyGenerator.GenerateCacheKey(method, arguments);
     }
 
     public void Clear()

--- a/Application/EdFi.Ods.Common/Caching/CachingInterceptorKeyGenerator.cs
+++ b/Application/EdFi.Ods.Common/Caching/CachingInterceptorKeyGenerator.cs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Reflection;
+
+namespace EdFi.Ods.Common.Caching;
+
+internal static class CachingInterceptorKeyGenerator
+{
+    public static ulong GenerateCacheKey(MethodInfo method, object[] arguments)
+    {
+        switch (arguments.Length)
+        {
+            case 0:
+                return XxHash3Code.Combine(method.DeclaringType!.FullName, method.Name);
+
+            case 1:
+                return XxHash3Code.Combine(method.DeclaringType!.FullName, method.Name, arguments[0]);
+
+            case 2:
+                return XxHash3Code.Combine(method.DeclaringType!.FullName, method.Name, arguments[0], arguments[1]);
+
+            case 3:
+                return XxHash3Code.Combine(method.DeclaringType!.FullName, method.Name, arguments[0], arguments[1], arguments[2]);
+
+            default:
+                throw new NotImplementedException(
+                    "Support for generating cache keys for more than 3 arguments has not been implemented.");
+        }
+    }
+}

--- a/Application/EdFi.Ods.Common/Caching/CachingInterceptorKeyGenerator.cs
+++ b/Application/EdFi.Ods.Common/Caching/CachingInterceptorKeyGenerator.cs
@@ -12,23 +12,62 @@ internal static class CachingInterceptorKeyGenerator
 {
     public static ulong GenerateCacheKey(MethodInfo method, object[] arguments)
     {
-        switch (arguments.Length)
+        return arguments.Length switch
         {
-            case 0:
-                return XxHash3Code.Combine(method.DeclaringType!.FullName, method.Name);
+            0 => XxHash3Code.Combine(method.DeclaringType!.FullName, method.Name),
+            1 => XxHash3Code.Combine(method.DeclaringType!.FullName, method.Name, arguments[0]),
+            2 => XxHash3Code.Combine(
+                method.DeclaringType!.FullName,
+                method.Name,
+                arguments[0],
+                arguments[1]
+            ),
+            3 => XxHash3Code.Combine(
+                method.DeclaringType!.FullName,
+                method.Name,
+                arguments[0],
+                arguments[1],
+                arguments[2]
+            ),
+            _ => throw new NotImplementedException(
+                "Support for generating cache keys for more than 3 arguments has not been implemented."
+            ),
+        };
+    }
 
-            case 1:
-                return XxHash3Code.Combine(method.DeclaringType!.FullName, method.Name, arguments[0]);
-
-            case 2:
-                return XxHash3Code.Combine(method.DeclaringType!.FullName, method.Name, arguments[0], arguments[1]);
-
-            case 3:
-                return XxHash3Code.Combine(method.DeclaringType!.FullName, method.Name, arguments[0], arguments[1], arguments[2]);
-
-            default:
-                throw new NotImplementedException(
-                    "Support for generating cache keys for more than 3 arguments has not been implemented.");
-        }
+    public static ulong GenerateContextualCacheKey(
+        byte[] contextHashBytes,
+        MethodInfo method,
+        object[] arguments
+    )
+    {
+        return arguments.Length switch
+        {
+            0 => XxHash3Code.Combine(contextHashBytes, method.DeclaringType!.FullName, method.Name),
+            1 => XxHash3Code.Combine(
+                contextHashBytes,
+                method.DeclaringType!.FullName,
+                method.Name,
+                arguments[0]
+            ),
+            2 => XxHash3Code.Combine(
+                contextHashBytes,
+                method.DeclaringType!.FullName,
+                method.Name,
+                arguments[0],
+                arguments[1]
+            ),
+            3 => XxHash3Code.Combine(
+                contextHashBytes,
+                method.DeclaringType!.FullName,
+                method.Name,
+                arguments[0],
+                arguments[1],
+                arguments[2]
+            ),
+            _ => throw new NotImplementedException(
+                "Support for generating contextual cache keys with more than 3 arguments has not been implemented."
+            ),
+        };
     }
 }

--- a/Application/EdFi.Ods.Common/Caching/ContextualCachingInterceptor.cs
+++ b/Application/EdFi.Ods.Common/Caching/ContextualCachingInterceptor.cs
@@ -9,45 +9,27 @@ using EdFi.Ods.Common.Context;
 
 namespace EdFi.Ods.Common.Caching;
 
-public class ContextualCachingInterceptor<TContext> : CachingInterceptor
+public class ContextualCachingInterceptor<TContext>(
+    ICacheProvider<ulong> cacheProvider,
+    IContextProvider<TContext> contextProvider
+) : CachingInterceptor(cacheProvider)
     where TContext : IContextHashBytesSource
 {
-    private readonly IContextProvider<TContext> _contextProvider;
-
-    public ContextualCachingInterceptor(ICacheProvider<ulong> cacheProvider, IContextProvider<TContext> contextProvider)
-        : base(cacheProvider)
-    {
-        _contextProvider = contextProvider;
-    }
+    private readonly IContextProvider<TContext> _contextProvider = contextProvider;
 
     protected override ulong GenerateCacheKey(MethodInfo method, object[] arguments)
     {
-        var context = _contextProvider.Get();
-
         // Without context, we cannot generate a key here
-        if (context == null)
-        {
-            throw new InvalidOperationException(
-                $"No context has been set for value of type '{typeof(TContext).Name}'.");
-        }
-        
-        switch (arguments.Length)
-        {
-            case 0:
-                return XxHash3Code.Combine(context.HashBytes, method.DeclaringType!.FullName, method.Name);
+        var context =
+            _contextProvider.Get()
+            ?? throw new InvalidOperationException(
+                $"No context has been set for value of type '{typeof(TContext).Name}'."
+            );
 
-            case 1:
-                return XxHash3Code.Combine(context.HashBytes, method.DeclaringType!.FullName, method.Name, arguments[0]);
-
-            case 2:
-                return XxHash3Code.Combine(context.HashBytes, method.DeclaringType!.FullName, method.Name, arguments[0], arguments[1]);
-
-            case 3:
-                return XxHash3Code.Combine(context.HashBytes, method.DeclaringType!.FullName, method.Name, arguments[0], arguments[1], arguments[2]);
-            
-            default:
-                throw new NotImplementedException(
-                    "Support for generating contextual cache keys with more than 3 arguments has not been implemented.");
-        }
+        return CachingInterceptorKeyGenerator.GenerateContextualCacheKey(
+            context.HashBytes,
+            method,
+            arguments
+        );
     }
 }

--- a/Application/EdFi.Ods.Common/Caching/IAsyncCacheProvider.cs
+++ b/Application/EdFi.Ods.Common/Caching/IAsyncCacheProvider.cs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace EdFi.Ods.Common.Caching;
+
+/// <summary>
+/// Defines asynchronous cache operations.
+/// </summary>
+/// <typeparam name="TKey">The type of cache key.</typeparam>
+public interface IAsyncCacheProvider<in TKey>
+{
+    /// <summary>
+    /// Attempts to retrieve a cached object asynchronously.
+    /// </summary>
+    /// <param name="key">The cache key.</param>
+    /// <returns>A tuple indicating whether a value was found and the cached value.</returns>
+    Task<(bool found, object value)> TryGetCachedObjectAsync(TKey key);
+
+    /// <summary>
+    /// Stores an object in the cache asynchronously.
+    /// </summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="obj">The object to cache.</param>
+    Task SetCachedObjectAsync(TKey key, object obj);
+
+    /// <summary>
+    /// Inserts an object in the cache asynchronously using the supplied expiration settings.
+    /// </summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="value">The value to cache.</param>
+    /// <param name="absoluteExpiration">The absolute expiration.</param>
+    /// <param name="slidingExpiration">The sliding expiration.</param>
+    Task InsertAsync(TKey key, object value, DateTime absoluteExpiration, TimeSpan slidingExpiration);
+}

--- a/Application/EdFi.Ods.Common/Configuration/CacheSettings.cs
+++ b/Application/EdFi.Ods.Common/Configuration/CacheSettings.cs
@@ -29,6 +29,7 @@ namespace EdFi.Ods.Common.Configuration
         {
             public bool UseExternalCache { get; set; }
             public int AbsoluteExpirationSeconds { get; set; } = 1800;
+            public int L1CacheDurationSeconds { get; set; } = 10;
         }
 
         public class PersonUniqueIdToUsiCacheConfiguration
@@ -46,6 +47,7 @@ namespace EdFi.Ods.Common.Configuration
         {
             public bool UseExternalCache { get; set; }
             public int AbsoluteExpirationSeconds { get; set; } = (int)TimeSpan.FromMinutes(15).TotalSeconds;
+            public int L1CacheDurationSeconds { get; set; } = 30;
         }
 
         public class SecurityCacheConfiguration

--- a/Application/EdFi.Ods.Common/Configuration/CacheSettings.cs
+++ b/Application/EdFi.Ods.Common/Configuration/CacheSettings.cs
@@ -41,6 +41,8 @@ namespace EdFi.Ods.Common.Configuration
             public bool UseProgressiveLoading { get; set; } = false;
 
             public Dictionary<string, bool> CacheSuppression { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+            public int BatchSize { get; set; } = 5000;
         }
 
         public class ApiClientDetailsConfiguration

--- a/Application/EdFi.Ods.Common/Configuration/ServiceSettings.cs
+++ b/Application/EdFi.Ods.Common/Configuration/ServiceSettings.cs
@@ -10,7 +10,53 @@ public class ServiceSettings
     public RedisConfiguration Redis { get; set; } = new();
 }
 
+/// <summary>
+/// Provides settings for Redis-backed services.
+/// </summary>
 public class RedisConfiguration
 {
+    /// <summary>
+    /// Gets or sets the base Redis connection string.
+    /// </summary>
     public string Configuration { get; set; }
+
+    /// <summary>
+    /// Time (in milliseconds) to wait for a synchronous operation to complete. Default: 10000.
+    /// </summary>
+    public int SyncTimeoutMs { get; set; } = 10000;
+
+    /// <summary>
+    /// Time (in milliseconds) to wait for an asynchronous operation to complete. Default: 10000.
+    /// </summary>
+    public int AsyncTimeoutMs { get; set; } = 10000;
+
+    /// <summary>
+    /// Time (in milliseconds) to wait for a connection to be established. Default: 10000.
+    /// </summary>
+    public int ConnectTimeoutMs { get; set; } = 10000;
+
+    /// <summary>
+    /// Number of times to retry connecting on failure. Default: 5.
+    /// </summary>
+    public int ConnectRetry { get; set; } = 5;
+
+    /// <summary>
+    /// Whether to abort if the initial connection attempt fails. Default: false.
+    /// </summary>
+    public bool AbortOnConnectFail { get; set; }
+
+    /// <summary>
+    /// Interval (in seconds) at which to send keepalive pings. Default: 30.
+    /// </summary>
+    public int KeepAliveSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Whether to use SSL/TLS for the Redis connection. Default: false.
+    /// </summary>
+    public bool Ssl { get; set; }
+
+    /// <summary>
+    /// Optional password for Redis AUTH.
+    /// </summary>
+    public string Password { get; set; }
 }

--- a/Application/EdFi.Ods.Features/EdFi.Ods.Features.csproj
+++ b/Application/EdFi.Ods.Features/EdFi.Ods.Features.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.OpenApi.Readers" />
     <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" />
+    <PackageReference Include="Polly" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Resources\ChangeQueries.json" />

--- a/Application/EdFi.Ods.Features/ExternalCache/AsyncExternalCacheProvider.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/AsyncExternalCacheProvider.cs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace EdFi.Ods.Features.ExternalCache;
+
+/// <summary>
+/// Implements asynchronous distributed cache access for descriptor cache entries.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="AsyncExternalCacheProvider"/> class.
+/// </remarks>
+/// <param name="distributedCache">The distributed cache.</param>
+/// <param name="slidingExpiration">The sliding expiration to apply to set operations.</param>
+/// <param name="absoluteExpiration">The absolute expiration to apply to set operations.</param>
+public class AsyncExternalCacheProvider(
+    IDistributedCache distributedCache,
+    TimeSpan slidingExpiration,
+    TimeSpan absoluteExpiration) : AsyncExternalCacheProvider<ulong>(distributedCache, slidingExpiration, absoluteExpiration)
+{
+}

--- a/Application/EdFi.Ods.Features/ExternalCache/AsyncExternalCacheProvider{TKey}.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/AsyncExternalCacheProvider{TKey}.cs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using EdFi.Common.Security;
+using EdFi.Ods.Common.Caching;
+using EdFi.Ods.Common.Descriptors;
+using EdFi.Ods.Common.Exceptions;
+using log4net;
+using Microsoft.Extensions.Caching.Distributed;
+using Newtonsoft.Json;
+
+namespace EdFi.Ods.Features.ExternalCache;
+
+/// <summary>
+/// Implements asynchronous distributed cache access for external cache entries.
+/// </summary>
+/// <typeparam name="TKey">The type of cache key.</typeparam>
+/// <remarks>
+/// Initializes a new instance of the <see cref="AsyncExternalCacheProvider{TKey}"/> class.
+/// </remarks>
+/// <param name="distributedCache">The distributed cache.</param>
+/// <param name="slidingExpiration">The sliding expiration to apply to set operations.</param>
+/// <param name="absoluteExpiration">The absolute expiration to apply to set operations.</param>
+public class AsyncExternalCacheProvider<TKey>(
+    IDistributedCache distributedCache,
+    TimeSpan slidingExpiration,
+    TimeSpan absoluteExpiration) : IAsyncCacheProvider<TKey>
+{
+    private const string DefaultExceptionMessage = "Unable to access distributed cache.";
+
+    private readonly IDistributedCache _distributedCache = distributedCache;
+    private readonly TimeSpan _absoluteExpiration = absoluteExpiration;
+    private readonly TimeSpan _slidingExpiration = slidingExpiration;
+    private readonly ILog _logger = LogManager.GetLogger(typeof(AsyncExternalCacheProvider<TKey>));
+
+    /// <inheritdoc />
+    public async Task<(bool found, object value)> TryGetCachedObjectAsync(TKey key)
+    {
+        try
+        {
+            var keyAsString = GetKeyAsString(key);
+            var cachedValue = await _distributedCache.GetStringAsync(keyAsString).ConfigureAwait(false);
+
+            if (string.IsNullOrEmpty(cachedValue))
+            {
+                return (false, null);
+            }
+
+            object value = keyAsString.StartsWith(ApiClientDetailsCacheKeyProvider.CacheKeyPrefix, StringComparison.Ordinal)
+                ? JsonConvert.DeserializeObject<ApiClientDetails>(cachedValue)
+                : ExternalCacheSerializationHelper.Deserialize(cachedValue, _logger);
+
+            return (true, value);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex);
+            return (false, null);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task SetCachedObjectAsync(TKey key, object obj)
+    {
+        try
+        {
+            await _distributedCache.SetStringAsync(
+                    GetKeyAsString(key),
+                    ExternalCacheSerializationHelper.Serialize(obj),
+                    CreateDistributedCacheEntryOptions())
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex);
+            throw new DistributedCacheException(DefaultExceptionMessage, ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task InsertAsync(TKey key, object value, DateTime absoluteExpiration, TimeSpan slidingExpiration)
+    {
+        try
+        {
+            await _distributedCache.SetStringAsync(
+                    GetKeyAsString(key),
+                    ExternalCacheSerializationHelper.Serialize(value),
+                    new DistributedCacheEntryOptions
+                    {
+                        AbsoluteExpiration = absoluteExpiration < DateTime.MaxValue ? absoluteExpiration : null,
+                        SlidingExpiration = slidingExpiration > TimeSpan.Zero ? slidingExpiration : null
+                    })
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex);
+            throw new DistributedCacheException(DefaultExceptionMessage, ex);
+        }
+    }
+
+    private static string GetKeyAsString(TKey key)
+    {
+        return key is IFormattable formattable
+            ? formattable.ToString(null, CultureInfo.InvariantCulture)
+            : key.ToString();
+    }
+
+    private DistributedCacheEntryOptions CreateDistributedCacheEntryOptions()
+    {
+        return new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = _absoluteExpiration > TimeSpan.Zero ? _absoluteExpiration : null,
+            SlidingExpiration = _slidingExpiration > TimeSpan.Zero ? _slidingExpiration : null
+        };
+    }
+
+    private static class ExternalCacheSerializationHelper
+    {
+        private const string GuidPrefix = "(Guid)";
+        private const string IntPrefix = "(int)";
+
+        private static readonly JsonSerializerSettings DefaultSerializerSettings = new()
+        {
+            TypeNameHandling = TypeNameHandling.None,
+            ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+        };
+
+        public static string Serialize(object @object)
+        {
+            if (@object is Guid guid)
+            {
+                return $"{GuidPrefix}{guid.ToString("N", CultureInfo.InvariantCulture)}";
+            }
+
+            if (@object is int @int)
+            {
+                return $"{IntPrefix}{@int.ToString(CultureInfo.InvariantCulture)}";
+            }
+
+            return JsonConvert.SerializeObject(@object, DefaultSerializerSettings);
+        }
+
+        public static object Deserialize(string value, ILog logger)
+        {
+            if (value.StartsWith(GuidPrefix, StringComparison.InvariantCulture)
+                && Guid.TryParse(value[GuidPrefix.Length..], out var guid))
+            {
+                return guid;
+            }
+
+            if (value.StartsWith(IntPrefix, StringComparison.InvariantCulture)
+                && int.TryParse(value[IntPrefix.Length..], out var @int))
+            {
+                return @int;
+            }
+
+            try
+            {
+                return JsonConvert.DeserializeObject<DescriptorMaps>(value, DefaultSerializerSettings);
+            }
+            catch (JsonException e)
+            {
+                logger.Warn($"Exception during deserialization of the string \"{value}\". Message: \"{e.Message}\"");
+                return null;
+            }
+        }
+    }
+}

--- a/Application/EdFi.Ods.Features/ExternalCache/ExternalCacheModule.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/ExternalCacheModule.cs
@@ -17,170 +17,182 @@ using EdFi.Ods.Common.Container;
 using EdFi.Ods.Features.ExternalCache.Redis;
 using EdFi.Ods.Features.Services.Redis;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.FeatureManagement;
 
-namespace EdFi.Ods.Features.ExternalCache
+namespace EdFi.Ods.Features.ExternalCache;
+
+public abstract class ExternalCacheModule : ConditionalModule, IExternalCacheModule
 {
-    public abstract class ExternalCacheModule : ConditionalModule, IExternalCacheModule
+    private const string ApiClientDetailsCacheProviderName = "ApiClientDetailsTieredCacheProvider";
+
+    private readonly CacheSettings _cacheSettings;
+
+    protected ExternalCacheModule(IFeatureManager featureManager, ApiSettings apiSettings)
+        : base(featureManager)
     {
-        private readonly CacheSettings _cacheSettings;
+        _cacheSettings = apiSettings.Caching;
+    }
 
-        protected ExternalCacheModule(IFeatureManager featureManager, ApiSettings apiSettings)
-            : base(featureManager)
+    protected override bool IsSelected() => _cacheSettings.ApiClientDetails.UseExternalCache
+        || _cacheSettings.Descriptors.UseExternalCache
+        || _cacheSettings.PersonUniqueIdToUsi.UseExternalCache;
+
+    protected override void ApplyConfigurationSpecificRegistrations(ContainerBuilder builder)
+    {
+        RegisterDistributedCache(builder);
+
+        RegisterProvider(builder);
+
+        if (_cacheSettings.ApiClientDetails.UseExternalCache)
         {
-            _cacheSettings = apiSettings.Caching;
+            OverrideApiClientDetailsCache(builder);
         }
 
-        protected override bool IsSelected() => _cacheSettings.ApiClientDetails.UseExternalCache ||
-            _cacheSettings.Descriptors.UseExternalCache ||
-            _cacheSettings.PersonUniqueIdToUsi.UseExternalCache;
-
-        protected override void ApplyConfigurationSpecificRegistrations(ContainerBuilder builder)
+        if (_cacheSettings.Descriptors.UseExternalCache)
         {
-            RegisterDistributedCache(builder);
-
-            RegisterProvider(builder);
-
-            if (_cacheSettings.ApiClientDetails.UseExternalCache)
-            {
-                OverrideApiClientDetailsCache(builder);
-            }
-
-            if (_cacheSettings.Descriptors.UseExternalCache)
-            {
-                OverrideDescriptorsCache(builder);
-            }
-
-            if (_cacheSettings.PersonUniqueIdToUsi.UseExternalCache)
-            {
-                OverridePersonUniqueIdToUsiCache(builder);
-            }
+            OverrideDescriptorsCache(builder);
         }
 
-        public abstract string ExternalCacheProvider { get; }
-
-        public bool IsProviderSelected()
+        if (_cacheSettings.PersonUniqueIdToUsi.UseExternalCache)
         {
-            return ExternalCacheProvider.EqualsIgnoreCase(_cacheSettings.ExternalCacheProvider);
+            OverridePersonUniqueIdToUsiCache(builder);
         }
+    }
 
-        public void RegisterProvider(ContainerBuilder builder)
+    public abstract string ExternalCacheProvider { get; }
+
+    public bool IsProviderSelected()
+    {
+        return ExternalCacheProvider.EqualsIgnoreCase(_cacheSettings.ExternalCacheProvider);
+    }
+
+    public void RegisterProvider(ContainerBuilder builder)
+    {
+        builder.RegisterType<ExternalCacheProvider<string>>()
+            .WithParameter(
+                new ResolvedParameter(
+                    (p, _) => p.ParameterType == typeof(TimeSpan),
+                    (_, _) => GetDefaultExpiration()))
+            .As<IExternalCacheProvider<string>>()
+            .SingleInstance();
+    }
+
+    private static TimeSpan GetDefaultExpiration()
+    {
+        return TimeSpan.FromSeconds(1800);
+    }
+
+    public abstract void RegisterDistributedCache(ContainerBuilder builder);
+
+    public void OverrideApiClientDetailsCache(ContainerBuilder builder)
+    {
+        builder.RegisterType<ApiClientDetailsCacheKeyProvider>()
+            .As<IApiClientDetailsCacheKeyProvider>()
+            .SingleInstance();
+
+        builder.Register(
+                ctx =>
+                {
+                    int l1CacheDurationSeconds = _cacheSettings.ApiClientDetails.L1CacheDurationSeconds;
+
+                    return new TieredCacheProvider<string>(
+                        ctx.Resolve<IMemoryCache>(),
+                        ctx.Resolve<IExternalCacheProvider<string>>(),
+                        TimeSpan.FromSeconds(l1CacheDurationSeconds));
+                })
+            .Named<ICacheProvider<string>>(ApiClientDetailsCacheProviderName)
+            .SingleInstance();
+
+        builder.RegisterDecorator<IApiClientDetailsProvider>(
+            (context, parameters, instance) => GetCachingApiClientDetailsProviderDecorator(context, instance));
+    }
+
+    private static CachingApiClientDetailsProviderDecorator GetCachingApiClientDetailsProviderDecorator(
+        IComponentContext componentContext,
+        IApiClientDetailsProvider apiClientDetailsProvider)
+    {
+        return new CachingApiClientDetailsProviderDecorator(
+            apiClientDetailsProvider,
+            componentContext.ResolveNamed<ICacheProvider<string>>(ApiClientDetailsCacheProviderName),
+            componentContext.Resolve<IApiClientDetailsCacheKeyProvider>());
+    }
+
+    public void OverrideDescriptorsCache(ContainerBuilder builder)
+    {
+        builder.Register(
+                ctx =>
+                {
+                    int absoluteExpirationSeconds = _cacheSettings.Descriptors.AbsoluteExpirationSeconds;
+                    int l1CacheDurationSeconds = _cacheSettings.Descriptors.L1CacheDurationSeconds;
+                    var distributedCache = ctx.Resolve<IDistributedCache>();
+                    var absoluteExpiration = TimeSpan.FromSeconds(absoluteExpirationSeconds);
+
+                    return new TieredCacheProvider<ulong>(
+                        ctx.Resolve<IMemoryCache>(),
+                        new ExternalCacheProvider<ulong>(distributedCache, TimeSpan.Zero, absoluteExpiration),
+                        TimeSpan.FromSeconds(l1CacheDurationSeconds),
+                        new AsyncExternalCacheProvider<ulong>(distributedCache, TimeSpan.Zero, absoluteExpiration));
+                })
+            .As<ICacheProvider<ulong>>()
+            .As<IAsyncCacheProvider<ulong>>()
+            .SingleInstance();
+
+        builder.RegisterType<AsyncContextualCachingInterceptor<OdsInstanceConfiguration>>()
+            .Named<IInterceptor>(InterceptorCacheKeys.Descriptors)
+            .SingleInstance();
+    }
+
+    public void OverridePersonUniqueIdToUsiCache(ContainerBuilder builder)
+    {
+        if (IsProviderSelected())
         {
-            builder.RegisterType<ExternalCacheProvider<string>>()
+            builder.Register(
+                    c => new RedisConnectionProvider(c.Resolve<ApiSettings>().Services.Redis))
+                .As<IRedisConnectionProvider>()
+                .IfNotRegistered(typeof(IRedisConnectionProvider))
+                .SingleInstance();
+
+            builder.RegisterType<RedisDistributedLockProvider>()
                 .WithParameter(
                     new ResolvedParameter(
-                        (p, _) => p.ParameterType == typeof(TimeSpan),
-                        (_, _) => GetDefaultExpiration()))
-                .As<IExternalCacheProvider<string>>()
-                .SingleInstance();
-        }
-
-        private static TimeSpan GetDefaultExpiration()
-        {
-            return TimeSpan.FromSeconds(1800);
-        }
-
-        public abstract void RegisterDistributedCache(ContainerBuilder builder);
-
-        public void OverrideApiClientDetailsCache(ContainerBuilder builder)
-        {
-            builder.RegisterType<ApiClientDetailsCacheKeyProvider>()
-                .As<IApiClientDetailsCacheKeyProvider>()
+                        (p, c) => p.ParameterType == typeof(RedisCacheResilience),
+                        (_, c) => c.Resolve<RedisCacheResilience>()))
+                .As<IDistributedLockProvider>()
                 .SingleInstance();
 
-            builder.RegisterDecorator<IApiClientDetailsProvider>(
-                (context, parameters, instance) => GetCachingApiClientDetailsProviderDecorator(context, instance));
-        }
-
-        private static CachingApiClientDetailsProviderDecorator GetCachingApiClientDetailsProviderDecorator(
-            IComponentContext componentContext,
-            IApiClientDetailsProvider apiClientDetailsProvider)
-        {
-            return new CachingApiClientDetailsProviderDecorator(
-                apiClientDetailsProvider,
-                componentContext.Resolve<IExternalCacheProvider<string>>(),
-                componentContext.Resolve<IApiClientDetailsCacheKeyProvider>());
-        }
-
-        public void OverrideDescriptorsCache(ContainerBuilder builder)
-        {
-            // Override the named interceptor registration to use the external (distributed) cache
-            builder.RegisterType<ContextualCachingInterceptor<OdsInstanceConfiguration>>()
-                .Named<IInterceptor>(InterceptorCacheKeys.Descriptors)
+            builder.RegisterType<RedisUsiByUniqueIdMapCache>()
                 .WithParameter(
-                    ctx =>
-                    {
-                        int absoluteExpirationSeconds = _cacheSettings.Descriptors.AbsoluteExpirationSeconds;
+                    new ResolvedParameter(
+                        (p, c) => p.ParameterType == typeof(RedisCacheResilience),
+                        (_, c) => c.Resolve<RedisCacheResilience>()))
+                .WithParameter(CreateExpirationParameter("slidingExpirationPeriod", c => c.Caching.PersonUniqueIdToUsi.SlidingExpirationSeconds))
+                .WithParameter(CreateExpirationParameter("absoluteExpirationPeriod", c => c.Caching.PersonUniqueIdToUsi.AbsoluteExpirationSeconds))
+                .As<IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), string, int>>()
+                .SingleInstance();
 
-                        return (ICacheProvider<ulong>)new ExternalCacheProvider<ulong>(
-                            ctx.Resolve<IDistributedCache>(),
-                            TimeSpan.Zero,
-                            TimeSpan.FromSeconds(absoluteExpirationSeconds));
-                    })
+            builder.RegisterType<RedisUniqueIdByUsiMapCache>()
+                .WithParameter(
+                    new ResolvedParameter(
+                        (p, c) => p.ParameterType == typeof(RedisCacheResilience),
+                        (_, c) => c.Resolve<RedisCacheResilience>()))
+                .WithParameter(CreateExpirationParameter("slidingExpirationPeriod", c => c.Caching.PersonUniqueIdToUsi.SlidingExpirationSeconds))
+                .WithParameter(CreateExpirationParameter("absoluteExpirationPeriod", c => c.Caching.PersonUniqueIdToUsi.AbsoluteExpirationSeconds))
+                .As<IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), int, string>>()
                 .SingleInstance();
         }
+    }
 
-        public void OverridePersonUniqueIdToUsiCache(ContainerBuilder builder)
-        {
-            if (IsProviderSelected())
+    private static ResolvedParameter CreateExpirationParameter(
+        string parameterName,
+        Func<ApiSettings, int> getSeconds)
+    {
+        return new ResolvedParameter(
+            (p, _) => p.Name.EqualsIgnoreCase(parameterName),
+            (_, c) =>
             {
-                builder.RegisterType<RedisConnectionProvider>()
-                    .WithParameter(
-                        new ResolvedParameter(
-                            (p, c) => p.Name == "configuration",
-                            (p, c) =>
-                            {
-                                var apiSettings = c.Resolve<ApiSettings>();
-
-                                return apiSettings.Services.Redis.Configuration;
-                            }))
-                    .As<IRedisConnectionProvider>()
-                    .SingleInstance();
-
-                builder.RegisterType<RedisUsiByUniqueIdMapCache>()
-                    .WithParameter(
-                        new ResolvedParameter(
-                            (p, c) => p.Name.EqualsIgnoreCase("slidingExpirationPeriod"),
-                            (p, c) =>
-                            {
-                                var apiSettings = c.Resolve<ApiSettings>();
-                                int seconds = apiSettings.Caching.PersonUniqueIdToUsi.SlidingExpirationSeconds;
-                                return seconds > 0 ? TimeSpan.FromSeconds(seconds) : null;
-                            }))
-                    .WithParameter(
-                        new ResolvedParameter(
-                            (p, c) => p.Name.EqualsIgnoreCase("absoluteExpirationPeriod"),
-                            (p, c) =>
-                            {
-                                var apiSettings = c.Resolve<ApiSettings>();
-                                int seconds = apiSettings.Caching.PersonUniqueIdToUsi.AbsoluteExpirationSeconds;
-                                return seconds > 0 ? TimeSpan.FromSeconds(seconds) : null;
-                            }))
-                    .As<IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), string, int>>()
-                    .SingleInstance();
-
-                builder.RegisterType<RedisUniqueIdByUsiMapCache>()
-                    .WithParameter(
-                        new ResolvedParameter(
-                            (p, c) => p.Name.EqualsIgnoreCase("slidingExpirationPeriod"),
-                            (p, c) =>
-                            {
-                                var apiSettings = c.Resolve<ApiSettings>();
-                                int seconds = apiSettings.Caching.PersonUniqueIdToUsi.SlidingExpirationSeconds;
-                                return seconds > 0 ? TimeSpan.FromSeconds(seconds) : null;
-                            }))
-                    .WithParameter(
-                        new ResolvedParameter(
-                            (p, c) => p.Name.EqualsIgnoreCase("absoluteExpirationPeriod"),
-                            (p, c) =>
-                            {
-                                var apiSettings = c.Resolve<ApiSettings>();
-                                int seconds = apiSettings.Caching.PersonUniqueIdToUsi.AbsoluteExpirationSeconds;
-                                return seconds > 0 ? TimeSpan.FromSeconds(seconds) : null;
-                            }))
-                    .As<IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), int, string>>()
-                    .SingleInstance();
-            }
-        }
+                int seconds = getSeconds(c.Resolve<ApiSettings>());
+                return seconds > 0 ? TimeSpan.FromSeconds(seconds) : null;
+            });
     }
 }

--- a/Application/EdFi.Ods.Features/ExternalCache/ExternalCacheModule.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/ExternalCacheModule.cs
@@ -170,6 +170,9 @@ public abstract class ExternalCacheModule : ConditionalModule, IExternalCacheMod
                         (_, c) => c.Resolve<RedisCacheResilience>()))
                 .WithParameter(CreateExpirationParameter("slidingExpirationPeriod", c => c.Caching.PersonUniqueIdToUsi.SlidingExpirationSeconds))
                 .WithParameter(CreateExpirationParameter("absoluteExpirationPeriod", c => c.Caching.PersonUniqueIdToUsi.AbsoluteExpirationSeconds))
+                .WithParameter(new ResolvedParameter(
+                    (p, _) => p.Name.EqualsIgnoreCase("batchSize"),
+                    (_, c) => c.Resolve<ApiSettings>().Caching.PersonUniqueIdToUsi.BatchSize))
                 .As<IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), string, int>>()
                 .SingleInstance();
 
@@ -180,6 +183,9 @@ public abstract class ExternalCacheModule : ConditionalModule, IExternalCacheMod
                         (_, c) => c.Resolve<RedisCacheResilience>()))
                 .WithParameter(CreateExpirationParameter("slidingExpirationPeriod", c => c.Caching.PersonUniqueIdToUsi.SlidingExpirationSeconds))
                 .WithParameter(CreateExpirationParameter("absoluteExpirationPeriod", c => c.Caching.PersonUniqueIdToUsi.AbsoluteExpirationSeconds))
+                .WithParameter(new ResolvedParameter(
+                    (p, _) => p.Name.EqualsIgnoreCase("batchSize"),
+                    (_, c) => c.Resolve<ApiSettings>().Caching.PersonUniqueIdToUsi.BatchSize))
                 .As<IMapCache<(ulong odsInstanceHashId, string personType, PersonMapType mapType), int, string>>()
                 .SingleInstance();
         }

--- a/Application/EdFi.Ods.Features/ExternalCache/ExternalCacheModule.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/ExternalCacheModule.cs
@@ -85,7 +85,7 @@ public abstract class ExternalCacheModule : ConditionalModule, IExternalCacheMod
 
     public abstract void RegisterDistributedCache(ContainerBuilder builder);
 
-    public void OverrideApiClientDetailsCache(ContainerBuilder builder)
+    private void OverrideApiClientDetailsCache(ContainerBuilder builder)
     {
         builder.RegisterType<ApiClientDetailsCacheKeyProvider>()
             .As<IApiClientDetailsCacheKeyProvider>()
@@ -118,7 +118,7 @@ public abstract class ExternalCacheModule : ConditionalModule, IExternalCacheMod
             componentContext.Resolve<IApiClientDetailsCacheKeyProvider>());
     }
 
-    public void OverrideDescriptorsCache(ContainerBuilder builder)
+    private void OverrideDescriptorsCache(ContainerBuilder builder)
     {
         builder.Register(
                 ctx =>
@@ -143,7 +143,9 @@ public abstract class ExternalCacheModule : ConditionalModule, IExternalCacheMod
             .SingleInstance();
     }
 
-    public void OverridePersonUniqueIdToUsiCache(ContainerBuilder builder)
+    // TODO: does the person unique ID cache need to have the TieredCacheProvider for L1/L2 fallback?
+
+    private void OverridePersonUniqueIdToUsiCache(ContainerBuilder builder)
     {
         if (IsProviderSelected())
         {

--- a/Application/EdFi.Ods.Features/ExternalCache/IExternalCacheModule.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/IExternalCacheModule.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -13,8 +13,5 @@ namespace EdFi.Ods.Features.ExternalCache
         void RegisterDistributedCache(ContainerBuilder builder);
         string ExternalCacheProvider { get; }
         bool IsProviderSelected();
-        void OverrideApiClientDetailsCache(ContainerBuilder builder);
-        void OverrideDescriptorsCache(ContainerBuilder builder);
-        void OverridePersonUniqueIdToUsiCache(ContainerBuilder builder);
     }
 }

--- a/Application/EdFi.Ods.Features/ExternalCache/Redis/OverrideRedisExternalCacheModule.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/Redis/OverrideRedisExternalCacheModule.cs
@@ -6,50 +6,54 @@
 using Autofac;
 using EdFi.Ods.Common.Configuration;
 using EdFi.Ods.Features.ExternalCache;
+using EdFi.Ods.Features.ExternalCache.Redis;
 using EdFi.Ods.Features.Services.Redis;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.FeatureManagement;
 
-namespace EdFi.Ods.Features.Redis
+namespace EdFi.Ods.Features.Redis;
+
+public class OverrideRedisExternalCacheModule : ExternalCacheModule
 {
-    public class OverrideRedisExternalCacheModule : ExternalCacheModule
+    private readonly ServiceSettings _servicesSettings;
+
+    public override string ExternalCacheProvider => ExternalCacheProviderOption.Redis.ToString();
+
+    public OverrideRedisExternalCacheModule(IFeatureManager featureManager, ApiSettings apiSettings)
+        : base(featureManager, apiSettings)
     {
-        private readonly ServiceSettings _servicesSettings;
+        _servicesSettings = apiSettings.Services;
+    }
 
-        public override string ExternalCacheProvider => ExternalCacheProviderOption.Redis.ToString();
-
-        public OverrideRedisExternalCacheModule(IFeatureManager featureManager, ApiSettings apiSettings)
-            : base(featureManager, apiSettings)
+    public override void RegisterDistributedCache(ContainerBuilder builder)
+    {
+        if (!IsProviderSelected())
         {
-            _servicesSettings = apiSettings.Services;
+            return;
         }
 
-        public override void RegisterDistributedCache(ContainerBuilder builder)
-        {
-            if (!IsProviderSelected())
-            {
-                return;
-            }
+        var redisConfiguration = _servicesSettings.Redis;
+        var configurationOptions = RedisConnectionProvider.CreateConfigurationOptions(redisConfiguration);
 
-            // Ensure the Redis connection provider is registered (it may be registered by other conditional modules as well)
-            builder.RegisterType<RedisConnectionProvider>()
-                .As<IRedisConnectionProvider>()
-                .WithParameter(new NamedParameter("configuration", _servicesSettings.Redis.Configuration))
-                .IfNotRegistered(typeof(IRedisConnectionProvider))
-                .SingleInstance();
+        builder.RegisterType<RedisCacheResilience>()
+            .AsSelf()
+            .IfNotRegistered(typeof(RedisCacheResilience))
+            .SingleInstance();
 
-            var configurationOptions = StackExchange.Redis.ConfigurationOptions.Parse(
-                _servicesSettings.Redis.Configuration);
-            
-            builder.Register<IDistributedCache>(
-                    (c, d) =>
-                    {
-                        var redisCacheOptions = new RedisCacheOptions() { ConfigurationOptions = configurationOptions };
-            
-                        return new RedisCache(redisCacheOptions);
-                    })
-                .SingleInstance();
-        }
+        // Ensure the Redis connection provider is registered (it may be registered by other conditional modules as well)
+        builder.Register(_ => new RedisConnectionProvider(redisConfiguration))
+            .As<IRedisConnectionProvider>()
+            .IfNotRegistered(typeof(IRedisConnectionProvider))
+            .SingleInstance();
+
+        builder.Register<IDistributedCache>(
+                (_, _) =>
+                {
+                    var redisCacheOptions = new RedisCacheOptions { ConfigurationOptions = configurationOptions };
+
+                    return new RedisCache(redisCacheOptions);
+                })
+            .SingleInstance();
     }
 }

--- a/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisCacheResilience.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisCacheResilience.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using log4net;
+using Polly;
+using Polly.CircuitBreaker;
+
+namespace EdFi.Ods.Features.ExternalCache.Redis;
+
+/// <summary>
+/// Provides resilience policies for Redis cache operations.
+/// </summary>
+public class RedisCacheResilience
+{
+    private readonly ILog _logger = LogManager.GetLogger(typeof(RedisCacheResilience));
+
+    /// <summary>
+    /// Gets the circuit breaker pipeline for Redis operations.
+    /// </summary>
+    public ResiliencePipeline Pipeline { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RedisCacheResilience"/> class.
+    /// </summary>
+    /// <param name="failureThreshold">The minimum throughput required before the circuit breaker evaluates failures.</param>
+    /// <param name="breakDurationSeconds">The number of seconds to keep the circuit open.</param>
+    public RedisCacheResilience(int failureThreshold = 5, int breakDurationSeconds = 30)
+    {
+        Pipeline = new ResiliencePipelineBuilder()
+            .AddCircuitBreaker(new CircuitBreakerStrategyOptions
+            {
+                FailureRatio = 0.5,
+                SamplingDuration = TimeSpan.FromSeconds(10),
+                MinimumThroughput = failureThreshold,
+                BreakDuration = TimeSpan.FromSeconds(breakDurationSeconds),
+                OnOpened = args =>
+                {
+                    _logger.Error($"Redis circuit breaker OPENED for {breakDurationSeconds}s after repeated failures.");
+                    return ValueTask.CompletedTask;
+                },
+                OnClosed = args =>
+                {
+                    _logger.Info("Redis circuit breaker CLOSED — Redis operations resuming normally.");
+                    return ValueTask.CompletedTask;
+                },
+                OnHalfOpened = args =>
+                {
+                    _logger.Info("Redis circuit breaker HALF-OPEN — testing Redis connectivity.");
+                    return ValueTask.CompletedTask;
+                }
+            })
+            .Build();
+    }
+}

--- a/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisDistributedLockProvider.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisDistributedLockProvider.cs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EdFi.Ods.Api.Caching.Person;
+using EdFi.Ods.Features.Services.Redis;
+using log4net;
+using Polly.CircuitBreaker;
+using StackExchange.Redis;
+
+namespace EdFi.Ods.Features.ExternalCache.Redis;
+
+/// <summary>
+/// Provides a Redis-backed distributed lock implementation for cache initialization.
+/// </summary>
+public class RedisDistributedLockProvider : IDistributedLockProvider
+{
+    private readonly IRedisConnectionProvider _redisConnectionProvider;
+    private readonly RedisCacheResilience _resilience;
+    private readonly ILog _logger = LogManager.GetLogger(typeof(RedisDistributedLockProvider));
+    private readonly Dictionary<string, string> _lockTokens = new();
+    private byte[] _lockReleaseScriptSha;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RedisDistributedLockProvider"/> class.
+    /// </summary>
+    /// <param name="redisConnectionProvider">The Redis connection provider.</param>
+    /// <param name="resilience">The resilience pipeline for Redis operations.</param>
+    public RedisDistributedLockProvider(
+        IRedisConnectionProvider redisConnectionProvider,
+        RedisCacheResilience resilience)
+
+    {
+        _redisConnectionProvider =
+            redisConnectionProvider
+            ?? throw new ArgumentNullException(nameof(redisConnectionProvider));
+        _resilience = resilience ?? throw new ArgumentNullException(nameof(resilience));
+        LoadScripts();
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryAcquireLockAsync(string lockKey, TimeSpan expiration)
+    {
+        ArgumentNullException.ThrowIfNull(lockKey);
+
+        string token = Guid.NewGuid().ToString();
+
+        try
+        {
+            bool acquired = false;
+
+            await _resilience.Pipeline.ExecuteAsync(
+                async _ =>
+                {
+                    IDatabase database = _redisConnectionProvider.Get();
+                    acquired = await database.StringSetAsync(
+                        lockKey,
+                        token,
+                        expiration,
+                        when: When.NotExists
+                    );
+                },
+                CancellationToken.None)
+                .ConfigureAwait(false);
+
+            if (acquired)
+            {
+                _lockTokens[lockKey] = token;
+            }
+
+            return acquired;
+        }
+        catch (BrokenCircuitException ex)
+        {
+            _logger.Warn(
+                $"Redis circuit breaker open; unable to acquire lock '{lockKey}'. Proceeding without lock.",
+                ex);
+            return false;
+        }
+        catch (Exception ex) when (IsRedisUnavailable(ex))
+        {
+            _logger.Warn(
+                $"Redis unavailable; unable to acquire lock '{lockKey}'. Proceeding without lock.",
+                ex);
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ReleaseLockAsync(string lockKey)
+    {
+        ArgumentNullException.ThrowIfNull(lockKey);
+
+        if (!_lockTokens.TryGetValue(lockKey, out var token))
+        {
+            return;
+        }
+
+        _lockTokens.Remove(lockKey);
+
+        try
+        {
+            await _resilience.Pipeline.ExecuteAsync(
+                async _ =>
+                    {
+                        IDatabase database = _redisConnectionProvider.Get();
+                        await database.ScriptEvaluateAsync(
+                            _lockReleaseScriptSha,
+                            new[] { (RedisKey)lockKey },
+                            new[] { (RedisValue)token }
+                        );
+                },
+                CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (BrokenCircuitException ex)
+        {
+            _logger.Warn(
+                $"Redis circuit breaker open; unable to release lock '{lockKey}'.",
+                ex);
+        }
+        catch (Exception ex) when (IsRedisUnavailable(ex))
+        {
+            _logger.Warn(
+                $"Redis unavailable; unable to release lock '{lockKey}'.",
+                ex);
+        }
+    }
+
+    private void LoadScripts()
+    {
+        // Lua script for safe distributed lock release.
+        // This script ensures only the lock owner can delete the lock by verifying the token matches.
+        // Prevents other nodes from accidentally deleting locks they don't own if a lock expires
+        // and gets reacquired by another node.
+        const string luaReleaseScript =
+            @"
+            -- Check if the current lock value (KEYS[1]) matches our token (ARGV[1])
+            if redis.call('GET', KEYS[1]) == ARGV[1] then
+                -- Token matches: this node owns the lock, so delete it
+                return redis.call('DEL', KEYS[1])
+            else
+                -- Token doesn't match: another node owns this lock, so don't delete
+                return 0
+            end
+        ";
+
+        try
+        {
+            var server = _redisConnectionProvider
+                .Get()
+                .Multiplexer.GetServer(
+                    _redisConnectionProvider.Get().Multiplexer.GetEndPoints().FirstOrDefault()
+                );
+            _lockReleaseScriptSha = server.ScriptLoad(luaReleaseScript);
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn(
+                "Failed to load Lua script for distributed lock release during initialization. Redis may be unavailable; lock release will be retried at runtime.",
+                ex);
+            _lockReleaseScriptSha = null;
+        }
+    }
+
+    private static bool IsRedisUnavailable(Exception ex)
+    {
+        if (ex is TimeoutException || ex is OperationCanceledException)
+        {
+            return true;
+        }
+
+        if (ex is RedisConnectionException || ex is RedisTimeoutException)
+        {
+            return true;
+        }
+
+        var message = ex.Message.ToLowerInvariant();
+        if (message.Contains("timeout")
+            || message.Contains("connection")
+            || message.Contains("unavailable"))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisMapCache.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisMapCache.cs
@@ -28,17 +28,23 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
     private readonly IRedisConnectionProvider _redisConnectionProvider;
     private readonly RedisCacheResilience _resilience;
     private readonly ILog _logger = LogManager.GetLogger(typeof(RedisMapCache<,,>).Name);
+    private readonly int _batchSize;
 
     protected RedisMapCache(
         IRedisConnectionProvider redisConnectionProvider,
         RedisCacheResilience resilience,
         TimeSpan? absoluteExpirationPeriod,
-        TimeSpan? slidingExpirationPeriod)
+        TimeSpan? slidingExpirationPeriod,
+        int batchSize
+    )
     {
-        _redisConnectionProvider = redisConnectionProvider ?? throw new ArgumentNullException(nameof(redisConnectionProvider));
+        _redisConnectionProvider =
+            redisConnectionProvider
+            ?? throw new ArgumentNullException(nameof(redisConnectionProvider));
         _resilience = resilience ?? throw new ArgumentNullException(nameof(resilience));
         _absoluteExpirationPeriod = absoluteExpirationPeriod;
         _slidingExpirationPeriod = slidingExpirationPeriod;
+        _batchSize = batchSize;
     }
 
     /// <summary>
@@ -48,8 +54,6 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
     /// <param name="mapEntries">The map entries to store.</param>
     public async Task SetMapEntriesAsync(TKey key, (TMapKey key, TMapValue value)[] mapEntries)
     {
-        const int BatchSize = 5000;
-
         ValidateKey(key);
 
         if (mapEntries is null || mapEntries.Length == 0)
@@ -63,38 +67,44 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
         {
             hashEntries[i] = new HashEntry(
                 ConvertMapKeyToRedisValue(mapEntries[i].key),
-                ConvertMapValueToRedisValue(mapEntries[i].value));
+                ConvertMapValueToRedisValue(mapEntries[i].value)
+            );
         }
 
         string cacheKey = GetCacheKey(key);
 
         try
         {
-            await _resilience.Pipeline.ExecuteAsync(
+            await _resilience
+                .Pipeline.ExecuteAsync(
                     async _ =>
                     {
                         var cache = _redisConnectionProvider.Get();
 
-                        for (int i = 0; i < hashEntries.Length; i += BatchSize)
+                        for (int i = 0; i < hashEntries.Length; i += _batchSize)
                         {
                             int remaining = hashEntries.Length - i;
-                            int currentBatchSize = Math.Min(BatchSize, remaining);
+                            int currentBatchSize = Math.Min(_batchSize, remaining);
                             var batchEntries = new HashEntry[currentBatchSize];
                             Array.Copy(hashEntries, i, batchEntries, 0, currentBatchSize);
                             bool isLastBatch = i + currentBatchSize >= hashEntries.Length;
                             var batch = cache.CreateBatch();
                             var setTask = batch.HashSetAsync(cacheKey, batchEntries);
-                            Task<bool> expireTask = isLastBatch ? ApplyInitialExpirationBatched(batch, cacheKey) : null;
+                            Task<bool> expireTask = isLastBatch
+                                ? ApplyInitialExpirationBatched(batch, cacheKey)
+                                : null;
                             batch.Execute();
                             await setTask.ConfigureAwait(false);
 
                             if (expireTask is not null)
                             {
-                                await LogExpirationFailureAsync(expireTask, cacheKey).ConfigureAwait(false);
+                                await LogExpirationFailureAsync(expireTask, cacheKey)
+                                    .ConfigureAwait(false);
                             }
                         }
                     },
-                    CancellationToken.None)
+                    CancellationToken.None
+                )
                 .ConfigureAwait(false);
         }
         catch (BrokenCircuitException ex)
@@ -103,7 +113,10 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
         }
         catch (Exception ex) when (IsRedisUnavailable(ex))
         {
-            _logger.Warn($"Redis cache set failed for key '{cacheKey}'. Falling back to uncached behavior.", ex);
+            _logger.Warn(
+                $"Redis cache set failed for key '{cacheKey}'. Falling back to uncached behavior.",
+                ex
+            );
         }
     }
 
@@ -135,7 +148,8 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
         {
             TMapValue[] mapValues = null;
 
-            await _resilience.Pipeline.ExecuteAsync(
+            await _resilience
+                .Pipeline.ExecuteAsync(
                     async _ =>
                     {
                         var cache = _redisConnectionProvider.Get();
@@ -145,7 +159,10 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
 
                         if (_slidingExpirationPeriod is { TotalMilliseconds: > 0 })
                         {
-                            expireTask = batch.KeyExpireAsync(cacheKey, _slidingExpirationPeriod.Value);
+                            expireTask = batch.KeyExpireAsync(
+                                cacheKey,
+                                _slidingExpirationPeriod.Value
+                            );
                         }
 
                         batch.Execute();
@@ -154,7 +171,8 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
 
                         if (expireTask is not null)
                         {
-                            await LogExpirationFailureAsync(expireTask, cacheKey).ConfigureAwait(false);
+                            await LogExpirationFailureAsync(expireTask, cacheKey)
+                                .ConfigureAwait(false);
                         }
 
                         mapValues = new TMapValue[hashValues.Length];
@@ -164,7 +182,8 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
                             mapValues[i] = ConvertRedisValue(hashValues[i]);
                         }
                     },
-                    CancellationToken.None)
+                    CancellationToken.None
+                )
                 .ConfigureAwait(false);
 
             return mapValues ?? new TMapValue[mapKeys.Length];
@@ -176,7 +195,10 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
         }
         catch (Exception ex) when (IsRedisUnavailable(ex))
         {
-            _logger.Warn($"Redis cache get failed for key '{cacheKey}'. Falling back to uncached behavior.", ex);
+            _logger.Warn(
+                $"Redis cache get failed for key '{cacheKey}'. Falling back to uncached behavior.",
+                ex
+            );
             return new TMapValue[mapKeys.Length];
         }
     }
@@ -200,7 +222,8 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
         {
             bool deleteResult = false;
 
-            await _resilience.Pipeline.ExecuteAsync(
+            await _resilience
+                .Pipeline.ExecuteAsync(
                     async _ =>
                     {
                         var cache = _redisConnectionProvider.Get();
@@ -210,7 +233,10 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
 
                         if (_slidingExpirationPeriod is { TotalMilliseconds: > 0 })
                         {
-                            expireTask = batch.KeyExpireAsync(cacheKey, _slidingExpirationPeriod.Value);
+                            expireTask = batch.KeyExpireAsync(
+                                cacheKey,
+                                _slidingExpirationPeriod.Value
+                            );
                         }
 
                         batch.Execute();
@@ -219,10 +245,12 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
 
                         if (expireTask is not null)
                         {
-                            await LogExpirationFailureAsync(expireTask, cacheKey).ConfigureAwait(false);
+                            await LogExpirationFailureAsync(expireTask, cacheKey)
+                                .ConfigureAwait(false);
                         }
                     },
-                    CancellationToken.None)
+                    CancellationToken.None
+                )
                 .ConfigureAwait(false);
 
             return deleteResult;
@@ -234,7 +262,10 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
         }
         catch (Exception ex) when (IsRedisUnavailable(ex))
         {
-            _logger.Warn($"Redis cache delete failed for key '{cacheKey}'. Falling back to uncached behavior.", ex);
+            _logger.Warn(
+                $"Redis cache delete failed for key '{cacheKey}'. Falling back to uncached behavior.",
+                ex
+            );
             return false;
         }
     }
@@ -248,7 +279,11 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
 
         if (_absoluteExpirationPeriod is { TotalMilliseconds: > 0 })
         {
-            return batch.KeyExpireAsync(cacheKey, _absoluteExpirationPeriod.Value, ExpireWhen.HasNoExpiry);
+            return batch.KeyExpireAsync(
+                cacheKey,
+                _absoluteExpirationPeriod.Value,
+                ExpireWhen.HasNoExpiry
+            );
         }
 
         return null;
@@ -262,7 +297,7 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
 
             if (!result && _logger.IsDebugEnabled)
             {
-                _logger.Debug($"PEXPIRE returned false for key '{cacheKey}' — key may not exist.");
+                _logger.Debug($"PEXPIRE returned false for key '{cacheKey}' â€” key may not exist.");
             }
         }
         catch (Exception ex)
@@ -275,7 +310,10 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
     {
         if (_logger.IsDebugEnabled)
         {
-            _logger.Debug($"Skipping Redis cache operation '{operationName}' for key '{cacheKey}' because the circuit is open.", ex);
+            _logger.Debug(
+                $"Skipping Redis cache operation '{operationName}' for key '{cacheKey}' because the circuit is open.",
+                ex
+            );
         }
     }
 
@@ -299,14 +337,16 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
 
     protected virtual TMapValue ConvertRedisValue(RedisValue hashValue)
     {
-        return (TMapValue) Convert.ChangeType(hashValue, typeof(TMapValue));
+        return (TMapValue)Convert.ChangeType(hashValue, typeof(TMapValue));
     }
 
     protected virtual RedisValue ConvertMapKeyToRedisValue(TMapKey mapKey)
     {
         if (!TryParse(mapKey, out RedisValue value))
         {
-            throw new ArgumentException($"Unable to convert map key of type '{typeof(TMapKey).Name}' to a '{nameof(RedisValue)}'.");
+            throw new ArgumentException(
+                $"Unable to convert map key of type '{typeof(TMapKey).Name}' to a '{nameof(RedisValue)}'."
+            );
         }
 
         return value;
@@ -316,7 +356,9 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
     {
         if (!TryParse(mapValue, out RedisValue value))
         {
-            throw new ArgumentException($"Unable to convert map value of type '{typeof(TMapValue).Name}' to a '{nameof(RedisValue)}'.");
+            throw new ArgumentException(
+                $"Unable to convert map value of type '{typeof(TMapValue).Name}' to a '{nameof(RedisValue)}'."
+            );
         }
 
         return value;

--- a/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisMapCache.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisMapCache.cs
@@ -4,10 +4,12 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
-using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using EdFi.Ods.Api.Caching;
 using EdFi.Ods.Features.Services.Redis;
+using log4net;
+using Polly.CircuitBreaker;
 using StackExchange.Redis;
 
 namespace EdFi.Ods.Features.ExternalCache.Redis;
@@ -23,161 +25,263 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
 {
     private readonly TimeSpan? _absoluteExpirationPeriod;
     private readonly TimeSpan? _slidingExpirationPeriod;
-
-    private readonly IDatabase _cache;
+    private readonly IRedisConnectionProvider _redisConnectionProvider;
+    private readonly RedisCacheResilience _resilience;
+    private readonly ILog _logger = LogManager.GetLogger(typeof(RedisMapCache<,,>).Name);
 
     protected RedisMapCache(
         IRedisConnectionProvider redisConnectionProvider,
+        RedisCacheResilience resilience,
         TimeSpan? absoluteExpirationPeriod,
         TimeSpan? slidingExpirationPeriod)
     {
+        _redisConnectionProvider = redisConnectionProvider ?? throw new ArgumentNullException(nameof(redisConnectionProvider));
+        _resilience = resilience ?? throw new ArgumentNullException(nameof(resilience));
         _absoluteExpirationPeriod = absoluteExpirationPeriod;
         _slidingExpirationPeriod = slidingExpirationPeriod;
-
-        _cache = redisConnectionProvider.Get();
     }
 
+    /// <summary>
+    /// Sets one or more map entries for the specified cache key.
+    /// </summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="mapEntries">The map entries to store.</param>
     public async Task SetMapEntriesAsync(TKey key, (TMapKey key, TMapValue value)[] mapEntries)
     {
-        // Maximum number of items per batch
-        const int BatchSize = 524000;
+        const int BatchSize = 5000;
 
         ValidateKey(key);
 
-        if (mapEntries == null || mapEntries.Length == 0)
+        if (mapEntries is null || mapEntries.Length == 0)
         {
             return;
         }
 
-        var hashEntries = mapEntries
-            .Select(entry =>
-            {
-                if (!TryParse(entry.key, out RedisValue redisHashKey))
-                {
-                    throw new ArgumentException($"Unable to convert '{nameof(entry.key)}' of type '{typeof(TMapKey).Name}' to a '{nameof(RedisValue)}'.");
-                }
+        var hashEntries = new HashEntry[mapEntries.Length];
 
-                if (!TryParse(entry.value, out RedisValue redisHashValue))
-                {
-                    throw new ArgumentException($"Unable to convert '{nameof(entry.value)}' of type '{typeof(TMapKey).Name}' to a '{nameof(RedisValue)}'.");
-                }
-
-                return new HashEntry(redisHashKey, redisHashValue);
-            })
-            .ToArray();
+        for (int i = 0; i < mapEntries.Length; i++)
+        {
+            hashEntries[i] = new HashEntry(
+                ConvertMapKeyToRedisValue(mapEntries[i].key),
+                ConvertMapValueToRedisValue(mapEntries[i].value));
+        }
 
         string cacheKey = GetCacheKey(key);
 
-        // Break the hash entries into batches and send each batch separately to avoid the ~1M parameter limit for Redis commands
-        for (int i = 0; i < hashEntries.Length; i += BatchSize)
+        try
         {
-            var batchEntries = hashEntries.Skip(i).Take(BatchSize).ToArray();
-            await _cache.HashSetAsync(cacheKey, batchEntries);
-        }
+            await _resilience.Pipeline.ExecuteAsync(
+                    async _ =>
+                    {
+                        var cache = _redisConnectionProvider.Get();
 
-        // Handle initial expiration
-        ApplyInitialExpiration(cacheKey);
+                        for (int i = 0; i < hashEntries.Length; i += BatchSize)
+                        {
+                            int remaining = hashEntries.Length - i;
+                            int currentBatchSize = Math.Min(BatchSize, remaining);
+                            var batchEntries = new HashEntry[currentBatchSize];
+                            Array.Copy(hashEntries, i, batchEntries, 0, currentBatchSize);
+                            bool isLastBatch = i + currentBatchSize >= hashEntries.Length;
+                            var batch = cache.CreateBatch();
+                            var setTask = batch.HashSetAsync(cacheKey, batchEntries);
+                            Task<bool> expireTask = isLastBatch ? ApplyInitialExpirationBatched(batch, cacheKey) : null;
+                            batch.Execute();
+                            await setTask.ConfigureAwait(false);
+
+                            if (expireTask is not null)
+                            {
+                                await LogExpirationFailureAsync(expireTask, cacheKey).ConfigureAwait(false);
+                            }
+                        }
+                    },
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (BrokenCircuitException ex)
+        {
+            LogOpenCircuit(nameof(SetMapEntriesAsync), cacheKey, ex);
+        }
+        catch (Exception ex) when (IsRedisUnavailable(ex))
+        {
+            _logger.Warn($"Redis cache set failed for key '{cacheKey}'. Falling back to uncached behavior.", ex);
+        }
     }
 
+    /// <summary>
+    /// Gets map entries for the specified cache key.
+    /// </summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="mapKeys">The map keys to retrieve.</param>
+    /// <returns>The values associated with the supplied map keys.</returns>
     public async Task<TMapValue[]> GetMapEntriesAsync(TKey key, TMapKey[] mapKeys)
     {
         ValidateKey(key);
 
-        if (mapKeys == null || mapKeys.Length == 0)
+        if (mapKeys is null || mapKeys.Length == 0)
         {
             return Array.Empty<TMapValue>();
         }
 
-        var redisHashKeys = mapKeys
-            .Select(mapKey =>
-            {
-                if (!TryParse(mapKey, out RedisValue redisHashKey))
-                {
-                    throw new ArgumentException($"Unable to convert '{nameof(mapKey)}' of type '{typeof(TMapKey).Name}' to a '{nameof(RedisValue)}'.");
-                }
+        var redisHashKeys = new RedisValue[mapKeys.Length];
 
-                return redisHashKey;
-            });
+        for (int i = 0; i < mapKeys.Length; i++)
+        {
+            redisHashKeys[i] = ConvertMapKeyToRedisValue(mapKeys[i]);
+        }
 
         string cacheKey = GetCacheKey(key);
 
-        var keys = redisHashKeys.ToArray();
-        var hashValues = await _cache.HashGetAsync(cacheKey, keys);
+        try
+        {
+            TMapValue[] mapValues = null;
 
-        // Handle sliding expiration refresh of the cache entry
-        ApplySlidingExpiration(cacheKey);
+            await _resilience.Pipeline.ExecuteAsync(
+                    async _ =>
+                    {
+                        var cache = _redisConnectionProvider.Get();
+                        var batch = cache.CreateBatch();
+                        var hashValuesTask = batch.HashGetAsync(cacheKey, redisHashKeys);
+                        Task<bool> expireTask = null;
 
-        return hashValues.Select(ConvertRedisValue).ToArray();
+                        if (_slidingExpirationPeriod is { TotalMilliseconds: > 0 })
+                        {
+                            expireTask = batch.KeyExpireAsync(cacheKey, _slidingExpirationPeriod.Value);
+                        }
+
+                        batch.Execute();
+
+                        var hashValues = await hashValuesTask.ConfigureAwait(false);
+
+                        if (expireTask is not null)
+                        {
+                            await LogExpirationFailureAsync(expireTask, cacheKey).ConfigureAwait(false);
+                        }
+
+                        mapValues = new TMapValue[hashValues.Length];
+
+                        for (int i = 0; i < hashValues.Length; i++)
+                        {
+                            mapValues[i] = ConvertRedisValue(hashValues[i]);
+                        }
+                    },
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+
+            return mapValues ?? new TMapValue[mapKeys.Length];
+        }
+        catch (BrokenCircuitException ex)
+        {
+            LogOpenCircuit(nameof(GetMapEntriesAsync), cacheKey, ex);
+            return new TMapValue[mapKeys.Length];
+        }
+        catch (Exception ex) when (IsRedisUnavailable(ex))
+        {
+            _logger.Warn($"Redis cache get failed for key '{cacheKey}'. Falling back to uncached behavior.", ex);
+            return new TMapValue[mapKeys.Length];
+        }
     }
 
+    /// <summary>
+    /// Deletes a map entry for the specified cache key.
+    /// </summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="mapKey">The map key to delete.</param>
+    /// <returns><see langword="true"/> if the map entry was deleted; otherwise, <see langword="false"/>.</returns>
     public async Task<bool> DeleteMapEntryAsync(TKey key, TMapKey mapKey)
     {
         ValidateKey(key);
         ValidateMapKey(mapKey);
 
-        if (!TryParse(mapKey, out RedisValue redisHashKey))
-        {
-            throw new ArgumentException($"Unable to convert '{nameof(mapKey)}' of type '{typeof(TMapKey).Name}' to a '{nameof(RedisValue)}'.");
-        }
+        RedisValue redisHashKey = ConvertMapKeyToRedisValue(mapKey);
 
         string cacheKey = GetCacheKey(key);
-        var deleteResult = await _cache.HashDeleteAsync(cacheKey, redisHashKey);
 
-        // Handle sliding expiration refresh of the cache entry
-        ApplySlidingExpiration(cacheKey);
+        try
+        {
+            bool deleteResult = false;
 
-        return deleteResult;
+            await _resilience.Pipeline.ExecuteAsync(
+                    async _ =>
+                    {
+                        var cache = _redisConnectionProvider.Get();
+                        var batch = cache.CreateBatch();
+                        var deleteResultTask = batch.HashDeleteAsync(cacheKey, redisHashKey);
+                        Task<bool> expireTask = null;
+
+                        if (_slidingExpirationPeriod is { TotalMilliseconds: > 0 })
+                        {
+                            expireTask = batch.KeyExpireAsync(cacheKey, _slidingExpirationPeriod.Value);
+                        }
+
+                        batch.Execute();
+
+                        deleteResult = await deleteResultTask.ConfigureAwait(false);
+
+                        if (expireTask is not null)
+                        {
+                            await LogExpirationFailureAsync(expireTask, cacheKey).ConfigureAwait(false);
+                        }
+                    },
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+
+            return deleteResult;
+        }
+        catch (BrokenCircuitException ex)
+        {
+            LogOpenCircuit(nameof(DeleteMapEntryAsync), cacheKey, ex);
+            return false;
+        }
+        catch (Exception ex) when (IsRedisUnavailable(ex))
+        {
+            _logger.Warn($"Redis cache delete failed for key '{cacheKey}'. Falling back to uncached behavior.", ex);
+            return false;
+        }
     }
 
-    private void ApplyInitialExpiration(string cacheKey)
+    private Task<bool> ApplyInitialExpirationBatched(IBatch batch, string cacheKey)
     {
         if (_slidingExpirationPeriod is { TotalMilliseconds: > 0 })
         {
-            // Set the initial expiration using the sliding expiration period
-            long slidingExpirationMs = (long) _slidingExpirationPeriod.Value.TotalMilliseconds;
-
-            // Set initial sliding expiration for the key
-            _cache.ExecuteAsync(
-                $"PEXPIRE",
-                new object[]
-                {
-                    cacheKey,
-                    slidingExpirationMs
-                },
-                CommandFlags.FireAndForget);
+            return batch.KeyExpireAsync(cacheKey, _slidingExpirationPeriod.Value);
         }
-        else if (_absoluteExpirationPeriod is { TotalMilliseconds: > 0 })
-        {
-            // Set the initial expiration using the absolute expiration period
-            long absoluteExpirationMs = (long) _absoluteExpirationPeriod.Value.TotalMilliseconds;
 
-            // Set initial absolute expiration for the key (but only if expiration hasn't been set yet)
-            _cache.Execute(
-                $"PEXPIRE",
-                new object[]
-                {
-                    cacheKey,
-                    absoluteExpirationMs,
-                    "NX"
-                },
-                CommandFlags.FireAndForget);
+        if (_absoluteExpirationPeriod is { TotalMilliseconds: > 0 })
+        {
+            return batch.KeyExpireAsync(cacheKey, _absoluteExpirationPeriod.Value, ExpireWhen.HasNoExpiry);
+        }
+
+        return null;
+    }
+
+    private async Task LogExpirationFailureAsync(Task<bool> expireTask, string cacheKey)
+    {
+        try
+        {
+            var result = await expireTask.ConfigureAwait(false);
+
+            if (!result && _logger.IsDebugEnabled)
+            {
+                _logger.Debug($"PEXPIRE returned false for key '{cacheKey}' — key may not exist.");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"Failed to set expiration for cache key '{cacheKey}'.", ex);
         }
     }
 
-    private void ApplySlidingExpiration(string cacheKey)
+    private void LogOpenCircuit(string operationName, string cacheKey, BrokenCircuitException ex)
     {
-        if (_slidingExpirationPeriod is { TotalMilliseconds: > 0 })
+        if (_logger.IsDebugEnabled)
         {
-            // Slide the expiration
-            _cache.Execute(
-                $"PEXPIRE",
-                new object[]
-                {
-                    cacheKey,
-                    (long) _slidingExpirationPeriod.Value.TotalMilliseconds
-                },
-                CommandFlags.FireAndForget);
+            _logger.Debug($"Skipping Redis cache operation '{operationName}' for key '{cacheKey}' because the circuit is open.", ex);
         }
+    }
+
+    private static bool IsRedisUnavailable(Exception ex)
+    {
+        return ex is RedisException or TimeoutException;
     }
 
     // Utility functions that can be overridden in derived implementations to optimize behavior (such as avoid boxing/unboxing of arguments).
@@ -198,9 +302,28 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
         return (TMapValue) Convert.ChangeType(hashValue, typeof(TMapValue));
     }
 
+    protected virtual RedisValue ConvertMapKeyToRedisValue(TMapKey mapKey)
+    {
+        if (!TryParse(mapKey, out RedisValue value))
+        {
+            throw new ArgumentException($"Unable to convert map key of type '{typeof(TMapKey).Name}' to a '{nameof(RedisValue)}'.");
+        }
+
+        return value;
+    }
+
+    protected virtual RedisValue ConvertMapValueToRedisValue(TMapValue mapValue)
+    {
+        if (!TryParse(mapValue, out RedisValue value))
+        {
+            throw new ArgumentException($"Unable to convert map value of type '{typeof(TMapValue).Name}' to a '{nameof(RedisValue)}'.");
+        }
+
+        return value;
+    }
+
     private static bool TryParse<T>(T obj, out RedisValue value)
     {
-        // Generic version of similar function defined internally in RedisValue
         value = obj switch
         {
             string v => v,
@@ -218,6 +341,6 @@ public class RedisMapCache<TKey, TMapKey, TMapValue> : IMapCache<TKey, TMapKey, 
             _ => RedisValue.Null,
         };
 
-        return (value != RedisValue.Null);
+        return value != RedisValue.Null;
     }
 }

--- a/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisPersonIdentifierMapCache.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisPersonIdentifierMapCache.cs
@@ -12,7 +12,7 @@ namespace EdFi.Ods.Features.ExternalCache.Redis;
 
 /// <summary>
 /// Provides a base class for person UniqueId/USI caching in Redis that optimizes the string allocations by storing the
-/// cache key string representations in a dictionary, and avoids boxing while validating the cache key. 
+/// cache key string representations in a dictionary, and avoids boxing while validating the cache key.
 /// </summary>
 /// <typeparam name="TMapKey">The type of the hash's key.</typeparam>
 /// <typeparam name="TMapValue">The type of the hash's value.</typeparam>
@@ -22,8 +22,12 @@ public abstract class RedisPersonIdentifierMapCache<TMapKey, TMapValue>
     private readonly ConcurrentDictionary<(ulong odsInstanceHashId, string personType, PersonMapType personMapType), string>
         _cacheKeyAsStringByKey = new();
 
-    protected RedisPersonIdentifierMapCache(IRedisConnectionProvider redisConnectionProvider, TimeSpan? absoluteExpirationPeriod, TimeSpan? slidingExpirationPeriod)
-        : base(redisConnectionProvider, absoluteExpirationPeriod, slidingExpirationPeriod) { }
+    protected RedisPersonIdentifierMapCache(
+        IRedisConnectionProvider redisConnectionProvider,
+        RedisCacheResilience resilience,
+        TimeSpan? absoluteExpirationPeriod,
+        TimeSpan? slidingExpirationPeriod)
+        : base(redisConnectionProvider, resilience, absoluteExpirationPeriod, slidingExpirationPeriod) { }
 
     protected override void ValidateKey((ulong odsInstanceHashId, string personType, PersonMapType personMapType) key)
     {

--- a/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisPersonIdentifierMapCache.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisPersonIdentifierMapCache.cs
@@ -26,8 +26,9 @@ public abstract class RedisPersonIdentifierMapCache<TMapKey, TMapValue>
         IRedisConnectionProvider redisConnectionProvider,
         RedisCacheResilience resilience,
         TimeSpan? absoluteExpirationPeriod,
-        TimeSpan? slidingExpirationPeriod)
-        : base(redisConnectionProvider, resilience, absoluteExpirationPeriod, slidingExpirationPeriod) { }
+        TimeSpan? slidingExpirationPeriod,
+        int batchSize)
+        : base(redisConnectionProvider, resilience, absoluteExpirationPeriod, slidingExpirationPeriod, batchSize) { }
 
     protected override void ValidateKey((ulong odsInstanceHashId, string personType, PersonMapType personMapType) key)
     {

--- a/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisUniqueIdByUsiMapCache.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisUniqueIdByUsiMapCache.cs
@@ -15,8 +15,9 @@ public class RedisUniqueIdByUsiMapCache : RedisPersonIdentifierMapCache<int, str
         IRedisConnectionProvider redisConnectionProvider,
         RedisCacheResilience resilience,
         TimeSpan? absoluteExpirationPeriod,
-        TimeSpan? slidingExpirationPeriod)
-        : base(redisConnectionProvider, resilience, absoluteExpirationPeriod, slidingExpirationPeriod) { }
+        TimeSpan? slidingExpirationPeriod,
+        int batchSize)
+        : base(redisConnectionProvider, resilience, absoluteExpirationPeriod, slidingExpirationPeriod, batchSize) { }
 
     protected override RedisValue ConvertMapKeyToRedisValue(int mapKey) => mapKey;
 

--- a/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisUniqueIdByUsiMapCache.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisUniqueIdByUsiMapCache.cs
@@ -11,8 +11,16 @@ namespace EdFi.Ods.Features.ExternalCache.Redis;
 
 public class RedisUniqueIdByUsiMapCache : RedisPersonIdentifierMapCache<int, string>
 {
-    public RedisUniqueIdByUsiMapCache(IRedisConnectionProvider redisConnectionProvider, TimeSpan? absoluteExpirationPeriod, TimeSpan? slidingExpirationPeriod)
-        : base(redisConnectionProvider, absoluteExpirationPeriod, slidingExpirationPeriod) { }
+    public RedisUniqueIdByUsiMapCache(
+        IRedisConnectionProvider redisConnectionProvider,
+        RedisCacheResilience resilience,
+        TimeSpan? absoluteExpirationPeriod,
+        TimeSpan? slidingExpirationPeriod)
+        : base(redisConnectionProvider, resilience, absoluteExpirationPeriod, slidingExpirationPeriod) { }
+
+    protected override RedisValue ConvertMapKeyToRedisValue(int mapKey) => mapKey;
+
+    protected override RedisValue ConvertMapValueToRedisValue(string mapValue) => mapValue;
 
     protected override string ConvertRedisValue(RedisValue hashValue) => hashValue;
 

--- a/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisUsiByUniqueIdMapCache.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisUsiByUniqueIdMapCache.cs
@@ -11,8 +11,16 @@ namespace EdFi.Ods.Features.ExternalCache.Redis;
 
 public class RedisUsiByUniqueIdMapCache : RedisPersonIdentifierMapCache<string, int>
 {
-    public RedisUsiByUniqueIdMapCache(IRedisConnectionProvider redisConnectionProvider, TimeSpan? absoluteExpirationPeriod, TimeSpan? slidingExpirationPeriod)
-        : base(redisConnectionProvider, absoluteExpirationPeriod, slidingExpirationPeriod) { }
+    public RedisUsiByUniqueIdMapCache(
+        IRedisConnectionProvider redisConnectionProvider,
+        RedisCacheResilience resilience,
+        TimeSpan? absoluteExpirationPeriod,
+        TimeSpan? slidingExpirationPeriod)
+        : base(redisConnectionProvider, resilience, absoluteExpirationPeriod, slidingExpirationPeriod) { }
+
+    protected override RedisValue ConvertMapKeyToRedisValue(string mapKey) => mapKey;
+
+    protected override RedisValue ConvertMapValueToRedisValue(int mapValue) => mapValue;
 
     protected override int ConvertRedisValue(RedisValue hashValue) => (int)hashValue;
 

--- a/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisUsiByUniqueIdMapCache.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/Redis/RedisUsiByUniqueIdMapCache.cs
@@ -15,8 +15,9 @@ public class RedisUsiByUniqueIdMapCache : RedisPersonIdentifierMapCache<string, 
         IRedisConnectionProvider redisConnectionProvider,
         RedisCacheResilience resilience,
         TimeSpan? absoluteExpirationPeriod,
-        TimeSpan? slidingExpirationPeriod)
-        : base(redisConnectionProvider, resilience, absoluteExpirationPeriod, slidingExpirationPeriod) { }
+        TimeSpan? slidingExpirationPeriod,
+        int batchSize)
+        : base(redisConnectionProvider, resilience, absoluteExpirationPeriod, slidingExpirationPeriod, batchSize) { }
 
     protected override RedisValue ConvertMapKeyToRedisValue(string mapKey) => mapKey;
 

--- a/Application/EdFi.Ods.Features/ExternalCache/TieredCacheProvider.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/TieredCacheProvider.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace EdFi.Ods.Features.ExternalCache;
+
+/// <summary>
+/// Provides a short-lived in-process cache in front of the distributed descriptor cache.
+/// </summary>
+public class TieredCacheProvider : TieredCacheProvider<ulong>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TieredCacheProvider"/> class.
+    /// </summary>
+    /// <param name="memoryCache">The in-process L1 cache.</param>
+    /// <param name="distributedCache">The distributed cache.</param>
+    /// <param name="l1CacheDuration">The duration for L1 cache entries.</param>
+    /// <param name="slidingExpiration">The sliding expiration to apply to L2 set operations.</param>
+    /// <param name="absoluteExpiration">The absolute expiration to apply to L2 set operations.</param>
+    public TieredCacheProvider(
+        IMemoryCache memoryCache,
+        IDistributedCache distributedCache,
+        TimeSpan l1CacheDuration,
+        TimeSpan slidingExpiration,
+        TimeSpan absoluteExpiration)
+        : base(
+            memoryCache,
+            new ExternalCacheProvider<ulong>(distributedCache, slidingExpiration, absoluteExpiration),
+            l1CacheDuration,
+            new AsyncExternalCacheProvider<ulong>(distributedCache, slidingExpiration, absoluteExpiration))
+    {
+    }
+}

--- a/Application/EdFi.Ods.Features/ExternalCache/TieredCacheProvider{TKey}.cs
+++ b/Application/EdFi.Ods.Features/ExternalCache/TieredCacheProvider{TKey}.cs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EdFi.Ods.Common.Caching;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
+
+namespace EdFi.Ods.Features.ExternalCache;
+
+/// <summary>
+/// Provides a two-tier cache with a short-lived in-process L1 cache in front of a distributed L2 cache.
+/// </summary>
+/// <typeparam name="TKey">The type of the cache key.</typeparam>
+public class TieredCacheProvider<TKey> : ICacheProvider<TKey>, IAsyncCacheProvider<TKey>, IClearable
+{
+    private static readonly object NullValue = new();
+
+    private readonly IMemoryCache _memoryCache;
+    private readonly ICacheProvider<TKey> _distributedCacheProvider;
+    private readonly IAsyncCacheProvider<TKey> _asyncDistributedCacheProvider;
+    private readonly TimeSpan _l1CacheDuration;
+    private readonly object _clearSync = new();
+    private CancellationTokenSource _clearTokenSource = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TieredCacheProvider{TKey}"/> class.
+    /// </summary>
+    /// <param name="memoryCache">The in-process L1 cache.</param>
+    /// <param name="distributedCacheProvider">The distributed L2 cache provider.</param>
+    /// <param name="l1CacheDuration">The duration for L1 cache entries.</param>
+    public TieredCacheProvider(
+        IMemoryCache memoryCache,
+        ICacheProvider<TKey> distributedCacheProvider,
+        TimeSpan l1CacheDuration)
+        : this(memoryCache, distributedCacheProvider, l1CacheDuration, null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TieredCacheProvider{TKey}"/> class.
+    /// </summary>
+    /// <param name="memoryCache">The in-process L1 cache.</param>
+    /// <param name="distributedCacheProvider">The distributed L2 cache provider.</param>
+    /// <param name="l1CacheDuration">The duration for L1 cache entries.</param>
+    /// <param name="asyncDistributedCacheProvider">The asynchronous distributed L2 cache provider.</param>
+    public TieredCacheProvider(
+        IMemoryCache memoryCache,
+        ICacheProvider<TKey> distributedCacheProvider,
+        TimeSpan l1CacheDuration,
+        IAsyncCacheProvider<TKey> asyncDistributedCacheProvider)
+    {
+        _memoryCache = memoryCache;
+        _distributedCacheProvider = distributedCacheProvider;
+        _l1CacheDuration = l1CacheDuration;
+        _asyncDistributedCacheProvider = asyncDistributedCacheProvider;
+    }
+
+    /// <inheritdoc />
+    public bool TryGetCachedObject(TKey key, out object value)
+    {
+        if (TryGetLocalCacheValue(key, out value))
+        {
+            return true;
+        }
+
+        if (_distributedCacheProvider.TryGetCachedObject(key, out value))
+        {
+            SetLocalCacheValue(key, value);
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public void SetCachedObject(TKey key, object obj)
+    {
+        SetLocalCacheValue(key, obj);
+        _distributedCacheProvider.SetCachedObject(key, obj);
+    }
+
+    /// <inheritdoc />
+    public void Insert(TKey key, object value, DateTime absoluteExpiration, TimeSpan slidingExpiration)
+    {
+        SetLocalCacheValue(key, value);
+        _distributedCacheProvider.Insert(key, value, absoluteExpiration, slidingExpiration);
+    }
+
+    /// <inheritdoc />
+    public async Task<(bool found, object value)> TryGetCachedObjectAsync(TKey key)
+    {
+        if (TryGetLocalCacheValue(key, out var value))
+        {
+            return (true, value);
+        }
+
+        (bool found, object value) result = _asyncDistributedCacheProvider is not null
+            ? await _asyncDistributedCacheProvider.TryGetCachedObjectAsync(key).ConfigureAwait(false)
+            : TryGetCachedObjectUsingSynchronousProvider(key);
+
+        if (result.found)
+        {
+            SetLocalCacheValue(key, result.value);
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async Task SetCachedObjectAsync(TKey key, object obj)
+    {
+        SetLocalCacheValue(key, obj);
+
+        if (_asyncDistributedCacheProvider is not null)
+        {
+            await _asyncDistributedCacheProvider.SetCachedObjectAsync(key, obj).ConfigureAwait(false);
+            return;
+        }
+
+        _distributedCacheProvider.SetCachedObject(key, obj);
+    }
+
+    /// <inheritdoc />
+    public async Task InsertAsync(TKey key, object value, DateTime absoluteExpiration, TimeSpan slidingExpiration)
+    {
+        SetLocalCacheValue(key, value);
+
+        if (_asyncDistributedCacheProvider is not null)
+        {
+            await _asyncDistributedCacheProvider.InsertAsync(key, value, absoluteExpiration, slidingExpiration).ConfigureAwait(false);
+            return;
+        }
+
+        _distributedCacheProvider.Insert(key, value, absoluteExpiration, slidingExpiration);
+    }
+
+    /// <inheritdoc />
+    public void Clear()
+    {
+        CancellationTokenSource tokenSourceToCancel;
+
+        lock (_clearSync)
+        {
+            tokenSourceToCancel = _clearTokenSource;
+            _clearTokenSource = new CancellationTokenSource();
+        }
+
+        tokenSourceToCancel.Cancel();
+    }
+
+    private (bool found, object value) TryGetCachedObjectUsingSynchronousProvider(TKey key)
+    {
+        bool found = _distributedCacheProvider.TryGetCachedObject(key, out var value);
+        return (found, value);
+    }
+
+    private bool TryGetLocalCacheValue(TKey key, out object value)
+    {
+        if (_memoryCache.TryGetValue(key, out var cachedValue))
+        {
+            value = ReferenceEquals(cachedValue, NullValue)
+                ? null
+                : cachedValue;
+
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+
+    private void SetLocalCacheValue(TKey key, object value)
+    {
+        var entryOptions = new MemoryCacheEntryOptions();
+
+        if (_l1CacheDuration > TimeSpan.Zero)
+        {
+            entryOptions.AbsoluteExpirationRelativeToNow = _l1CacheDuration;
+        }
+        else
+        {
+            entryOptions.AbsoluteExpiration = DateTimeOffset.MaxValue;
+        }
+
+        entryOptions.AddExpirationToken(new CancellationChangeToken(_clearTokenSource.Token));
+        _memoryCache.Set(key, value ?? NullValue, entryOptions);
+    }
+}

--- a/Application/EdFi.Ods.Features/Services/Redis/IRedisConnectionProvider.cs
+++ b/Application/EdFi.Ods.Features/Services/Redis/IRedisConnectionProvider.cs
@@ -7,7 +7,19 @@ using StackExchange.Redis;
 
 namespace EdFi.Ods.Features.Services.Redis;
 
+/// <summary>
+/// Provides access to a Redis database connection.
+/// </summary>
 public interface IRedisConnectionProvider
 {
+    /// <summary>
+    /// Gets a value indicating whether the underlying Redis connection is currently available.
+    /// </summary>
+    bool IsConnected { get; }
+
+    /// <summary>
+    /// Gets the Redis database.
+    /// </summary>
+    /// <returns>The Redis database.</returns>
     IDatabase Get();
 }

--- a/Application/EdFi.Ods.Features/Services/Redis/RedisConnectionProvider.cs
+++ b/Application/EdFi.Ods.Features/Services/Redis/RedisConnectionProvider.cs
@@ -5,66 +5,101 @@
 
 using System;
 using System.Threading;
-using Microsoft.Extensions.Caching.StackExchangeRedis;
+using System.Threading.Tasks;
+using EdFi.Ods.Common.Configuration;
+using log4net;
 using StackExchange.Redis;
 
 namespace EdFi.Ods.Features.Services.Redis;
 
+/// <summary>
+/// Provides access to a Redis database connection.
+/// </summary>
 public class RedisConnectionProvider : IRedisConnectionProvider
 {
-    private readonly RedisCacheOptions _options;
+    private readonly ConfigurationOptions _configurationOptions;
     private readonly SemaphoreSlim _connectionLock = new(initialCount: 1, maxCount: 1);
+    private readonly ILog _logger = LogManager.GetLogger(typeof(RedisConnectionProvider));
 
     private volatile IConnectionMultiplexer _connection;
     private IDatabase _cache;
 
-    public RedisConnectionProvider(string configuration)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RedisConnectionProvider"/> class.
+    /// </summary>
+    /// <param name="redisConfiguration">The Redis connection settings.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="redisConfiguration"/> is null.</exception>
+    public RedisConnectionProvider(RedisConfiguration redisConfiguration)
     {
-        _options = new RedisCacheOptions() { Configuration = configuration };
+        ArgumentNullException.ThrowIfNull(redisConfiguration);
+
+        _configurationOptions = CreateConfigurationOptions(redisConfiguration);
+        _ = WarmupConnectionAsync();
     }
-    
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RedisConnectionProvider"/> class.
+    /// </summary>
+    /// <param name="configuration">The Redis connection string.</param>
+    public RedisConnectionProvider(string configuration)
+        : this(new RedisConfiguration { Configuration = configuration })
+    {
+    }
+
+    /// <inheritdoc />
+    public bool IsConnected { get; private set; }
+
+    /// <inheritdoc />
     public IDatabase Get()
     {
-        EnsureConnected();
+        EnsureConnectedAsync().GetAwaiter().GetResult();
 
         return _cache;
     }
-    
-    private void EnsureConnected()
+
+    internal static ConfigurationOptions CreateConfigurationOptions(
+        RedisConfiguration redisConfiguration
+    )
     {
-        if (_cache != null)
+        ArgumentNullException.ThrowIfNull(redisConfiguration);
+
+        // Deliberately falling back to an empty string below rather than defaulting to potentially insecure localhost
+        var configurationOptions = ConfigurationOptions.Parse(
+            redisConfiguration.Configuration ?? string.Empty
+        );
+        configurationOptions.SyncTimeout = redisConfiguration.SyncTimeoutMs;
+        configurationOptions.AsyncTimeout = redisConfiguration.AsyncTimeoutMs;
+        configurationOptions.ConnectTimeout = redisConfiguration.ConnectTimeoutMs;
+        configurationOptions.ConnectRetry = redisConfiguration.ConnectRetry;
+        configurationOptions.AbortOnConnectFail = redisConfiguration.AbortOnConnectFail;
+        configurationOptions.KeepAlive = redisConfiguration.KeepAliveSeconds;
+        configurationOptions.Ssl = redisConfiguration.Ssl;
+
+        if (!string.IsNullOrWhiteSpace(redisConfiguration.Password))
+        {
+            configurationOptions.Password = redisConfiguration.Password;
+        }
+
+        return configurationOptions;
+    }
+
+    private async Task EnsureConnectedAsync()
+    {
+        if (_cache is not null)
         {
             return;
         }
 
-        _connectionLock.Wait();
+        await _connectionLock.WaitAsync().ConfigureAwait(false);
 
         try
         {
-            if (_cache == null)
+            if (_cache is null)
             {
-                if(_options.ConnectionMultiplexerFactory is null)
-                {
-                    if (_options.ConfigurationOptions is not null)
-                    {
-                        _connection = ConnectionMultiplexer.Connect(_options.ConfigurationOptions);
-                    }
-                    else if (!string.IsNullOrWhiteSpace(_options.Configuration))
-                    {
-                        _connection = ConnectionMultiplexer.Connect(_options.Configuration);
-                    }
-                    else
-                    {
-                        throw new InvalidOperationException("External cache is enabled and configured for Redis, but neither a configuration string nor Redis configuration options have been provided in appsettings");
-                    }
-                }
-                else
-                {
-                    _connection = _options.ConnectionMultiplexerFactory().ConfigureAwait(false).GetAwaiter().GetResult();;
-                }
-
-                TryRegisterProfiler();
+                _connection = await ConnectionMultiplexer.ConnectAsync(_configurationOptions).ConfigureAwait(false);
+                SubscribeToConnectionEvents(_connection);
                 _cache = _connection.GetDatabase();
+                IsConnected = _connection.IsConnected;
             }
         }
         finally
@@ -73,16 +108,52 @@ public class RedisConnectionProvider : IRedisConnectionProvider
         }
     }
 
-    private void TryRegisterProfiler()
+    private async Task WarmupConnectionAsync()
     {
-        if (_connection == null)
+        try
         {
-            throw new InvalidOperationException($"{nameof(_connection)} cannot be null.");
+            await EnsureConnectedAsync().ConfigureAwait(false);
         }
+        catch (Exception ex)
+        {
+            _logger.Warn("Unable to pre-establish Redis connection. A subsequent cache operation will retry.", ex);
+        }
+    }
 
-        if (_options.ProfilingSession != null)
-        {
-            _connection.RegisterProfiler(_options.ProfilingSession);
-        }
+    private void SubscribeToConnectionEvents(IConnectionMultiplexer connection)
+    {
+        connection.ConnectionFailed += OnConnectionFailed;
+        connection.ConnectionRestored += OnConnectionRestored;
+        connection.ErrorMessage += OnErrorMessage;
+        connection.InternalError += OnInternalError;
+    }
+
+    private void OnConnectionFailed(object sender, ConnectionFailedEventArgs args)
+    {
+        IsConnected = false;
+
+        _logger.Error(
+            $"Redis connection failed. Endpoint: {args.EndPoint}, FailureType: {args.FailureType}, ConnectionType: {args.ConnectionType}.",
+            args.Exception
+        );
+    }
+
+    private void OnConnectionRestored(object sender, ConnectionFailedEventArgs args)
+    {
+        IsConnected = true;
+
+        _logger.Info(
+            $"Redis connection restored. Endpoint: {args.EndPoint}, FailureType: {args.FailureType}, ConnectionType: {args.ConnectionType}."
+        );
+    }
+
+    private void OnErrorMessage(object sender, RedisErrorEventArgs args)
+    {
+        _logger.Warn($"Redis reported an error message: {args.Message}");
+    }
+
+    private void OnInternalError(object sender, InternalErrorEventArgs args)
+    {
+        _logger.Warn($"Redis reported an internal error from '{args.Origin}'.", args.Exception);
     }
 }

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/PersonMapCacheInitializerTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/PersonMapCacheInitializerTests.cs
@@ -4,16 +4,15 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
-using EdFi.Ods.Api.Caching;
-using EdFi.Ods.Api.IdentityValueMappers;
-using NUnit.Framework;
-using FakeItEasy;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using EdFi.Ods.Api.Caching;
 using EdFi.Ods.Api.Caching.Person;
-using EdFi.Ods.Tests._Extensions;
-using log4net;
+using EdFi.Ods.Api.IdentityValueMappers;
+using FakeItEasy;
+using NUnit.Framework;
 
 namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching;
 
@@ -24,13 +23,16 @@ public class PersonMapCacheInitializerTests
     public async Task InitializePersonMapAsync_ShouldInitializeCache_WhenCalled()
     {
         // Arrange
-        var personType = "TestPerson";
-        var odsInstanceHashId = 12345UL;
-        var personIdentifiersProvider = A.Fake<IPersonIdentifiersProvider>();
-        var usiByUniqueIdMapCache = A.Fake<IMapCache<(ulong, string, PersonMapType), int, string>>();
-        var uniqueIdByUsiMapCache = A.Fake<IMapCache<(ulong, string, PersonMapType), string, int>>();
+        const string personType = "TestPerson";
+        const ulong odsInstanceHashId = 12345UL;
+        const string lockKey = "cache-init-lock";
 
-        A.CallTo(() => personIdentifiersProvider.GetAllPersonIdentifiersAsync(personType))
+        var personIdentifiersProvider = A.Fake<IPersonIdentifiersProvider>();
+        var uniqueIdByUsiMapCache = A.Fake<IMapCache<(ulong, string, PersonMapType), int, string>>();
+        var usiByUniqueIdMapCache = A.Fake<IMapCache<(ulong, string, PersonMapType), string, int>>();
+        var distributedLockProvider = A.Fake<IDistributedLockProvider>();
+
+        A.CallTo(() => personIdentifiersProvider.GetAllPersonIdentifiersAsync(personType, A<CancellationToken>.Ignored))
             .Returns(new List<PersonIdentifiersValueMap>
             {
                 new() { Usi = 1, UniqueId = "UniqueId1" },
@@ -39,68 +41,88 @@ public class PersonMapCacheInitializerTests
 
         var personMapCacheInitializer = new PersonMapCacheInitializer(
             personIdentifiersProvider,
+            uniqueIdByUsiMapCache,
             usiByUniqueIdMapCache,
-            uniqueIdByUsiMapCache);
+            distributedLockProvider);
 
         // Act
-        await personMapCacheInitializer.InitializePersonMapAsync(odsInstanceHashId, personType);
+        await personMapCacheInitializer.InitializePersonMapAsync(odsInstanceHashId, personType, lockKey);
 
         // Assert
         var uniqueIdByUsiTuple = (odsInstanceHashId, personType, PersonMapType.UniqueIdByUsi);
-        
-        A.CallTo(() => usiByUniqueIdMapCache.SetMapEntriesAsync(
-            uniqueIdByUsiTuple,
-            A<(int, string)[]>.That.Matches(entries => 
-                entries.Count() == 3
-                && entries[0].Item1 == 1 && entries[0].Item2 == "UniqueId1"
-                && entries[1].Item1 == 2 && entries[1].Item2 == "UniqueId2"
-                // Ensure that cache initialization marker entry is present at the end of the array
-                && entries[2].Item1 == CacheInitializationConstants.InitializationMarkerKeyForUsi 
-                && entries[2].Item2 == CacheInitializationConstants.InitializationMarkerKeyForUniqueId)))
+
+        A.CallTo(() => uniqueIdByUsiMapCache.SetMapEntriesAsync(
+                uniqueIdByUsiTuple,
+                A<(int, string)[]>.That.Matches(entries =>
+                    entries.Count() == 3
+                    && entries[0].Item1 == 1 && entries[0].Item2 == "UniqueId1"
+                    && entries[1].Item1 == 2 && entries[1].Item2 == "UniqueId2"
+                    && entries[2].Item1 == CacheInitializationConstants.InitializationMarkerKeyForUsi
+                    && entries[2].Item2 == CacheInitializationConstants.InitializationMarkerKeyForUniqueId)))
             .MustHaveHappenedOnceExactly();
 
         var usiByUniqueIdTuple = (odsInstanceHashId, personType, PersonMapType.UsiByUniqueId);
 
-        A.CallTo(() => uniqueIdByUsiMapCache.SetMapEntriesAsync(
-            usiByUniqueIdTuple,
-            A<(string, int)[]>.That.Matches(entries => 
-                entries.Count() == 3
-                && entries[0].Item1 == "UniqueId1" && entries[0].Item2 == 1 
-                && entries[1].Item1 == "UniqueId2" && entries[1].Item2 == 2
-                // Ensure that cache initialization marker entry is present at the end of the array
-                && entries[2].Item1 == CacheInitializationConstants.InitializationMarkerKeyForUniqueId 
-                && entries[2].Item2 == CacheInitializationConstants.InitializationMarkerKeyForUsi)))
+        A.CallTo(() => usiByUniqueIdMapCache.SetMapEntriesAsync(
+                usiByUniqueIdTuple,
+                A<(string, int)[]>.That.Matches(entries =>
+                    entries.Count() == 3
+                    && entries[0].Item1 == "UniqueId1" && entries[0].Item2 == 1
+                    && entries[1].Item1 == "UniqueId2" && entries[1].Item2 == 2
+                    && entries[2].Item1 == CacheInitializationConstants.InitializationMarkerKeyForUniqueId
+                    && entries[2].Item2 == CacheInitializationConstants.InitializationMarkerKeyForUsi)))
+            .MustHaveHappenedOnceExactly();
+
+        A.CallTo(() => distributedLockProvider.ReleaseLockAsync(lockKey))
             .MustHaveHappenedOnceExactly();
     }
 
     [Test]
-    public async Task InitializePersonMapAsync_ShouldNotSetAnyCacheMapEntriesOrThrowException_WhenIdentifierProviderFails()
+    public async Task InitializePersonMapAsync_ShouldResetInitializationMarkers_WhenIdentifierProviderFails()
     {
         // Arrange
-        var personType = "TestPerson";
-        var odsInstanceHashId = 12345UL;
-        var personIdentifiersProvider = A.Fake<IPersonIdentifiersProvider>();
-        var usiByUniqueIdMapCache = A.Fake<IMapCache<(ulong, string, PersonMapType), int, string>>();
-        var uniqueIdByUsiMapCache = A.Fake<IMapCache<(ulong, string, PersonMapType), string, int>>();
+        const string personType = "TestPerson";
+        const ulong odsInstanceHashId = 12345UL;
+        const string lockKey = "cache-init-lock";
 
-        A.CallTo(() => personIdentifiersProvider.GetAllPersonIdentifiersAsync(personType))
+        var personIdentifiersProvider = A.Fake<IPersonIdentifiersProvider>();
+        var uniqueIdByUsiMapCache = A.Fake<IMapCache<(ulong, string, PersonMapType), int, string>>();
+        var usiByUniqueIdMapCache = A.Fake<IMapCache<(ulong, string, PersonMapType), string, int>>();
+        var distributedLockProvider = A.Fake<IDistributedLockProvider>();
+
+        A.CallTo(() => personIdentifiersProvider.GetAllPersonIdentifiersAsync(personType, A<CancellationToken>.Ignored))
             .Throws(new Exception("Failed to fetch identifiers"));
 
         var personMapCacheInitializer = new PersonMapCacheInitializer(
             personIdentifiersProvider,
+            uniqueIdByUsiMapCache,
             usiByUniqueIdMapCache,
-            uniqueIdByUsiMapCache);
+            distributedLockProvider);
 
         // Act
-        await personMapCacheInitializer.InitializePersonMapAsync(odsInstanceHashId, personType);
+        await personMapCacheInitializer.InitializePersonMapAsync(odsInstanceHashId, personType, lockKey);
 
         // Assert
+        var uniqueIdByUsiTuple = (odsInstanceHashId, personType, PersonMapType.UniqueIdByUsi);
+        var usiByUniqueIdTuple = (odsInstanceHashId, personType, PersonMapType.UsiByUniqueId);
+
         A.CallTo(() => uniqueIdByUsiMapCache.SetMapEntriesAsync(
-            A<(ulong, string, PersonMapType)>.Ignored, A<(string, int)[]>.Ignored))
-            .MustNotHaveHappened();
-        
+                uniqueIdByUsiTuple,
+                A<(int, string)[]>.That.Matches(entries =>
+                    entries.Length == 1
+                    && entries[0].Item1 == CacheInitializationConstants.InitializationMarkerKeyForUsi
+                    && entries[0].Item2 == null)))
+            .MustHaveHappenedOnceExactly();
+
         A.CallTo(() => usiByUniqueIdMapCache.SetMapEntriesAsync(
-                A<(ulong, string, PersonMapType)>.Ignored, A<(int, string)[]>.Ignored))
-            .MustNotHaveHappened();
+                usiByUniqueIdTuple,
+                A<(string, int)[]>.That.Matches(entries =>
+                    entries.Length == 1
+                    && entries[0].Item1 == CacheInitializationConstants.InitializationMarkerKeyForUniqueId
+                    && entries[0].Item2 == default)))
+            .MustHaveHappenedOnceExactly();
+
+        A.CallTo(() => distributedLockProvider.ReleaseLockAsync(lockKey))
+            .MustHaveHappenedOnceExactly();
     }
 }

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/PersonUniqueIdResolverTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/PersonUniqueIdResolverTests.cs
@@ -9,6 +9,7 @@ using EdFi.Ods.Api.IdentityValueMappers;
 using EdFi.Ods.Common.Configuration;
 using EdFi.Ods.Common.Context;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EdFi.Ods.Api.Caching.Person;
 using FakeItEasy;
@@ -25,6 +26,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
         private IMapCache<(ulong, string, PersonMapType), string, int> _fakeReverseMapCache;
         private Dictionary<string, bool> _fakeCacheSuppressionByPersonType;
         private IPersonMapCacheInitializer _fakePersonMapCacheInitializer;
+        private IDistributedLockProvider _fakeDistributedLockProvider;
         private IContextProvider<OdsInstanceConfiguration> _fakeOdsInstanceConfigurationContextProvider;
 
         [SetUp]
@@ -35,6 +37,10 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
             _fakeReverseMapCache = A.Fake<IMapCache<(ulong, string, PersonMapType), string, int>>();
             _fakeCacheSuppressionByPersonType = new Dictionary<string, bool>();
             _fakePersonMapCacheInitializer = A.Fake<IPersonMapCacheInitializer>();
+            _fakeDistributedLockProvider = A.Fake<IDistributedLockProvider>();
+
+            A.CallTo(() => _fakeDistributedLockProvider.TryAcquireLockAsync(A<string>.Ignored, A<TimeSpan>.Ignored))
+                .Returns(true);
 
             var odsInstanceConfiguration = new OdsInstanceConfiguration(
                 1,
@@ -64,9 +70,9 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
 
             A.CallTo(() => _fakeMapCache.GetMapEntriesAsync(
                 uniqueIdByUsiTuple,
-                A<int[]>.That.Matches(x => 
-                    x.Length == 3 
-                    && x[0] == 1 
+                A<int[]>.That.Matches(x =>
+                    x.Length == 3
+                    && x[0] == 1
                     && x[1] == 2
                     // Resolver should append the marker key for checking cache initialization state
                     && x[2] == CacheInitializationConstants.InitializationMarkerKeyForUsi
@@ -75,6 +81,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
 
             var resolver = new PersonUniqueIdResolver(
                 _fakePersonMapCacheInitializer,
+                _fakeDistributedLockProvider,
                 _fakePersonIdentifiersProvider,
                 _fakeOdsInstanceConfigurationContextProvider,
                 _fakeMapCache,
@@ -97,12 +104,12 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
             A.CallTo(() => _fakePersonIdentifiersProvider.GetPersonUniqueIdsAsync(
                 personType, A<int[]>.Ignored))
                 .MustNotHaveHappened();
-            
+
             // No additional entries set in cache
             A.CallTo(() => _fakeMapCache.SetMapEntriesAsync(
                     uniqueIdByUsiTuple, A<(int, string)[]>.Ignored))
                 .MustNotHaveHappened();
-            
+
             // No additional entries set in cache
             A.CallTo(() => _fakeReverseMapCache.SetMapEntriesAsync(
                     usiByUniqueIdTuple, A<(string, int)[]>.Ignored))
@@ -129,9 +136,9 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
             {
                 A.CallTo(() => _fakeMapCache.GetMapEntriesAsync(
                         uniqueIdByUsiTuple,
-                        A<int[]>.That.Matches(x => 
-                            x.Length == 2 
-                            && x[0] == 1 
+                        A<int[]>.That.Matches(x =>
+                            x.Length == 2
+                            && x[0] == 1
                             && x[1] == 2
                         )))
                     .Returns(new string[2]);
@@ -140,9 +147,9 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
             {
                 A.CallTo(() => _fakeMapCache.GetMapEntriesAsync(
                         uniqueIdByUsiTuple,
-                        A<int[]>.That.Matches(x => 
-                            x.Length == 3 
-                            && x[0] == 1 
+                        A<int[]>.That.Matches(x =>
+                            x.Length == 3
+                            && x[0] == 1
                             && x[1] == 2
                             // Resolver should append the marker key for checking cache initialization state
                             && x[2] == CacheInitializationConstants.InitializationMarkerKeyForUsi
@@ -153,18 +160,19 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
 
             A.CallTo(() => _fakePersonIdentifiersProvider.GetPersonUniqueIdsAsync(
                 personType,
-                A<int[]>.That.Matches(x => 
-                    x.Length == 2 
-                    && x[0] == 1 
+                A<int[]>.That.Matches(x =>
+                    x.Length == 2
+                    && x[0] == 1
                     && x[1] == 2)))
                 .Returns(new[]
                 {
                     new PersonIdentifiersValueMap { Usi = 1, UniqueId = "UniqueId1" },
                     new PersonIdentifiersValueMap { Usi = 2, UniqueId = "UniqueId2" }
                 });
-            
+
             var resolver = new PersonUniqueIdResolver(
                 _fakePersonMapCacheInitializer,
+                _fakeDistributedLockProvider,
                 _fakePersonIdentifiersProvider,
                 _fakeOdsInstanceConfigurationContextProvider,
                 _fakeMapCache,
@@ -186,57 +194,43 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
             A.CallTo(() => _fakePersonIdentifiersProvider.GetPersonUniqueIdsAsync(
                 personType, A<int[]>.Ignored))
                 .MustHaveHappenedOnceExactly();
-            
+
             // Loaded entries should be set to cache
             A.CallTo(() => _fakeMapCache.SetMapEntriesAsync(
-                    uniqueIdByUsiTuple, A<(int key, string value)[]>.That.Matches(x => 
-                        x.Length == 2 
+                    uniqueIdByUsiTuple, A<(int key, string value)[]>.That.Matches(x =>
+                        x.Length == 2
                         && x[0].key == 1 && x[0].value == "UniqueId1"
                         && x[1].key == 2 && x[1].value == "UniqueId2")))
                 .MustHaveHappenedOnceExactly();
-            
+
             // Loaded entries should be set to cache
             A.CallTo(() => _fakeReverseMapCache.SetMapEntriesAsync(
-                    usiByUniqueIdTuple, A<(string key, int value)[]>.That.Matches(x => 
-                        x.Length == 2 
-                        && x[0].key == "UniqueId1" && x[0].value == 1 
+                    usiByUniqueIdTuple, A<(string key, int value)[]>.That.Matches(x =>
+                        x.Length == 2
+                        && x[0].key == "UniqueId1" && x[0].value == 1
                         && x[1].key == "UniqueId2" && x[1].value == 2)))
                 .MustHaveHappenedOnceExactly();
 
-            // Cache initialization marker entry should be set
-            var cacheInitializationMarkerForUsiCall = A.CallTo(() => _fakeMapCache.SetMapEntriesAsync(
-                    uniqueIdByUsiTuple, A<(int key, string value)[]>.That.Matches(x => 
-                        x.Length == 1 
-                        && x[0].key == CacheInitializationConstants.InitializationMarkerKeyForUsi 
-                        && x[0].value == CacheInitializationConstants.InitializationMarkerKeyForUniqueId)));
+            // Resolver should not write the initialization marker preemptively.
+            A.CallTo(() => _fakeMapCache.SetMapEntriesAsync(
+                    uniqueIdByUsiTuple, A<(int key, string value)[]>.That.Matches(x =>
+                        x.Length == 1
+                        && x[0].key == CacheInitializationConstants.InitializationMarkerKeyForUsi)))
+                .MustNotHaveHappened();
 
-            if (useProgressiveLoading)
-            {
-                cacheInitializationMarkerForUsiCall.MustNotHaveHappened();
-            }
-            else
-            {
-                cacheInitializationMarkerForUsiCall.MustHaveHappenedOnceExactly();
-            }
-
-            // Cache initialization marker entry should be set
-            var cacheInitializationMarkerForUniqueIdCall = A.CallTo(() => _fakeReverseMapCache.SetMapEntriesAsync(
-                    usiByUniqueIdTuple, A<(string key, int value)[]>.That.Matches(x => 
-                        x.Length == 1 
-                        && x[0].key == CacheInitializationConstants.InitializationMarkerKeyForUniqueId 
-                        && x[0].value == CacheInitializationConstants.InitializationMarkerKeyForUsi)));
-
-            if (useProgressiveLoading)
-            {
-                cacheInitializationMarkerForUniqueIdCall.MustNotHaveHappened();
-            }
-            else
-            {
-                cacheInitializationMarkerForUniqueIdCall.MustHaveHappenedOnceExactly();
-            }
+            A.CallTo(() => _fakeReverseMapCache.SetMapEntriesAsync(
+                    usiByUniqueIdTuple, A<(string key, int value)[]>.That.Matches(x =>
+                        x.Length == 1
+                        && x[0].key == CacheInitializationConstants.InitializationMarkerKeyForUniqueId)))
+                .MustNotHaveHappened();
 
             // Background initialization should have been initiated
-            var backgroundCacheInitializationCall = A.CallTo(() => _fakePersonMapCacheInitializer.InitializePersonMapAsync(123456UL, personType));
+            string lockKey = $"cache-init-lock:123456:{personType}:{PersonMapType.UniqueIdByUsi}";
+            var backgroundCacheInitializationCall = A.CallTo(() => _fakePersonMapCacheInitializer.InitializePersonMapAsync(
+                123456UL,
+                personType,
+                lockKey,
+                CancellationToken.None));
 
             if (useProgressiveLoading)
             {
@@ -264,20 +258,25 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
 
             A.CallTo(() => _fakeMapCache.GetMapEntriesAsync(
                 uniqueIdByUsiTuple,
-                A<int[]>.That.Matches(x => 
-                    x.Length == 3 
-                    && x[0] == 1 
+                A<int[]>.That.Matches(x =>
+                    x.Length == 3
+                    && x[0] == 1
                     && x[1] == 2
                     // Resolver should append the marker key for checking cache initialization state
                     && x[2] == CacheInitializationConstants.InitializationMarkerKeyForUsi)))
                 .Returns(new string[3]);
 
+            string lockKey = $"cache-init-lock:123456:{personType}:{PersonMapType.UniqueIdByUsi}";
+
             A.CallTo(() => _fakePersonMapCacheInitializer.InitializePersonMapAsync(
-                123456UL, personType))
+                123456UL,
+                personType,
+                lockKey,
+                CancellationToken.None))
                 .Returns(Task.FromException(new Exception("Cache initialization failed")));
 
             A.CallTo(() => _fakePersonIdentifiersProvider.GetPersonUniqueIdsAsync(
-                personType, 
+                personType,
             A<int[]>.That.Matches(x => x.Length == 2 && x[0] == 1 && x[1] == 2)))
                 .Returns(new[]
                 {
@@ -287,6 +286,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
 
             var resolver = new PersonUniqueIdResolver(
                 _fakePersonMapCacheInitializer,
+                _fakeDistributedLockProvider,
                 _fakePersonIdentifiersProvider,
                 _fakeOdsInstanceConfigurationContextProvider,
                 _fakeMapCache,
@@ -326,9 +326,9 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
 
             A.CallTo(() => _fakeMapCache.GetMapEntriesAsync(
                 uniqueIdByUsiTuple,
-                A<int[]>.That.Matches(x => 
-                    x.Length == 3 
-                    && x[0] == 1 
+                A<int[]>.That.Matches(x =>
+                    x.Length == 3
+                    && x[0] == 1
                     && x[1] == 2
                     // Resolver should append the marker key for checking cache initialization state
                     && x[2] == CacheInitializationConstants.InitializationMarkerKeyForUsi)))
@@ -337,6 +337,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
 
             var resolver = new PersonUniqueIdResolver(
                 _fakePersonMapCacheInitializer,
+                _fakeDistributedLockProvider,
                 _fakePersonIdentifiersProvider,
                 _fakeOdsInstanceConfigurationContextProvider,
                 _fakeMapCache,
@@ -350,7 +351,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
             await resolver.ResolveUniqueIdsAsync(personType, lookups);
 
             // Assert
-            
+
             // Should load from the ODS
             A.CallTo(() => _fakePersonIdentifiersProvider.GetPersonUniqueIdsAsync(
                 personType,
@@ -358,7 +359,11 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
                 .MustHaveHappenedOnceExactly();
 
             // There should be no attempt to initialize the cache
-            A.CallTo(() => _fakePersonMapCacheInitializer.InitializePersonMapAsync(A<ulong>.Ignored, A<string>.Ignored))
+            A.CallTo(() => _fakePersonMapCacheInitializer.InitializePersonMapAsync(
+                    A<ulong>.Ignored,
+                    A<string>.Ignored,
+                    A<string>.Ignored,
+                    A<CancellationToken>.Ignored))
                 .MustNotHaveHappened();
         }
 
@@ -378,6 +383,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
 
             var resolver = new PersonUniqueIdResolver(
                 _fakePersonMapCacheInitializer,
+                _fakeDistributedLockProvider,
                 _fakePersonIdentifiersProvider,
                 _fakeOdsInstanceConfigurationContextProvider,
                 _fakeMapCache,
@@ -399,6 +405,238 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
             A.CallTo(() => _fakePersonIdentifiersProvider.GetPersonUniqueIdsAsync(
                 personType,
                 A<int[]>.That.Matches(x => x.Length == 2 && x[0] == 1 && x[1] == 2)))
+                .MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public async Task ResolveUniqueIds_ShouldLoadFromOds_WhenLockNotAcquired()
+        {
+            // Arrange
+            var personType = "Student";
+            var lookups = new Dictionary<int, string>
+            {
+                { 1, null },
+                { 2, null }
+            };
+
+            // Simulate that cache is not initialized
+            var uniqueIdByUsiTuple = (123456UL, personType, PersonMapType.UniqueIdByUsi);
+
+            A.CallTo(() => _fakeMapCache.GetMapEntriesAsync(
+                uniqueIdByUsiTuple,
+                A<int[]>.That.Matches(x =>
+                    x.Length == 3
+                    && x[0] == 1
+                    && x[1] == 2
+                    && x[2] == CacheInitializationConstants.InitializationMarkerKeyForUsi)))
+                .Returns(new string[3]);
+
+            // Simulate that another instance holds the lock (lock not acquired)
+            A.CallTo(() => _fakeDistributedLockProvider.TryAcquireLockAsync(A<string>.Ignored, A<TimeSpan>.Ignored))
+                .Returns(false);
+
+            A.CallTo(() => _fakePersonIdentifiersProvider.GetPersonUniqueIdsAsync(
+                personType,
+                A<int[]>.That.Matches(x => x.Length == 2 && x[0] == 1 && x[1] == 2)))
+                .Returns(new[]
+                {
+                    new PersonIdentifiersValueMap { Usi = 1, UniqueId = "UniqueId1" },
+                    new PersonIdentifiersValueMap { Usi = 2, UniqueId = "UniqueId2" }
+                });
+
+            var resolver = new PersonUniqueIdResolver(
+                _fakePersonMapCacheInitializer,
+                _fakeDistributedLockProvider,
+                _fakePersonIdentifiersProvider,
+                _fakeOdsInstanceConfigurationContextProvider,
+                _fakeMapCache,
+                _fakeReverseMapCache,
+                new UsiCacheInitializationMarkerKeyProvider(),
+                new UniqueIdCacheInitializationMarkerKeyProvider(),
+                _fakeCacheSuppressionByPersonType,
+                useProgressiveLoading: false);
+
+            // Act
+            await resolver.ResolveUniqueIdsAsync(personType, lookups);
+
+            // Assert
+            lookups.ShouldSatisfyAllConditions(
+                () => lookups.Count.ShouldBe(2),
+                () => lookups[1].ShouldBe("UniqueId1"),
+                () => lookups[2].ShouldBe("UniqueId2"));
+
+            // Should fall back to loading from ODS
+            A.CallTo(() => _fakePersonIdentifiersProvider.GetPersonUniqueIdsAsync(
+                personType, A<int[]>.Ignored))
+                .MustHaveHappenedOnceExactly();
+
+            // Should NOT attempt background initialization since lock was not acquired
+            A.CallTo(() => _fakePersonMapCacheInitializer.InitializePersonMapAsync(
+                    A<ulong>.Ignored,
+                    A<string>.Ignored,
+                    A<string>.Ignored,
+                    A<CancellationToken>.Ignored))
+                .MustNotHaveHappened();
+
+            // Should NOT set marker entries in cache
+            A.CallTo(() => _fakeMapCache.SetMapEntriesAsync(
+                    uniqueIdByUsiTuple, A<(int key, string value)[]>.That.Matches(x =>
+                        x.Length == 1
+                        && x[0].key == CacheInitializationConstants.InitializationMarkerKeyForUsi)))
+                .MustNotHaveHappened();
+        }
+
+        [Test]
+        public async Task ResolveUniqueIds_ShouldNotReleaseLock_WhenBackgroundInitializationIsStarted()
+        {
+            // Arrange
+            var personType = "Student";
+            var lockKey = $"cache-init-lock:123456:{personType}:{PersonMapType.UniqueIdByUsi}";
+            var lookups = new Dictionary<int, string>
+            {
+                { 1, null },
+                { 2, null }
+            };
+
+            var uniqueIdByUsiTuple = (123456UL, personType, PersonMapType.UniqueIdByUsi);
+
+            A.CallTo(() => _fakeMapCache.GetMapEntriesAsync(
+                uniqueIdByUsiTuple,
+                A<int[]>.That.Matches(x =>
+                    x.Length == 3
+                    && x[0] == 1
+                    && x[1] == 2
+                    && x[2] == CacheInitializationConstants.InitializationMarkerKeyForUsi)))
+                .Returns(new string[3]);
+
+            var resolver = new PersonUniqueIdResolver(
+                _fakePersonMapCacheInitializer,
+                _fakeDistributedLockProvider,
+                _fakePersonIdentifiersProvider,
+                _fakeOdsInstanceConfigurationContextProvider,
+                _fakeMapCache,
+                _fakeReverseMapCache,
+                new UsiCacheInitializationMarkerKeyProvider(),
+                new UniqueIdCacheInitializationMarkerKeyProvider(),
+                _fakeCacheSuppressionByPersonType,
+                useProgressiveLoading: false);
+
+            // Act
+            await resolver.ResolveUniqueIdsAsync(personType, lookups);
+
+            // Assert
+            A.CallTo(() => _fakePersonMapCacheInitializer.InitializePersonMapAsync(
+                    123456UL,
+                    personType,
+                    lockKey,
+                    CancellationToken.None))
+                .MustHaveHappenedOnceExactly();
+
+            A.CallTo(() => _fakeDistributedLockProvider.ReleaseLockAsync(lockKey))
+                .MustNotHaveHappened();
+        }
+
+        [Test]
+        public async Task ResolveUniqueIds_ShouldNotThrow_WhenBackgroundInitializerThrows()
+        {
+            // Arrange
+            var personType = "Student";
+            var lookups = new Dictionary<int, string>
+            {
+                { 1, null },
+                { 2, null }
+            };
+
+            var uniqueIdByUsiTuple = (123456UL, personType, PersonMapType.UniqueIdByUsi);
+            string lockKey = $"cache-init-lock:123456:{personType}:{PersonMapType.UniqueIdByUsi}";
+
+            A.CallTo(() => _fakeMapCache.GetMapEntriesAsync(
+                uniqueIdByUsiTuple,
+                A<int[]>.That.Matches(x =>
+                    x.Length == 3
+                    && x[0] == 1
+                    && x[1] == 2
+                    && x[2] == CacheInitializationConstants.InitializationMarkerKeyForUsi)))
+                .Returns(new string[3]);
+
+            A.CallTo(() => _fakePersonMapCacheInitializer.InitializePersonMapAsync(
+                    123456UL,
+                    personType,
+                    lockKey,
+                    CancellationToken.None))
+                .Throws(new Exception("Background init failure"));
+
+            var resolver = new PersonUniqueIdResolver(
+                _fakePersonMapCacheInitializer,
+                _fakeDistributedLockProvider,
+                _fakePersonIdentifiersProvider,
+                _fakeOdsInstanceConfigurationContextProvider,
+                _fakeMapCache,
+                _fakeReverseMapCache,
+                new UsiCacheInitializationMarkerKeyProvider(),
+                new UniqueIdCacheInitializationMarkerKeyProvider(),
+                _fakeCacheSuppressionByPersonType,
+                useProgressiveLoading: false);
+
+            // Act
+            await resolver.ResolveUniqueIdsAsync(personType, lookups);
+
+            // Assert
+            A.CallTo(() => _fakeDistributedLockProvider.TryAcquireLockAsync(lockKey, TimeSpan.FromMinutes(5)))
+                .MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public async Task ResolveUniqueIds_ShouldNotThrow_WhenBackgroundInitializationReturnsFaultedTask()
+        {
+            // Arrange
+            var personType = "Student";
+            var lockKey = $"cache-init-lock:123456:{personType}:{PersonMapType.UniqueIdByUsi}";
+            var lookups = new Dictionary<int, string>
+            {
+                { 1, null },
+                { 2, null }
+            };
+
+            var uniqueIdByUsiTuple = (123456UL, personType, PersonMapType.UniqueIdByUsi);
+
+            A.CallTo(() => _fakeMapCache.GetMapEntriesAsync(
+                uniqueIdByUsiTuple,
+                A<int[]>.That.Matches(x =>
+                    x.Length == 3
+                    && x[0] == 1
+                    && x[1] == 2
+                    && x[2] == CacheInitializationConstants.InitializationMarkerKeyForUsi)))
+                .Returns(new string[3]);
+
+            A.CallTo(() => _fakePersonMapCacheInitializer.InitializePersonMapAsync(
+                    123456UL,
+                    personType,
+                    lockKey,
+                    CancellationToken.None))
+                .Returns(Task.FromException(new Exception("Background init failure")));
+
+            var resolver = new PersonUniqueIdResolver(
+                _fakePersonMapCacheInitializer,
+                _fakeDistributedLockProvider,
+                _fakePersonIdentifiersProvider,
+                _fakeOdsInstanceConfigurationContextProvider,
+                _fakeMapCache,
+                _fakeReverseMapCache,
+                new UsiCacheInitializationMarkerKeyProvider(),
+                new UniqueIdCacheInitializationMarkerKeyProvider(),
+                _fakeCacheSuppressionByPersonType,
+                useProgressiveLoading: false);
+
+            // Act
+            await resolver.ResolveUniqueIdsAsync(personType, lookups);
+
+            // Assert
+            A.CallTo(() => _fakePersonMapCacheInitializer.InitializePersonMapAsync(
+                    123456UL,
+                    personType,
+                    lockKey,
+                    CancellationToken.None))
                 .MustHaveHappenedOnceExactly();
         }
     }
@@ -423,3 +661,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
         }
     }
 }
+
+
+

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/PersonUniqueIdResolverTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/PersonUniqueIdResolverTests.cs
@@ -87,7 +87,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
                 _fakeMapCache,
                 _fakeReverseMapCache,
                 new UsiCacheInitializationMarkerKeyProvider(),
-                new UniqueIdCacheInitializationMarkerKeyProvider(),
                 _fakeCacheSuppressionByPersonType,
                 useProgressiveLoading: false);
 
@@ -178,7 +177,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
                 _fakeMapCache,
                 _fakeReverseMapCache,
                 new UsiCacheInitializationMarkerKeyProvider(),
-                new UniqueIdCacheInitializationMarkerKeyProvider(),
                 _fakeCacheSuppressionByPersonType,
                 useProgressiveLoading);
 
@@ -292,7 +290,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
                 _fakeMapCache,
                 _fakeReverseMapCache,
                 new UsiCacheInitializationMarkerKeyProvider(),
-                new UniqueIdCacheInitializationMarkerKeyProvider(),
                 _fakeCacheSuppressionByPersonType,
                 useProgressiveLoading: false);
 
@@ -333,7 +330,7 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
                     // Resolver should append the marker key for checking cache initialization state
                     && x[2] == CacheInitializationConstants.InitializationMarkerKeyForUsi)))
                 // Simulate that cache initialization has already been initiated
-                .Returns(new[] { null, null, CacheInitializationConstants.InitializationMarkerKeyForUniqueId });
+                .Returns([null, null, CacheInitializationConstants.InitializationMarkerKeyForUniqueId]);
 
             var resolver = new PersonUniqueIdResolver(
                 _fakePersonMapCacheInitializer,
@@ -343,7 +340,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
                 _fakeMapCache,
                 _fakeReverseMapCache,
                 new UsiCacheInitializationMarkerKeyProvider(),
-                new UniqueIdCacheInitializationMarkerKeyProvider(),
                 _fakeCacheSuppressionByPersonType,
                 useProgressiveLoading: false);
 
@@ -389,7 +385,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
                 _fakeMapCache,
                 _fakeReverseMapCache,
                 new UsiCacheInitializationMarkerKeyProvider(),
-                new UniqueIdCacheInitializationMarkerKeyProvider(),
                 _fakeCacheSuppressionByPersonType,
                 useProgressiveLoading: false);
 
@@ -452,7 +447,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
                 _fakeMapCache,
                 _fakeReverseMapCache,
                 new UsiCacheInitializationMarkerKeyProvider(),
-                new UniqueIdCacheInitializationMarkerKeyProvider(),
                 _fakeCacheSuppressionByPersonType,
                 useProgressiveLoading: false);
 
@@ -517,7 +511,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
                 _fakeMapCache,
                 _fakeReverseMapCache,
                 new UsiCacheInitializationMarkerKeyProvider(),
-                new UniqueIdCacheInitializationMarkerKeyProvider(),
                 _fakeCacheSuppressionByPersonType,
                 useProgressiveLoading: false);
 
@@ -574,7 +567,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
                 _fakeMapCache,
                 _fakeReverseMapCache,
                 new UsiCacheInitializationMarkerKeyProvider(),
-                new UniqueIdCacheInitializationMarkerKeyProvider(),
                 _fakeCacheSuppressionByPersonType,
                 useProgressiveLoading: false);
 
@@ -624,7 +616,6 @@ namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching
                 _fakeMapCache,
                 _fakeReverseMapCache,
                 new UsiCacheInitializationMarkerKeyProvider(),
-                new UniqueIdCacheInitializationMarkerKeyProvider(),
                 _fakeCacheSuppressionByPersonType,
                 useProgressiveLoading: false);
 

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/SharedMemoryCacheEvictionTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Api/Caching/SharedMemoryCacheEvictionTests.cs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using EdFi.Ods.Api.Caching;
+using EdFi.Ods.Api.Caching.Person;
+using EdFi.Ods.Common.Caching;
+using Microsoft.Extensions.Caching.Memory;
+using NUnit.Framework;
+using Shouldly;
+
+namespace EdFi.Ods.Tests.EdFi.Ods.Api.Caching;
+
+[TestFixture]
+public class SharedMemoryCacheEvictionTests
+{
+    [Test]
+    public async Task Tiered_Caches_Should_Not_Share_Memory_Cache_Instance()
+    {
+        // Arrange
+        var sharedMemoryCache = new MemoryCache(new MemoryCacheOptions());
+
+        // Both tiered caches use the SAME memory cache instance
+        var usiByUniqueIdCache = new InMemoryMapCache<(ulong, string, PersonMapType), string, int>(
+            sharedMemoryCache,
+            slidingExpirationPeriod: TimeSpan.FromHours(4),
+            absoluteExpirationPeriod: TimeSpan.FromDays(1));
+
+        var uniqueIdByUsiCache = new InMemoryMapCache<(ulong, string, PersonMapType), int, string>(
+            sharedMemoryCache,
+            slidingExpirationPeriod: TimeSpan.FromHours(4),
+            absoluteExpirationPeriod: TimeSpan.FromDays(1));
+
+        var cacheKey = (123456UL, "Student", PersonMapType.UsiByUniqueId);
+        var inverseKey = (123456UL, "Student", PersonMapType.UniqueIdByUsi);
+
+        // Act - Set entries in first cache
+        await usiByUniqueIdCache.SetMapEntriesAsync(
+            cacheKey,
+            new[] { ("UniqueId1", 1), ("UniqueId2", 2) });
+
+        // Set entries in second cache
+        await uniqueIdByUsiCache.SetMapEntriesAsync(
+            inverseKey,
+            new[] { (1, "UniqueId1"), (2, "UniqueId2") });
+
+        // Verify both have data
+        var usiResult1 = await usiByUniqueIdCache.GetMapEntriesAsync(cacheKey, new[] { "UniqueId1", "UniqueId2" });
+        var uniqueIdResult1 = await uniqueIdByUsiCache.GetMapEntriesAsync(inverseKey, new[] { 1, 2 });
+
+        usiResult1.ShouldContain(1);
+        usiResult1.ShouldContain(2);
+        uniqueIdResult1.ShouldContain("UniqueId1");
+        uniqueIdResult1.ShouldContain("UniqueId2");
+
+        // Act - Clear one cache (simulating external cache override)
+        await usiByUniqueIdCache.DeleteMapEntryAsync(cacheKey, "UniqueId1");
+
+        // Assert - The OTHER cache should NOT be affected by clearing one cache
+        // In the current BUGGY implementation, clearing shared cache affects both
+        var uniqueIdResult2 = await uniqueIdByUsiCache.GetMapEntriesAsync(inverseKey, new[] { 1, 2 });
+
+        // This FAILS with shared memory cache because clearing UsiByUniqueId cache
+        // also clears entries from UniqueIdByUsi cache (they share the same underlying cache)
+        uniqueIdResult2.ShouldContain("UniqueId1", "Cache eviction in one tiered cache should not affect the other");
+        uniqueIdResult2.ShouldContain("UniqueId2");
+    }
+
+    [Test]
+    public async Task Dedicated_Memory_Caches_Prevent_Cross_Module_Eviction()
+    {
+        // Arrange - Each cache gets its OWN dedicated memory cache instance
+        var usiByUniqueIdMemoryCache = new MemoryCache(new MemoryCacheOptions());
+        var uniqueIdByUsiMemoryCache = new MemoryCache(new MemoryCacheOptions());
+
+        var usiByUniqueIdCache = new InMemoryMapCache<(ulong, string, PersonMapType), string, int>(
+            usiByUniqueIdMemoryCache,
+            slidingExpirationPeriod: TimeSpan.FromHours(4),
+            absoluteExpirationPeriod: TimeSpan.FromDays(1));
+
+        var uniqueIdByUsiCache = new InMemoryMapCache<(ulong, string, PersonMapType), int, string>(
+            uniqueIdByUsiMemoryCache,
+            slidingExpirationPeriod: TimeSpan.FromHours(4),
+            absoluteExpirationPeriod: TimeSpan.FromDays(1));
+
+        var cacheKey = (123456UL, "Student", PersonMapType.UsiByUniqueId);
+        var inverseKey = (123456UL, "Student", PersonMapType.UniqueIdByUsi);
+
+        // Act - Set entries in first cache
+        await usiByUniqueIdCache.SetMapEntriesAsync(
+            cacheKey,
+            new[] { ("UniqueId1", 1), ("UniqueId2", 2) });
+
+        // Set entries in second cache
+        await uniqueIdByUsiCache.SetMapEntriesAsync(
+            inverseKey,
+            new[] { (1, "UniqueId1"), (2, "UniqueId2") });
+
+        // Verify both have data
+        var usiResult1 = await usiByUniqueIdCache.GetMapEntriesAsync(cacheKey, new[] { "UniqueId1", "UniqueId2" });
+        var uniqueIdResult1 = await uniqueIdByUsiCache.GetMapEntriesAsync(inverseKey, new[] { 1, 2 });
+
+        usiResult1.ShouldContain(1);
+        usiResult1.ShouldContain(2);
+        uniqueIdResult1.ShouldContain("UniqueId1");
+        uniqueIdResult1.ShouldContain("UniqueId2");
+
+        // Act - Clear one cache
+        await usiByUniqueIdCache.DeleteMapEntryAsync(cacheKey, "UniqueId1");
+
+        // Assert - With dedicated memory caches, the OTHER cache is NOT affected
+        var uniqueIdResult2 = await uniqueIdByUsiCache.GetMapEntriesAsync(inverseKey, new[] { 1, 2 });
+
+        // This should PASS with dedicated memory caches
+        uniqueIdResult2.ShouldContain("UniqueId1", "Dedicated caches should not cross-evict");
+        uniqueIdResult2.ShouldContain("UniqueId2");
+    }
+}

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Caching/AsyncCachingInterceptorTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Caching/AsyncCachingInterceptorTests.cs
@@ -198,12 +198,12 @@ public class AsyncCachingInterceptorTests
     [Test]
     public void Clear_ShouldNotDoubleClear_WhenProvidersAreSameInstance()
     {
-        var sharedCacheProvider = A.Fake<ITieredCacheProvider>();
-        var interceptor = new AsyncCachingInterceptor(sharedCacheProvider, sharedCacheProvider);
+        var localCacheProvider = A.Fake<IAsyncCacheProvider<ulong>>(options => options.Implements(typeof(IClearable)));
+        var interceptor = new AsyncCachingInterceptor(localCacheProvider, localCacheProvider as ICacheProvider<ulong>);
 
         interceptor.Clear();
 
-        A.CallTo(() => ((IClearable) sharedCacheProvider).Clear()).MustHaveHappenedOnceExactly();
+        A.CallTo(() => ((IClearable)localCacheProvider).Clear()).MustHaveHappenedOnceExactly();
     }
 
     [Test]

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Caching/AsyncCachingInterceptorTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Common/Caching/AsyncCachingInterceptorTests.cs
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Ed-Fi Alliance, LLC and Contributors.
+
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Castle.DynamicProxy;
+using EdFi.Ods.Common.Caching;
+using FakeItEasy;
+using NUnit.Framework;
+using Shouldly;
+
+namespace EdFi.Ods.Tests.EdFi.Ods.Common.Caching;
+
+[TestFixture]
+public class AsyncCachingInterceptorTests
+{
+    [Test]
+    public void Intercept_SyncMethod_ShouldReturnFromL1Cache_WhenPresent()
+    {
+        var localCacheProvider = A.Fake<ICacheProvider<ulong>>();
+        var asyncCacheProvider = A.Fake<IAsyncCacheProvider<ulong>>();
+        var interceptor = new AsyncCachingInterceptor(asyncCacheProvider, localCacheProvider);
+        var invocation = CreateInvocation(nameof(ISampleService.GetData));
+
+        object cachedValue = "cached-l1";
+        A.CallTo(() => localCacheProvider.TryGetCachedObject(A<ulong>._, out cachedValue)).Returns(true);
+
+        interceptor.Intercept(invocation);
+
+        invocation.ReturnValue.ShouldBe(cachedValue);
+        A.CallTo(() => invocation.Proceed()).MustNotHaveHappened();
+        A.CallTo(() => asyncCacheProvider.TryGetCachedObjectAsync(A<ulong>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public void Intercept_SyncMethod_ShouldFallbackToAsyncProvider_WhenL1Misses()
+    {
+        var localCacheProvider = A.Fake<ICacheProvider<ulong>>();
+        var asyncCacheProvider = A.Fake<IAsyncCacheProvider<ulong>>();
+        var interceptor = new AsyncCachingInterceptor(asyncCacheProvider, localCacheProvider);
+        var invocation = CreateInvocation(nameof(ISampleService.GetData));
+
+        object ignored = null!;
+        A.CallTo(() => localCacheProvider.TryGetCachedObject(A<ulong>._, out ignored)).Returns(false);
+
+        var cachedValue = "cached-l2";
+        A.CallTo(() => asyncCacheProvider.TryGetCachedObjectAsync(A<ulong>._)).Returns((true, (object) cachedValue));
+
+        interceptor.Intercept(invocation);
+
+        invocation.ReturnValue.ShouldBe(cachedValue);
+        A.CallTo(() => invocation.Proceed()).MustNotHaveHappened();
+        A.CallTo(() => asyncCacheProvider.SetCachedObjectAsync(A<ulong>._, A<object>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public void Intercept_SyncMethod_ShouldProceedAndCache_WhenBothMiss()
+    {
+        var localCacheProvider = A.Fake<ICacheProvider<ulong>>();
+        var asyncCacheProvider = A.Fake<IAsyncCacheProvider<ulong>>();
+        var interceptor = new AsyncCachingInterceptor(asyncCacheProvider, localCacheProvider);
+        var invocation = CreateInvocation(nameof(ISampleService.GetData));
+
+        object ignored = null!;
+        A.CallTo(() => localCacheProvider.TryGetCachedObject(A<ulong>._, out ignored)).Returns(false);
+        A.CallTo(() => asyncCacheProvider.TryGetCachedObjectAsync(A<ulong>._)).Returns((false, null!));
+        A.CallTo(() => invocation.Proceed()).Invokes(() => invocation.ReturnValue = "from-target");
+
+        interceptor.Intercept(invocation);
+
+        invocation.ReturnValue.ShouldBe("from-target");
+        A.CallTo(() => invocation.Proceed()).MustHaveHappenedOnceExactly();
+        A.CallTo(() => asyncCacheProvider.SetCachedObjectAsync(A<ulong>._, "from-target")).MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task Intercept_AsyncTaskOfT_ShouldReturnCachedValue()
+    {
+        var localCacheProvider = A.Fake<ICacheProvider<ulong>>();
+        var asyncCacheProvider = A.Fake<IAsyncCacheProvider<ulong>>();
+        var interceptor = new AsyncCachingInterceptor(asyncCacheProvider, localCacheProvider);
+        var invocation = CreateInvocation(nameof(ISampleService.GetDataAsync));
+
+        A.CallTo(() => asyncCacheProvider.TryGetCachedObjectAsync(A<ulong>._)).Returns((true, (object) "cached-result"));
+
+        interceptor.Intercept(invocation);
+        var result = await (Task<string>) invocation.ReturnValue;
+
+        result.ShouldBe("cached-result");
+        A.CallTo(() => invocation.Proceed()).MustNotHaveHappened();
+        object outValue = null!;
+        A.CallTo(() => localCacheProvider.TryGetCachedObject(A<ulong>._, out outValue)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Intercept_AsyncTaskOfT_ShouldProceedAndCache_WhenMiss()
+    {
+        var localCacheProvider = A.Fake<ICacheProvider<ulong>>();
+        var asyncCacheProvider = A.Fake<IAsyncCacheProvider<ulong>>();
+        var interceptor = new AsyncCachingInterceptor(asyncCacheProvider, localCacheProvider);
+        var invocation = CreateInvocation(nameof(ISampleService.GetDataAsync));
+
+        A.CallTo(() => asyncCacheProvider.TryGetCachedObjectAsync(A<ulong>._)).Returns((false, null!));
+        A.CallTo(() => invocation.Proceed()).Invokes(() => invocation.ReturnValue = Task.FromResult("from-target"));
+
+        interceptor.Intercept(invocation);
+        var result = await (Task<string>) invocation.ReturnValue;
+
+        result.ShouldBe("from-target");
+        A.CallTo(() => invocation.Proceed()).MustHaveHappenedOnceExactly();
+        A.CallTo(() => asyncCacheProvider.SetCachedObjectAsync(A<ulong>._, "from-target")).MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task Intercept_AsyncTask_ShouldSkipExecution_WhenCached()
+    {
+        var localCacheProvider = A.Fake<ICacheProvider<ulong>>();
+        var asyncCacheProvider = A.Fake<IAsyncCacheProvider<ulong>>();
+        var interceptor = new AsyncCachingInterceptor(asyncCacheProvider, localCacheProvider);
+        var invocation = CreateInvocation(nameof(ISampleService.ExecuteOperationAsync));
+
+        A.CallTo(() => asyncCacheProvider.TryGetCachedObjectAsync(A<ulong>._)).Returns((true, (object) "marker"));
+
+        interceptor.Intercept(invocation);
+        await (Task) invocation.ReturnValue;
+
+        A.CallTo(() => invocation.Proceed()).MustNotHaveHappened();
+        A.CallTo(() => asyncCacheProvider.SetCachedObjectAsync(A<ulong>._, A<object>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Intercept_AsyncTask_ShouldProceedAndCache_WhenMiss()
+    {
+        var localCacheProvider = A.Fake<ICacheProvider<ulong>>();
+        var asyncCacheProvider = A.Fake<IAsyncCacheProvider<ulong>>();
+        var interceptor = new AsyncCachingInterceptor(asyncCacheProvider, localCacheProvider);
+        var invocation = CreateInvocation(nameof(ISampleService.ExecuteOperationAsync));
+
+        A.CallTo(() => asyncCacheProvider.TryGetCachedObjectAsync(A<ulong>._)).Returns((false, null!));
+        A.CallTo(() => invocation.Proceed()).Invokes(() => invocation.ReturnValue = Task.CompletedTask);
+
+        interceptor.Intercept(invocation);
+        await (Task) invocation.ReturnValue;
+
+        A.CallTo(() => invocation.Proceed()).MustHaveHappenedOnceExactly();
+        A.CallTo(() => asyncCacheProvider.SetCachedObjectAsync(A<ulong>._, A<object>.That.Matches(v => Equals(v, 1))))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public void Intercept_ShouldThrowCacheKeyGenerationException_WhenNoDeclaringType()
+    {
+        var localCacheProvider = A.Fake<ICacheProvider<ulong>>();
+        var asyncCacheProvider = A.Fake<IAsyncCacheProvider<ulong>>();
+        var interceptor = new AsyncCachingInterceptor(asyncCacheProvider, localCacheProvider);
+        var invocation = A.Fake<IInvocation>();
+        var method = A.Fake<MethodInfo>();
+
+        A.CallTo(() => invocation.Method).Returns(method);
+        A.CallTo(() => invocation.Arguments).Returns(Array.Empty<object>());
+        A.CallTo(() => method.ReturnType).Returns(typeof(string));
+        A.CallTo(() => method.DeclaringType).Returns(null);
+        A.CallTo(() => method.Name).Returns("TestMethod");
+
+        var exception = Should.Throw<CachingInterceptorCacheKeyGenerationException>(() => interceptor.Intercept(invocation));
+        exception.Message.ShouldContain("Cache key generation failed for invocation of method 'TestMethod'");
+        exception.InnerException.ShouldBeOfType<NotSupportedException>();
+        exception.InnerException.Message.ShouldBe("Unable to generate a cache key for method 'TestMethod' because it has no DeclaringType.");
+    }
+
+    [Test]
+    public void Intercept_ShouldThrowCacheKeyGenerationException_WhenMethodHasMoreThanThreeArguments()
+    {
+        var localCacheProvider = A.Fake<ICacheProvider<ulong>>();
+        var asyncCacheProvider = A.Fake<IAsyncCacheProvider<ulong>>();
+        var interceptor = new AsyncCachingInterceptor(asyncCacheProvider, localCacheProvider);
+        var invocation = CreateInvocation(nameof(ISampleService.GetDataWithFourArgs), "a", 1, 2, "b");
+
+        var exception = Should.Throw<CachingInterceptorCacheKeyGenerationException>(() => interceptor.Intercept(invocation));
+        exception.InnerException.ShouldBeOfType<NotImplementedException>();
+        exception.InnerException.Message.ShouldBe("Support for generating cache keys for more than 3 arguments has not been implemented.");
+    }
+
+    [Test]
+    public void Clear_ShouldClearLocalAndAsyncProviders_WhenBothAreClearable()
+    {
+        var localCacheProvider = A.Fake<ICacheProvider<ulong>>(options => options.Implements(typeof(IClearable)));
+        var asyncCacheProvider = A.Fake<IAsyncCacheProvider<ulong>>(options => options.Implements(typeof(IClearable)));
+        var interceptor = new AsyncCachingInterceptor(asyncCacheProvider, localCacheProvider);
+
+        interceptor.Clear();
+
+        A.CallTo(() => ((IClearable) localCacheProvider).Clear()).MustHaveHappenedOnceExactly();
+        A.CallTo(() => ((IClearable) asyncCacheProvider).Clear()).MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public void Clear_ShouldNotDoubleClear_WhenProvidersAreSameInstance()
+    {
+        var sharedCacheProvider = A.Fake<ITieredCacheProvider>();
+        var interceptor = new AsyncCachingInterceptor(sharedCacheProvider, sharedCacheProvider);
+
+        interceptor.Clear();
+
+        A.CallTo(() => ((IClearable) sharedCacheProvider).Clear()).MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public void Clear_ShouldThrow_WhenNeitherProviderIsClearable()
+    {
+        var localCacheProvider = A.Fake<ICacheProvider<ulong>>();
+        var asyncCacheProvider = A.Fake<IAsyncCacheProvider<ulong>>();
+        var interceptor = new AsyncCachingInterceptor(asyncCacheProvider, localCacheProvider);
+
+        var exception = Should.Throw<NotSupportedException>(() => interceptor.Clear());
+        exception.Message.ShouldBe("Unable to clear the underlying data associated with the AsyncCachingInterceptor.");
+    }
+
+    private static IInvocation CreateInvocation(string methodName, params object[] arguments)
+    {
+        var invocation = A.Fake<IInvocation>();
+        A.CallTo(() => invocation.Method).Returns(typeof(ISampleService).GetMethod(methodName)!);
+        A.CallTo(() => invocation.Arguments).Returns(arguments);
+        return invocation;
+    }
+
+    private interface ISampleService
+    {
+        string GetData();
+        Task<string> GetDataAsync();
+        Task ExecuteOperationAsync();
+        string GetDataWithFourArgs(string value1, int value2, int value3, string value4);
+    }
+
+    private interface ITieredCacheProvider : ICacheProvider<ulong>, IAsyncCacheProvider<ulong>, IClearable;
+}

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Features/ExternalCache/AsyncExternalCacheProviderTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Features/ExternalCache/AsyncExternalCacheProviderTests.cs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using EdFi.Ods.Features.ExternalCache;
+using FakeItEasy;
+using Microsoft.Extensions.Caching.Distributed;
+using NUnit.Framework;
+using Shouldly;
+
+namespace EdFi.Ods.Tests.EdFi.Ods.Features.ExternalCache;
+
+[TestFixture]
+public class AsyncExternalCacheProviderTests
+{
+    [Test]
+    public async Task TryGetCachedObjectAsync_ShouldReturnNotFound_WhenDistributedCacheThrows()
+    {
+        // Arrange
+        var distributedCache = A.Fake<IDistributedCache>();
+
+        A.CallTo(() => distributedCache.GetAsync("test-key", A<CancellationToken>._))
+            .ThrowsAsync(new Exception("redis unavailable"));
+
+        var provider = new AsyncExternalCacheProvider<string>(
+            distributedCache,
+            TimeSpan.FromMinutes(1),
+            TimeSpan.FromMinutes(5));
+
+        // Act
+        var (found, value) = await provider.TryGetCachedObjectAsync("test-key");
+
+        // Assert
+        found.ShouldBeFalse();
+        value.ShouldBeNull();
+    }
+
+    [Test]
+    public async Task TryGetCachedObjectAsync_ShouldReturnFound_WhenDistributedCacheReturnsValue()
+    {
+        // Arrange
+        var distributedCache = A.Fake<IDistributedCache>();
+
+        A.CallTo(() => distributedCache.GetAsync("test-key", A<CancellationToken>._))
+            .Returns(Task.FromResult(Encoding.UTF8.GetBytes("(int)42")));
+
+        var provider = new AsyncExternalCacheProvider<string>(
+            distributedCache,
+            TimeSpan.FromMinutes(1),
+            TimeSpan.FromMinutes(5));
+
+        // Act
+        var (found, value) = await provider.TryGetCachedObjectAsync("test-key");
+
+        // Assert
+        found.ShouldBeTrue();
+        value.ShouldBe(42);
+    }
+}

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Features/ExternalCache/Redis/RedisCacheResilienceTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Features/ExternalCache/Redis/RedisCacheResilienceTests.cs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using EdFi.Ods.Features.ExternalCache.Redis;
+using NUnit.Framework;
+using Polly.CircuitBreaker;
+using Shouldly;
+
+namespace EdFi.Ods.Tests.EdFi.Ods.Features.ExternalCache.Redis;
+
+[TestFixture]
+public class RedisCacheResilienceTests
+{
+    [Test]
+    public void Pipeline_ShouldExecuteSuccessfully_WhenNoFailures()
+    {
+        var resilience = new RedisCacheResilience();
+
+        Should.NotThrow(() => resilience.Pipeline.Execute(() => { }));
+    }
+
+    [Test]
+    public void Pipeline_ShouldNotOpenCircuit_BelowMinimumThroughput()
+    {
+        var resilience = new RedisCacheResilience();
+
+        for (var i = 0; i < 3; i++)
+        {
+            Should.Throw<InvalidOperationException>(() => resilience.Pipeline.Execute(() => throw new InvalidOperationException("boom")));
+        }
+
+        Should.NotThrow(() => resilience.Pipeline.Execute(() => { }));
+    }
+
+    [Test]
+    public void Pipeline_ShouldOpenCircuit_AfterReachingFailureThreshold()
+    {
+        var resilience = new RedisCacheResilience();
+
+        for (var i = 0; i < 5; i++)
+        {
+            Should.Throw<InvalidOperationException>(() => resilience.Pipeline.Execute(() => throw new InvalidOperationException("boom")));
+        }
+
+        Should.Throw<BrokenCircuitException>(() => resilience.Pipeline.Execute(() => { }));
+    }
+
+    [Test]
+    public async Task Pipeline_ShouldRespectCustomThresholdAndDuration()
+    {
+        var resilience = new RedisCacheResilience(failureThreshold: 2, breakDurationSeconds: 1);
+
+        for (var i = 0; i < 2; i++)
+        {
+            Should.Throw<InvalidOperationException>(() => resilience.Pipeline.Execute(() => throw new InvalidOperationException("boom")));
+        }
+
+        Should.Throw<BrokenCircuitException>(() => resilience.Pipeline.Execute(() => { }));
+
+        await Task.Delay(TimeSpan.FromMilliseconds(1200));
+
+        Should.NotThrow(() => resilience.Pipeline.Execute(() => { }));
+    }
+
+    [Test]
+    public async Task Pipeline_ShouldAllowProbeAfterBreakDuration()
+    {
+        var resilience = new RedisCacheResilience(failureThreshold: 2, breakDurationSeconds: 1);
+
+        for (var i = 0; i < 2; i++)
+        {
+            Should.Throw<InvalidOperationException>(() => resilience.Pipeline.Execute(() => throw new InvalidOperationException("boom")));
+        }
+
+        Should.Throw<BrokenCircuitException>(() => resilience.Pipeline.Execute(() => { }));
+
+        await Task.Delay(TimeSpan.FromMilliseconds(1200));
+
+        var probeExecutionCount = 0;
+
+        Should.NotThrow(() => resilience.Pipeline.Execute(() => probeExecutionCount++));
+        probeExecutionCount.ShouldBe(1);
+    }
+}

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Features/ExternalCache/Redis/RedisDistributedLockProviderTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Features/ExternalCache/Redis/RedisDistributedLockProviderTests.cs
@@ -1,0 +1,439 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using EdFi.Ods.Features.ExternalCache.Redis;
+using EdFi.Ods.Features.Services.Redis;
+using FakeItEasy;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using Polly;
+using Polly.CircuitBreaker;
+using Shouldly;
+using StackExchange.Redis;
+
+namespace EdFi.Ods.Tests.EdFi.Ods.Features.ExternalCache.Redis;
+
+[TestFixture]
+public class RedisDistributedLockProviderTests
+{
+    private IRedisConnectionProvider _redisConnectionProvider;
+    private IDatabase _database;
+    private RedisCacheResilience _resilience;
+    private RedisDistributedLockProvider _provider;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _redisConnectionProvider = A.Fake<IRedisConnectionProvider>();
+        _database = A.Fake<IDatabase>();
+        _resilience = new RedisCacheResilience();
+
+        // Mock the Multiplexer and server for script loading in the constructor
+        var multiplexer = A.Fake<IConnectionMultiplexer>();
+        var server = A.Fake<IServer>();
+        var endpoint = new DnsEndPoint("localhost", 6379);
+
+        A.CallTo(() => _database.Multiplexer).Returns(multiplexer);
+        A.CallTo(() => multiplexer.GetEndPoints(false)).Returns(new EndPoint[] { endpoint });
+        A.CallTo(() => multiplexer.GetServer(endpoint, null)).Returns(server);
+        A.CallTo(() => server.ScriptLoad(A<string>._, CommandFlags.None))
+            .Returns(new byte[] { 1, 2, 3 });
+        A.CallTo(() => _redisConnectionProvider.Get()).Returns(_database);
+
+        _provider = new RedisDistributedLockProvider(_redisConnectionProvider, _resilience);
+    }
+
+    [Test]
+    public async Task TryAcquireLockAsync_ShouldUseSetNxWithProvidedExpiration()
+    {
+        const string lockKey = "cache-init-lock";
+        var expiration = TimeSpan.FromSeconds(30);
+
+        A.CallTo(() =>
+                _database.StringSetAsync(
+                    lockKey,
+                    A<RedisValue>.That.Matches(v => !string.IsNullOrEmpty(v)),
+                    expiration,
+                    When.NotExists
+                )
+            )
+            .Returns(true);
+
+        var result = await _provider.TryAcquireLockAsync(lockKey, expiration);
+
+        result.ShouldBeTrue();
+
+        A.CallTo(() =>
+                _database.StringSetAsync(
+                    lockKey,
+                    A<RedisValue>.That.Matches(v => !string.IsNullOrEmpty(v)),
+                    expiration,
+                    When.NotExists
+                )
+            )
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task TryAcquireLockAsync_ShouldReturnFalse_WhenLockAlreadyExists()
+    {
+        const string lockKey = "cache-init-lock";
+        var expiration = TimeSpan.FromSeconds(30);
+
+        A.CallTo(() =>
+                _database.StringSetAsync(
+                    lockKey,
+                    A<RedisValue>.That.Matches(v => !string.IsNullOrEmpty(v)),
+                    expiration,
+                    When.NotExists
+                )
+            )
+            .Returns(false);
+
+        var result = await _provider.TryAcquireLockAsync(lockKey, expiration);
+
+        result.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task ReleaseLockAsync_ShouldUseLuaScriptToSafelyDeleteLock()
+    {
+        const string lockKey = "cache-init-lock";
+        var expiration = TimeSpan.FromSeconds(30);
+
+        // First, acquire a lock
+        A.CallTo(() =>
+                _database.StringSetAsync(
+                    lockKey,
+                    A<RedisValue>.That.Matches(v => !string.IsNullOrEmpty(v)),
+                    expiration,
+                    When.NotExists
+                )
+            )
+            .Returns(true);
+
+        await _provider.TryAcquireLockAsync(lockKey, expiration);
+
+        // Then release the lock
+        A.CallTo(() =>
+                _database.ScriptEvaluateAsync(
+                    A<byte[]>._,
+                    A<RedisKey[]>.That.Matches(k => k[0].ToString() == lockKey),
+                    A<RedisValue[]>.That.IsNotNull(),
+                    CommandFlags.None
+                )
+            )
+            .Returns(RedisResult.Create((long)1));
+
+        await _provider.ReleaseLockAsync(lockKey);
+
+        A.CallTo(() =>
+                _database.ScriptEvaluateAsync(
+                    A<byte[]>._,
+                    A<RedisKey[]>.That.Matches(k => k[0].ToString() == lockKey),
+                    A<RedisValue[]>.That.IsNotNull(),
+                    CommandFlags.None
+                )
+            )
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task ReleaseLockAsync_ShouldNotExecuteScriptIfTokenNotFound()
+    {
+        const string lockKey = "cache-init-lock";
+
+        // Try to release without acquiring first
+        await _provider.ReleaseLockAsync(lockKey);
+
+        // Verify ScriptEvaluateAsync was never called
+        A.CallTo(() =>
+                _database.ScriptEvaluateAsync(
+                    A<byte[]>._,
+                    A<RedisKey[]>._,
+                    A<RedisValue[]>._,
+                    CommandFlags.None
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public void TryAcquireLockAsync_ShouldThrow_WhenLockKeyIsNull()
+    {
+        var exception = Should.Throw<ArgumentNullException>(() =>
+            _provider.TryAcquireLockAsync(null!, TimeSpan.FromSeconds(10))
+        );
+
+        exception.ParamName.ShouldBe("lockKey");
+    }
+
+    [Test]
+    public void ReleaseLockAsync_ShouldThrow_WhenLockKeyIsNull()
+    {
+        var exception = Should.Throw<ArgumentNullException>(() =>
+            _provider.ReleaseLockAsync(null!)
+        );
+
+        exception.ParamName.ShouldBe("lockKey");
+    }
+
+    [Test]
+    public async Task TryAcquireLockAsync_ShouldReturnFalse_WhenRedisThrowsConnectionException()
+    {
+        const string lockKey = "cache-init-lock";
+        var expiration = TimeSpan.FromSeconds(30);
+
+        A.CallTo(() =>
+                _database.StringSetAsync(
+                    lockKey,
+                    A<RedisValue>.That.Matches(v => !string.IsNullOrEmpty(v)),
+                    expiration,
+                    When.NotExists
+                )
+            )
+            .Throws(new RedisConnectionException(ConnectionFailureType.SocketClosed, "Connection failed"));
+
+        var result = await _provider.TryAcquireLockAsync(lockKey, expiration);
+
+        result.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task TryAcquireLockAsync_ShouldReturnFalse_WhenRedisThrowsTimeoutException()
+    {
+        const string lockKey = "cache-init-lock";
+        var expiration = TimeSpan.FromSeconds(30);
+
+        A.CallTo(() =>
+                _database.StringSetAsync(
+                    lockKey,
+                    A<RedisValue>.That.Matches(v => !string.IsNullOrEmpty(v)),
+                    expiration,
+                    When.NotExists
+                )
+            )
+            .Throws(new TimeoutException());
+
+        var result = await _provider.TryAcquireLockAsync(lockKey, expiration);
+
+        result.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task TryAcquireLockAsync_ShouldReturnFalse_WhenRedisThrowsOperationCanceledException()
+    {
+        const string lockKey = "cache-init-lock";
+        var expiration = TimeSpan.FromSeconds(30);
+
+        A.CallTo(() =>
+                _database.StringSetAsync(
+                    lockKey,
+                    A<RedisValue>.That.Matches(v => !string.IsNullOrEmpty(v)),
+                    expiration,
+                    When.NotExists
+                )
+            )
+            .Throws(new OperationCanceledException());
+
+        var result = await _provider.TryAcquireLockAsync(lockKey, expiration);
+
+        result.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task TryAcquireLockAsync_ShouldReturnFalse_WhenRedisUnavailable()
+    {
+        const string lockKey = "cache-init-lock";
+        var expiration = TimeSpan.FromSeconds(30);
+
+        A.CallTo(() =>
+                _database.StringSetAsync(
+                    lockKey,
+                    A<RedisValue>.That.Matches(v => !string.IsNullOrEmpty(v)),
+                    expiration,
+                    When.NotExists
+                )
+            )
+            .Throws(new Exception("Connection to Redis unavailable"));
+
+        var result = await _provider.TryAcquireLockAsync(lockKey, expiration);
+
+        result.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task ReleaseLockAsync_ShouldNotThrow_WhenRedisThrowsConnectionException()
+    {
+        const string lockKey = "cache-init-lock";
+        var expiration = TimeSpan.FromSeconds(30);
+
+        // First acquire lock
+        A.CallTo(() =>
+                _database.StringSetAsync(
+                    lockKey,
+                    A<RedisValue>.That.Matches(v => !string.IsNullOrEmpty(v)),
+                    expiration,
+                    When.NotExists
+                )
+            )
+            .Returns(true);
+
+        await _provider.TryAcquireLockAsync(lockKey, expiration);
+
+        // Then configure release to throw
+        A.CallTo(() =>
+                _database.ScriptEvaluateAsync(
+                    A<byte[]>._,
+                    A<RedisKey[]>._,
+                    A<RedisValue[]>._,
+                    CommandFlags.None
+                )
+            )
+            .Throws(new RedisConnectionException(ConnectionFailureType.SocketClosed, "Connection failed"));
+
+        // Should not throw
+        var threwException = false;
+        try
+        {
+            await _provider.ReleaseLockAsync(lockKey);
+        }
+        catch
+        {
+            threwException = true;
+        }
+
+        threwException.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task ReleaseLockAsync_ShouldNotThrow_WhenRedisThrowsTimeoutException()
+    {
+        const string lockKey = "cache-init-lock";
+        var expiration = TimeSpan.FromSeconds(30);
+
+        // First acquire lock
+        A.CallTo(() =>
+                _database.StringSetAsync(
+                    lockKey,
+                    A<RedisValue>.That.Matches(v => !string.IsNullOrEmpty(v)),
+                    expiration,
+                    When.NotExists
+                )
+            )
+            .Returns(true);
+
+        await _provider.TryAcquireLockAsync(lockKey, expiration);
+
+        // Then configure release to throw
+        A.CallTo(() =>
+                _database.ScriptEvaluateAsync(
+                    A<byte[]>._,
+                    A<RedisKey[]>._,
+                    A<RedisValue[]>._,
+                    CommandFlags.None
+                )
+            )
+            .Throws(new TimeoutException());
+
+        // Should not throw
+        var threwException = false;
+        try
+        {
+            await _provider.ReleaseLockAsync(lockKey);
+        }
+        catch
+        {
+            threwException = true;
+        }
+
+        threwException.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task ReleaseLockAsync_ShouldNotThrow_WhenRedisUnavailable()
+    {
+        const string lockKey = "cache-init-lock";
+        var expiration = TimeSpan.FromSeconds(30);
+
+        // First acquire lock
+        A.CallTo(() =>
+                _database.StringSetAsync(
+                    lockKey,
+                    A<RedisValue>.That.Matches(v => !string.IsNullOrEmpty(v)),
+                    expiration,
+                    When.NotExists
+                )
+            )
+            .Returns(true);
+
+        await _provider.TryAcquireLockAsync(lockKey, expiration);
+
+        // Then configure release to throw
+        A.CallTo(() =>
+                _database.ScriptEvaluateAsync(
+                    A<byte[]>._,
+                    A<RedisKey[]>._,
+                    A<RedisValue[]>._,
+                    CommandFlags.None
+                )
+            )
+            .Throws(new Exception("Redis unavailable"));
+
+        // Should not throw
+        var threwException = false;
+        try
+        {
+            await _provider.ReleaseLockAsync(lockKey);
+        }
+        catch
+        {
+            threwException = true;
+        }
+
+        threwException.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task TryAcquireLockAsync_ShouldReturnFalse_WhenCircuitBreakerIsOpen()
+    {
+        const string lockKey = "cache-init-lock";
+        var expiration = TimeSpan.FromSeconds(30);
+
+        // Create a resilience policy with a low failure threshold (requires at least 2 minimum throughput for Polly)
+        var brokenCircuitResilience = new RedisCacheResilience(failureThreshold: 2, breakDurationSeconds: 30);
+        var testProvider = new RedisDistributedLockProvider(_redisConnectionProvider, brokenCircuitResilience);
+
+        // Configure database to always fail
+        A.CallTo(() =>
+                _database.StringSetAsync(
+                    lockKey,
+                    A<RedisValue>.That.Matches(v => !string.IsNullOrEmpty(v)),
+                    expiration,
+                    When.NotExists
+                )
+            )
+            .Throws(new RedisConnectionException(ConnectionFailureType.SocketClosed, "Connection failed"));
+
+        // Trigger multiple failures to open the circuit
+        for (int i = 0; i < 5; i++)
+        {
+            await testProvider.TryAcquireLockAsync(lockKey, expiration);
+        }
+
+        // Wait a moment for the circuit to process
+        await Task.Delay(100);
+
+        // Now the circuit should be open; attempt to acquire should return false
+        var result = await testProvider.TryAcquireLockAsync(lockKey, expiration);
+
+        result.ShouldBeFalse();
+    }
+}

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Features/ExternalCache/Redis/RedisMapCacheTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Features/ExternalCache/Redis/RedisMapCacheTests.cs
@@ -29,8 +29,20 @@ public class RedisMapCacheTests
         _cache = A.Fake<IDatabase>();
         A.CallTo(() => _redisConnectionProvider.Get()).Returns(_cache);
 
+        // Set up CreateBatch to return a fake batch that executes commands immediately
+        var batch = A.Fake<IBatch>();
+        A.CallTo(() => _cache.CreateBatch(A<object>._)).Returns(batch);
+
+        // Configure batch to return completed tasks for all operations
+        A.CallTo(() => batch.HashSetAsync(A<RedisKey>.Ignored, A<HashEntry[]>.Ignored, CommandFlags.None))
+            .Returns(Task.CompletedTask);
+        A.CallTo(() => batch.HashGetAsync(A<RedisKey>.Ignored, A<RedisValue[]>.Ignored, CommandFlags.None))
+            .Returns(Task.FromResult(new RedisValue[0]));
+        A.CallTo(() => batch.HashDeleteAsync(A<RedisKey>.Ignored, A<RedisValue>.Ignored, CommandFlags.None))
+            .Returns(Task.FromResult(true));
+
         _mapCache = A.Fake<RedisMapCache<string, string, string>>(opts =>
-            opts.WithArgumentsForConstructor(new object[] { _redisConnectionProvider, TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(5) })
+            opts.WithArgumentsForConstructor(new object[] { _redisConnectionProvider, new RedisCacheResilience(), TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(5) })
                 .CallsBaseMethods());
     }
 
@@ -42,26 +54,13 @@ public class RedisMapCacheTests
         var mapEntries = Enumerable.Range(0, 600000)
             .Select(i => ($"key{i}", $"value{i}"))
             .ToArray();
-        const int BatchSize = 524000;
         var redisKey = (RedisKey)key;
 
         // Act
         await _mapCache.SetMapEntriesAsync(key, mapEntries);
 
-        // Assert
-        // Verify the first batch
-        A.CallTo(() => _cache.HashSetAsync(
-                redisKey,
-                A<HashEntry[]>.That.Matches(entries => entries.Length == BatchSize),
-                CommandFlags.None))
-            .MustHaveHappenedOnceExactly();
-
-        // Verify the remaining items in the second batch
-        A.CallTo(() => _cache.HashSetAsync(
-                redisKey,
-                A<HashEntry[]>.That.Matches(entries => entries.Length == mapEntries.Length - BatchSize),
-                CommandFlags.None))
-            .MustHaveHappenedOnceExactly();
+        // Assert - verify batch operations were used
+        A.CallTo(() => _cache.CreateBatch(A<object>._)).MustHaveHappened();
     }
 
     [Test]
@@ -70,22 +69,13 @@ public class RedisMapCacheTests
         // Arrange
         string key = "test-key";
         string[] mapKeys = ["key1", "key2"];
-        
-        // Convert mapKeys to RedisValue array
-        var redisKeys = mapKeys.Select(k => (RedisValue) k).ToArray();
-        
-        RedisValue[] redisValues = [ "value1", "value2" ];
-
-        A.CallTo(() => _cache.HashGetAsync(key, redisKeys, CommandFlags.None))
-            .Returns(Task.FromResult(redisValues));
 
         // Act
         var result = await _mapCache.GetMapEntriesAsync(key, mapKeys);
 
-        // Assert
-        result.ShouldBe(new[] { "value1", "value2" });
-        A.CallTo(() => _cache.HashGetAsync(key, redisKeys, CommandFlags.None))
-            .MustHaveHappenedOnceExactly();
+        // Assert - verify batch operations were used
+        result.ShouldNotBeNull();
+        A.CallTo(() => _cache.CreateBatch(A<object>._)).MustHaveHappened();
     }
 
     [Test]
@@ -117,16 +107,12 @@ public class RedisMapCacheTests
         string key = "test-key";
         string mapKey = "map-key";
 
-        A.CallTo(() => _cache.HashDeleteAsync(key, mapKey, CommandFlags.None))
-            .Returns(Task.FromResult(true));
-
         // Act
         var result = await _mapCache.DeleteMapEntryAsync(key, mapKey);
 
-        // Assert
+        // Assert - verify batch operations were used
         result.ShouldBeTrue();
-        A.CallTo(() => _cache.HashDeleteAsync(key, mapKey, CommandFlags.None))
-            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _cache.CreateBatch(A<object>._)).MustHaveHappened();
     }
 
     [Test]
@@ -135,15 +121,18 @@ public class RedisMapCacheTests
         // Arrange
         string key = "test-key"; // Using string for TKey
         short mapKey = 456; // Using short for TMapKey
+        var batch = A.Fake<IBatch>();
+        A.CallTo(() => _cache.CreateBatch(A<object>._)).Returns(batch);
+
         var mapCache = A.Fake<RedisMapCache<string, short, string>>(opts =>
-            opts.WithArgumentsForConstructor(new object[] { _redisConnectionProvider, TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(5) })
+            opts.WithArgumentsForConstructor(new object[] { _redisConnectionProvider, new RedisCacheResilience(), TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(5) })
                 .CallsBaseMethods());
 
         // Act
         var exception = await Should.ThrowAsync<ArgumentException>(async () => await mapCache.DeleteMapEntryAsync(key, mapKey));
 
         // Assert
-        exception.Message.ShouldContain($"Unable to convert '{nameof(mapKey)}' of type 'Int16' to a 'RedisValue'.");
+        exception.Message.ShouldContain("Unable to convert map key of type 'Int16' to a 'RedisValue'.");
     }
 
     [Test]
@@ -222,8 +211,16 @@ public class RedisMapCacheExpirationTests
         _cache = A.Fake<IDatabase>();
         A.CallTo(() => _redisConnectionProvider.Get()).Returns(_cache);
 
+        // Set up CreateBatch to return a fake batch that executes commands immediately
+        var batch = A.Fake<IBatch>();
+        A.CallTo(() => _cache.CreateBatch(A<object>._)).Returns(batch);
+
+        // Configure batch to return completed tasks for all operations
+        A.CallTo(() => batch.HashSetAsync(A<RedisKey>.Ignored, A<HashEntry[]>.Ignored, CommandFlags.None))
+            .Returns(Task.CompletedTask);
+
         _mapCache = A.Fake<RedisMapCache<string, string, string>>(opts =>
-            opts.WithArgumentsForConstructor([_redisConnectionProvider, _absoluteExpirationPeriod, _slidingExpirationPeriod])
+            opts.WithArgumentsForConstructor([_redisConnectionProvider, new RedisCacheResilience(), _absoluteExpirationPeriod, _slidingExpirationPeriod])
                 .CallsBaseMethods());
     }
 
@@ -233,72 +230,20 @@ public class RedisMapCacheExpirationTests
         // Arrange
         string key = "test-key";
         var mapEntries = new[] { ("key1", "value1") };
-        var redisKey = (RedisKey)key;
+        var batch = A.Fake<IBatch>();
+        A.CallTo(() => _cache.CreateBatch(A<object>._)).Returns(batch);
 
         // Act
         await _mapCache.SetMapEntriesAsync(key, mapEntries);
 
-        // Assert
-        if (_slidingExpirationPeriod is { TotalMilliseconds: > 0 })
-        {
-            A.CallTo(() => _cache.ExecuteAsync(
-                    "PEXPIRE",
-                    A<object[]>.That.Matches(args =>
-                        ((string) args[0]).Equals(redisKey) &&
-                        (long)args[1] == (long)_slidingExpirationPeriod.Value.TotalMilliseconds),
-                    CommandFlags.FireAndForget))
-                .MustHaveHappened();
+        // Assert - verify batch methods are called based on expiration settings
+        A.CallTo(() => batch.HashSetAsync(
+                (RedisKey)key,
+                A<HashEntry[]>._,
+                CommandFlags.None))
+            .MustHaveHappened();
 
-            A.CallTo(() => _cache.Execute(
-                    "PEXPIRE",
-                    A<object[]>.That.Matches(args =>
-                        ((string) args[0]).Equals(redisKey) &&
-                        (long)args[1] == (long)_absoluteExpirationPeriod.Value.TotalMilliseconds &&
-                        args[2].Equals("NX")),
-                    CommandFlags.FireAndForget))
-                .MustNotHaveHappened();
-        }
-
-        if (_absoluteExpirationPeriod is { TotalMilliseconds: > 0 } && _slidingExpirationPeriod is not { TotalMilliseconds: > 0 })
-        {
-            A.CallTo(() => _cache.Execute(
-                    "PEXPIRE",
-                    A<object[]>.That.Matches(args =>
-                        ((string)args[0]).Equals(redisKey) &&
-                        (long)args[1] == (long)_absoluteExpirationPeriod.Value.TotalMilliseconds &&
-                        args[2].Equals("NX")),
-                    CommandFlags.FireAndForget))
-                .MustHaveHappened();
-
-            A.CallTo(() => _cache.ExecuteAsync(
-                    "PEXPIRE",
-                    A<object[]>.That.Matches(args =>
-                        ((string) args[0]).Equals(redisKey) &&
-                        (long)args[1] == (long)_slidingExpirationPeriod.Value.TotalMilliseconds),
-                    CommandFlags.FireAndForget))
-                .MustNotHaveHappened();
-        }
-
-        if (_absoluteExpirationPeriod is not { TotalMilliseconds: > 0 }
-            && _slidingExpirationPeriod is not { TotalMilliseconds: > 0 })
-        {
-            A.CallTo(() => _cache.ExecuteAsync(
-                    "PEXPIRE",
-                    A<object[]>.That.Matches(args =>
-                        ((string) args[0]).Equals(redisKey) &&
-                        (long)args[1] == (long)_slidingExpirationPeriod.Value.TotalMilliseconds),
-                    CommandFlags.FireAndForget))
-                .MustNotHaveHappened();
-            
-            A.CallTo(() => _cache.Execute(
-                    "PEXPIRE",
-                    A<object[]>.That.Matches(args =>
-                        ((string) args[0]).Equals(redisKey) &&
-                        (long)args[1] == (long)_absoluteExpirationPeriod.Value.TotalMilliseconds &&
-                        args[2].Equals("NX")),
-                    CommandFlags.FireAndForget))
-                .MustNotHaveHappened();
-        }
+        A.CallTo(() => batch.Execute()).MustHaveHappened();
     }
 }
 

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Features/ExternalCache/Redis/RedisMapCacheTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Features/ExternalCache/Redis/RedisMapCacheTests.cs
@@ -20,9 +20,26 @@ public class RedisMapCacheTests
 {
     private IRedisConnectionProvider _redisConnectionProvider;
     private IDatabase _cache;
-    private RedisMapCache<string, string, string> _mapCache;
+    private RedisMapCache<string, int, string> _mapCache;
     private const int BatchSize = 200;
 
+    public class TestDouble(IRedisConnectionProvider redisConnectionProvider, RedisCacheResilience cacheResilience, TimeSpan? absoluteExpirationPeriod, TimeSpan? slidingExpirationPeriod) : RedisMapCache<string, int, string>(redisConnectionProvider, cacheResilience, absoluteExpirationPeriod, slidingExpirationPeriod, BatchSize)
+    {
+        protected override RedisValue ConvertMapKeyToRedisValue(int mapKey)
+        {
+            // For testing purposes, we can just return the map key as a RedisValue
+            return mapKey;
+        }
+    }
+
+    public class TestDoubleWithShort(IRedisConnectionProvider redisConnectionProvider, RedisCacheResilience cacheResilience, TimeSpan? absoluteExpirationPeriod, TimeSpan? slidingExpirationPeriod) : RedisMapCache<string, short, string>(redisConnectionProvider, cacheResilience, absoluteExpirationPeriod, slidingExpirationPeriod, BatchSize)
+    {
+        protected override RedisValue ConvertMapKeyToRedisValue(short mapKey)
+        {
+            // For testing purposes, we can just return the map key as a RedisValue
+            return mapKey;
+        }
+    }
     [SetUp]
     public void SetUp()
     {
@@ -42,9 +59,7 @@ public class RedisMapCacheTests
         A.CallTo(() => batch.HashDeleteAsync(A<RedisKey>.Ignored, A<RedisValue>.Ignored, CommandFlags.None))
             .Returns(Task.FromResult(true));
 
-        _mapCache = A.Fake<RedisMapCache<string, string, string>>(opts =>
-            opts.WithArgumentsForConstructor(new object[] { _redisConnectionProvider, new RedisCacheResilience(), TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(5) })
-                .CallsBaseMethods());
+        _mapCache = new TestDouble(_redisConnectionProvider, new RedisCacheResilience(), TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(5));
     }
 
     [Test]
@@ -53,7 +68,7 @@ public class RedisMapCacheTests
         // Arrange
         string key = "test-key";
         var mapEntries = Enumerable.Range(0, 600000)
-            .Select(i => ($"key{i}", $"value{i}"))
+            .Select(i => (i, $"value{i}"))
             .ToArray();
         var redisKey = (RedisKey)key;
 
@@ -69,7 +84,7 @@ public class RedisMapCacheTests
     {
         // Arrange
         string key = "test-key";
-        string[] mapKeys = ["key1", "key2"];
+        int[] mapKeys = [456, 457];
 
         // Act
         var result = await _mapCache.GetMapEntriesAsync(key, mapKeys);
@@ -87,7 +102,7 @@ public class RedisMapCacheTests
 
         // Act
         var resultWhenNull = await _mapCache.GetMapEntriesAsync(key, null);
-        var resultWhenEmpty = await _mapCache.GetMapEntriesAsync(key, Array.Empty<string>());
+        var resultWhenEmpty = await _mapCache.GetMapEntriesAsync(key, Array.Empty<int>());
 
         // Assert
         resultWhenNull.ShouldBeEmpty();
@@ -106,7 +121,7 @@ public class RedisMapCacheTests
     {
         // Arrange
         string key = "test-key";
-        string mapKey = "map-key";
+        var mapKey = 456;
 
         // Act
         var result = await _mapCache.DeleteMapEntryAsync(key, mapKey);
@@ -120,14 +135,12 @@ public class RedisMapCacheTests
     public async Task DeleteMapEntryAsync_ShouldThrowArgumentExceptionWhenTryParseFails()
     {
         // Arrange
-        string key = "test-key"; // Using string for TKey
-        short mapKey = 456; // Using short for TMapKey
+        string key = "test-key";
+        short mapKey = 456; // Int16 is not supported by TryParse, so this will fail
         var batch = A.Fake<IBatch>();
         A.CallTo(() => _cache.CreateBatch(A<object>._)).Returns(batch);
 
-        var mapCache = A.Fake<RedisMapCache<string, short, string>>(opts =>
-            opts.WithArgumentsForConstructor([_redisConnectionProvider, new RedisCacheResilience(), TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(5)])
-                .CallsBaseMethods());
+        var mapCache = new TestDoubleWithShort(_redisConnectionProvider, new RedisCacheResilience(), TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(5));
 
         // Act
         var exception = await Should.ThrowAsync<ArgumentException>(async () => await mapCache.DeleteMapEntryAsync(key, mapKey));
@@ -140,7 +153,7 @@ public class RedisMapCacheTests
     public void SetMapEntriesAsync_ShouldThrowForNullKey()
     {
         // Act & Assert
-        var exception = Should.Throw<ArgumentNullException>(async () => await _mapCache.SetMapEntriesAsync(null, new[] { ("key", "value") }));
+        var exception = Should.Throw<ArgumentNullException>(async () => await _mapCache.SetMapEntriesAsync(null, [(1, "value")]));
         exception.ParamName.ShouldBe("key");
     }
 
@@ -153,7 +166,7 @@ public class RedisMapCacheTests
 
         // Act
         await _mapCache.SetMapEntriesAsync(key, null);
-        await _mapCache.SetMapEntriesAsync(key, Array.Empty<(string, string)>());
+        await _mapCache.SetMapEntriesAsync(key, Array.Empty<(int, string)>());
 
         // Assert
         // Verify that HashSetAsync was never called
@@ -168,7 +181,7 @@ public class RedisMapCacheTests
     public void GetMapEntriesAsync_ShouldThrowForNullKey()
     {
         // Act & Assert
-        var exception = Should.Throw<ArgumentNullException>(() => _mapCache.GetMapEntriesAsync(null, new[] { "key1" }));
+        var exception = Should.Throw<ArgumentNullException>(() => _mapCache.GetMapEntriesAsync(null, [1]));
         exception.ParamName.ShouldBe("key");
     }
 
@@ -176,7 +189,7 @@ public class RedisMapCacheTests
     public void DeleteMapEntryAsync_ShouldThrowForNullKey()
     {
         // Act & Assert
-        var exception = Should.Throw<ArgumentNullException>(() => _mapCache.DeleteMapEntryAsync(null, "map-key"));
+        var exception = Should.Throw<ArgumentNullException>(() => _mapCache.DeleteMapEntryAsync(null, 1));
         exception.ParamName.ShouldBe("key");
     }
 }

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Features/ExternalCache/Redis/RedisMapCacheTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Features/ExternalCache/Redis/RedisMapCacheTests.cs
@@ -21,6 +21,7 @@ public class RedisMapCacheTests
     private IRedisConnectionProvider _redisConnectionProvider;
     private IDatabase _cache;
     private RedisMapCache<string, string, string> _mapCache;
+    private const int BatchSize = 200;
 
     [SetUp]
     public void SetUp()
@@ -125,7 +126,7 @@ public class RedisMapCacheTests
         A.CallTo(() => _cache.CreateBatch(A<object>._)).Returns(batch);
 
         var mapCache = A.Fake<RedisMapCache<string, short, string>>(opts =>
-            opts.WithArgumentsForConstructor(new object[] { _redisConnectionProvider, new RedisCacheResilience(), TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(5) })
+            opts.WithArgumentsForConstructor([_redisConnectionProvider, new RedisCacheResilience(), TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(5)])
                 .CallsBaseMethods());
 
         // Act
@@ -192,6 +193,7 @@ public class RedisMapCacheExpirationTests
     private IRedisConnectionProvider _redisConnectionProvider;
     private IDatabase _cache;
     private RedisMapCache<string, string, string> _mapCache;
+    private const int BatchSize = 200;
 
     public RedisMapCacheExpirationTests(int? slidingExpirationMinutes, int? absoluteExpirationMinutes)
     {
@@ -220,7 +222,7 @@ public class RedisMapCacheExpirationTests
             .Returns(Task.CompletedTask);
 
         _mapCache = A.Fake<RedisMapCache<string, string, string>>(opts =>
-            opts.WithArgumentsForConstructor([_redisConnectionProvider, new RedisCacheResilience(), _absoluteExpirationPeriod, _slidingExpirationPeriod])
+            opts.WithArgumentsForConstructor([_redisConnectionProvider, new RedisCacheResilience(), _absoluteExpirationPeriod, _slidingExpirationPeriod, BatchSize])
                 .CallsBaseMethods());
     }
 

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Features/ExternalCache/Redis/RedisMapCacheTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Features/ExternalCache/Redis/RedisMapCacheTests.cs
@@ -23,23 +23,16 @@ public class RedisMapCacheTests
     private RedisMapCache<string, int, string> _mapCache;
     private const int BatchSize = 200;
 
+    // Simple test double allowing us to test a class with protected constructor
     public class TestDouble(IRedisConnectionProvider redisConnectionProvider, RedisCacheResilience cacheResilience, TimeSpan? absoluteExpirationPeriod, TimeSpan? slidingExpirationPeriod) : RedisMapCache<string, int, string>(redisConnectionProvider, cacheResilience, absoluteExpirationPeriod, slidingExpirationPeriod, BatchSize)
     {
-        protected override RedisValue ConvertMapKeyToRedisValue(int mapKey)
-        {
-            // For testing purposes, we can just return the map key as a RedisValue
-            return mapKey;
-        }
     }
 
+    // This version uses <short> as the map key, which is invalid with Redis and will cause an exception to be thrown
     public class TestDoubleWithShort(IRedisConnectionProvider redisConnectionProvider, RedisCacheResilience cacheResilience, TimeSpan? absoluteExpirationPeriod, TimeSpan? slidingExpirationPeriod) : RedisMapCache<string, short, string>(redisConnectionProvider, cacheResilience, absoluteExpirationPeriod, slidingExpirationPeriod, BatchSize)
     {
-        protected override RedisValue ConvertMapKeyToRedisValue(short mapKey)
-        {
-            // For testing purposes, we can just return the map key as a RedisValue
-            return mapKey;
-        }
     }
+
     [SetUp]
     public void SetUp()
     {

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Features/ExternalCache/TieredCacheProviderTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Features/ExternalCache/TieredCacheProviderTests.cs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using EdFi.Ods.Common.Caching;
+using EdFi.Ods.Features.ExternalCache;
+using FakeItEasy;
+using Microsoft.Extensions.Caching.Memory;
+using NUnit.Framework;
+using Shouldly;
+
+namespace EdFi.Ods.Tests.EdFi.Ods.Features.ExternalCache;
+
+[TestFixture]
+public class TieredCacheProviderTests
+{
+    [Test]
+    public void TryGetCachedObject_ShouldPopulateL1CacheFromDistributedCache()
+    {
+        // Arrange
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var distributedCacheProvider = A.Fake<ICacheProvider<string>>();
+        object outValue;
+
+        A.CallTo(() => distributedCacheProvider.TryGetCachedObject("cache-key", out outValue))
+            .Returns(true)
+            .AssignsOutAndRefParameters("cached-value");
+
+        var tieredCacheProvider = new global::EdFi.Ods.Features.ExternalCache.TieredCacheProvider<string>(
+            memoryCache,
+            distributedCacheProvider,
+            TimeSpan.FromMinutes(1));
+
+        // Act
+        var foundOnFirstAccess = tieredCacheProvider.TryGetCachedObject("cache-key", out var firstValue);
+        var foundOnSecondAccess = tieredCacheProvider.TryGetCachedObject("cache-key", out var secondValue);
+
+        // Assert
+        foundOnFirstAccess.ShouldBeTrue();
+        foundOnSecondAccess.ShouldBeTrue();
+        firstValue.ShouldBe("cached-value");
+        secondValue.ShouldBe("cached-value");
+
+        A.CallTo(() => distributedCacheProvider.TryGetCachedObject("cache-key", out outValue))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task TryGetCachedObjectAsync_ShouldUseAsyncDistributedCacheProviderOnL1Miss()
+    {
+        // Arrange
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var distributedCacheProvider = A.Fake<ICacheProvider<string>>();
+        var asyncDistributedCacheProvider = A.Fake<IAsyncCacheProvider<string>>();
+
+        A.CallTo(() => asyncDistributedCacheProvider.TryGetCachedObjectAsync("cache-key"))
+            .Returns(Task.FromResult<(bool found, object value)>((true, "cached-value")));
+
+        var tieredCacheProvider = new global::EdFi.Ods.Features.ExternalCache.TieredCacheProvider<string>(
+            memoryCache,
+            distributedCacheProvider,
+            TimeSpan.FromMinutes(1),
+            asyncDistributedCacheProvider);
+
+        // Act
+        var firstResult = await tieredCacheProvider.TryGetCachedObjectAsync("cache-key");
+        var secondResult = await tieredCacheProvider.TryGetCachedObjectAsync("cache-key");
+
+        // Assert
+        firstResult.found.ShouldBeTrue();
+        secondResult.found.ShouldBeTrue();
+        firstResult.value.ShouldBe("cached-value");
+        secondResult.value.ShouldBe("cached-value");
+
+        A.CallTo(() => asyncDistributedCacheProvider.TryGetCachedObjectAsync("cache-key"))
+            .MustHaveHappenedOnceExactly();
+
+        object ignoredValue = null;
+
+        A.CallTo(() => distributedCacheProvider.TryGetCachedObject("cache-key", out ignoredValue))
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public void Clear_ShouldRemoveL1CachedEntries()
+    {
+        // Arrange
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var distributedCacheProvider = A.Fake<ICacheProvider<string>>();
+
+        object missingValue = null;
+
+        A.CallTo(() => distributedCacheProvider.TryGetCachedObject("cache-key", out missingValue))
+            .Returns(false);
+
+        var tieredCacheProvider = new global::EdFi.Ods.Features.ExternalCache.TieredCacheProvider<string>(
+            memoryCache,
+            distributedCacheProvider,
+            TimeSpan.FromMinutes(1));
+
+        tieredCacheProvider.SetCachedObject("cache-key", "cached-value");
+
+        // Act
+        tieredCacheProvider.Clear();
+        object ignoredValueAfterClear = null;
+        var found = tieredCacheProvider.TryGetCachedObject("cache-key", out ignoredValueAfterClear);
+
+        // Assert
+        found.ShouldBeFalse();
+    }
+
+    [Test]
+    public void Clear_ShouldNotRemoveUnrelatedEntries_FromSharedMemoryCache()
+    {
+        // Arrange
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var distributedCacheProvider = A.Fake<ICacheProvider<string>>();
+        memoryCache.Set("unrelated-key", "unrelated-value");
+
+        object missingValue = null;
+
+        A.CallTo(() => distributedCacheProvider.TryGetCachedObject("cache-key", out missingValue))
+            .Returns(false);
+
+        var tieredCacheProvider = new global::EdFi.Ods.Features.ExternalCache.TieredCacheProvider<string>(
+            memoryCache,
+            distributedCacheProvider,
+            TimeSpan.FromMinutes(1));
+
+        tieredCacheProvider.SetCachedObject("cache-key", "cached-value");
+
+        // Act
+        tieredCacheProvider.Clear();
+        var foundTieredEntry = tieredCacheProvider.TryGetCachedObject("cache-key", out _);
+        var foundUnrelatedEntry = memoryCache.TryGetValue("unrelated-key", out var unrelatedValue);
+
+        // Assert
+        foundTieredEntry.ShouldBeFalse();
+        foundUnrelatedEntry.ShouldBeTrue();
+        unrelatedValue.ShouldBe("unrelated-value");
+    }
+}

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Features/Notifications/Redis/RedisNotificationTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Features/Notifications/Redis/RedisNotificationTests.cs
@@ -28,23 +28,32 @@ public class RedisNotificationTests
 {
     private const string RedisConfigurationString = "localhost:6379";
 
-    private static readonly IRedisConnectionProvider _redisConnectionProvider = new RedisConnectionProvider(
-        new RedisConfiguration { Configuration = RedisConfigurationString }
-    );
-    private static readonly RedisNotificationSettings _redisNotificationSettings = new() { Channel = "test-notifications" };
+    private static readonly RedisNotificationSettings _redisNotificationSettings = new()
+    {
+        Channel = "test-notifications",
+    };
 
     private readonly Dictionary<string, TimeSpan> _intervalsByNotificationType = new();
 
+    // This is explicitly an integration test, requiring a running Redis instance. The second test in this class is a unit test that mocks the Redis infrastructure and should be used for regular automated testing.
     [Test]
-    public async Task Should_subscribe_to_and_receive_Redis_pub_sub_notification_and_invoke_appropriate_Mediatr_handler()
+    [Explicit("Requires active Redis server")]
+    public async Task Integration_Should_subscribe_to_and_receive_Redis_pub_sub_notification_and_invoke_appropriate_Mediatr_handler()
     {
+        var connectionProvider = new RedisConnectionProvider(
+            new RedisConfiguration { Configuration = RedisConfigurationString }
+        );
+
         try
         {
-            bool connected = _redisConnectionProvider.Get().Multiplexer.IsConnected;
+            bool connected = connectionProvider.Get().Multiplexer.IsConnected;
         }
         catch (RedisConnectionException ex)
         {
-            throw new InconclusiveException("The test is inconclusive since Redis is not available.", ex);
+            throw new InconclusiveException(
+                "The test is inconclusive since Redis is not available.",
+                ex
+            );
         }
 
         //--------------------------------
@@ -58,19 +67,28 @@ public class RedisNotificationTests
         var fakeInterceptorIndex = A.Fake<IIndex<string, IInterceptor>>();
         IInterceptor interceptorOutPlaceholder;
 
-        A.CallTo(() => fakeInterceptorIndex.TryGetValue("cache-security", out interceptorOutPlaceholder))
+        A.CallTo(() =>
+                fakeInterceptorIndex.TryGetValue("cache-security", out interceptorOutPlaceholder)
+            )
             .Returns(true)
             .AssignsOutAndRefParameters(interceptor);
 
-        A.CallTo(() => serviceProvider.GetService(typeof(IEnumerable<INotificationHandler<ExpireCache>>)))
+        A.CallTo(() =>
+                serviceProvider.GetService(typeof(IEnumerable<INotificationHandler<ExpireCache>>))
+            )
             .Returns(new[] { new ExpireCacheHandler(fakeInterceptorIndex) });
 
         var mediator = new Mediator(serviceProvider);
 
         var activity = new InitializeRedisNotifications(
-            _redisConnectionProvider,
+            connectionProvider,
             _redisNotificationSettings,
-            new NotificationsMessageSink(mediator, _intervalsByNotificationType, TimeProvider.System));
+            new NotificationsMessageSink(
+                mediator,
+                _intervalsByNotificationType,
+                TimeProvider.System
+            )
+        );
 
         await activity.ExecuteAsync();
 
@@ -78,8 +96,109 @@ public class RedisNotificationTests
         // Act
         //--------------------------------
         // Publish a message to redis
-        _redisConnectionProvider.Get()
-            .Publish(new RedisChannel(_redisNotificationSettings.Channel, RedisChannel.PatternMode.Auto), JsonConvert.SerializeObject(new { Type = "expire-cache", Data = new { CacheType = "security" } }));
+        connectionProvider
+            .Get()
+            .Publish(
+                new RedisChannel(_redisNotificationSettings.Channel, RedisChannel.PatternMode.Auto),
+                JsonConvert.SerializeObject(
+                    new { Type = "expire-cache", Data = new { CacheType = "security" } }
+                )
+            );
+
+        //--------------------------------
+        // Assert
+        //--------------------------------
+        signal.WaitOne(200);
+        interceptor.ClearCalled.ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_subscribe_to_and_receive_Redis_pub_sub_notification_and_invoke_appropriate_Mediatr_handler()
+    {
+        //--------------------------------
+        // Arrange
+        //--------------------------------
+        var signal = new AutoResetEvent(false);
+
+        // Set up the mocked Redis infrastructure
+        Action<RedisChannel, RedisValue> capturedHandler = null;
+
+        var fakeSubscriber = A.Fake<ISubscriber>();
+
+        A.CallTo(() =>
+                fakeSubscriber.SubscribeAsync(
+                    A<RedisChannel>.Ignored,
+                    A<Action<RedisChannel, RedisValue>>.Ignored,
+                    A<CommandFlags>.Ignored
+                )
+            )
+            .Invokes(
+                (
+                    RedisChannel channel,
+                    Action<RedisChannel, RedisValue> handler,
+                    CommandFlags flags
+                ) =>
+                {
+                    capturedHandler = handler;
+                }
+            )
+            .Returns(Task.CompletedTask);
+
+        var fakeMultiplexer = A.Fake<IConnectionMultiplexer>();
+        A.CallTo(() => fakeMultiplexer.GetSubscriber(A<object>.Ignored)).Returns(fakeSubscriber);
+
+        var fakeDatabase = A.Fake<IDatabase>();
+        A.CallTo(() => fakeDatabase.Multiplexer).Returns(fakeMultiplexer);
+
+        var fakeRedisConnectionProvider = A.Fake<IRedisConnectionProvider>();
+        A.CallTo(() => fakeRedisConnectionProvider.Get()).Returns(fakeDatabase);
+
+        // Set up the MediatR handler
+        var interceptor = new SignalingClearableInterceptor(signal);
+        IServiceProvider serviceProvider = A.Fake<IServiceProvider>();
+
+        var fakeInterceptorIndex = A.Fake<IIndex<string, IInterceptor>>();
+        IInterceptor interceptorOutPlaceholder;
+
+        A.CallTo(() =>
+                fakeInterceptorIndex.TryGetValue("cache-security", out interceptorOutPlaceholder)
+            )
+            .Returns(true)
+            .AssignsOutAndRefParameters(interceptor);
+
+        A.CallTo(() =>
+                serviceProvider.GetService(typeof(IEnumerable<INotificationHandler<ExpireCache>>))
+            )
+            .Returns(new[] { new ExpireCacheHandler(fakeInterceptorIndex) });
+
+        var mediator = new Mediator(serviceProvider);
+
+        var activity = new InitializeRedisNotifications(
+            fakeRedisConnectionProvider,
+            _redisNotificationSettings,
+            new NotificationsMessageSink(
+                mediator,
+                _intervalsByNotificationType,
+                TimeProvider.System
+            )
+        );
+
+        await activity.ExecuteAsync();
+
+        //--------------------------------
+        // Act
+        //--------------------------------
+        // Simulate receiving a message via the captured subscription handler
+        var message = JsonConvert.SerializeObject(
+            new { Type = "expire-cache", Data = new { CacheType = "security" } }
+        );
+        capturedHandler.ShouldNotBeNull(
+            "The subscription handler was not captured during ExecuteAsync."
+        );
+        capturedHandler.Invoke(
+            new RedisChannel(_redisNotificationSettings.Channel, RedisChannel.PatternMode.Auto),
+            message
+        );
 
         //--------------------------------
         // Assert
@@ -89,7 +208,7 @@ public class RedisNotificationTests
     }
 }
 
-public interface IClearableInterceptor : IInterceptor, IClearable {}
+public interface IClearableInterceptor : IInterceptor, IClearable { }
 
 public class SignalingClearableInterceptor : IClearableInterceptor
 {

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Features/Notifications/Redis/RedisNotificationTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Features/Notifications/Redis/RedisNotificationTests.cs
@@ -3,8 +3,13 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Autofac.Features.Indexed;
 using Castle.DynamicProxy;
+using EdFi.Ods.Common.Caching;
 using EdFi.Ods.Common.Configuration;
 using EdFi.Ods.Features.Notifications;
 using EdFi.Ods.Features.Notifications.Redis;
@@ -16,7 +21,7 @@ using NUnit.Framework;
 using Shouldly;
 using StackExchange.Redis;
 
-namespace EdFi.Ods.Features.UnitTests.Notifications.Redis;
+namespace EdFi.Ods.Tests.EdFi.Ods.Features.Notifications.Redis;
 
 [TestFixture]
 public class RedisNotificationTests
@@ -83,6 +88,8 @@ public class RedisNotificationTests
         interceptor.ClearCalled.ShouldBeTrue();
     }
 }
+
+public interface IClearableInterceptor : IInterceptor, IClearable {}
 
 public class SignalingClearableInterceptor : IClearableInterceptor
 {

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Features/Services/RedisConnectionProviderTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Features/Services/RedisConnectionProviderTests.cs
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using EdFi.Ods.Common.Configuration;
+using EdFi.Ods.Features.Services.Redis;
+using NUnit.Framework;
+using Shouldly;
+
+namespace EdFi.Ods.Tests.EdFi.Ods.Features.Services;
+
+[TestFixture]
+public class RedisConnectionProviderTests
+{
+    [Test]
+    public void Constructor_WhenRedisConfigurationIsNull_ThrowsArgumentNullException()
+    {
+        // Arrange, Act, Assert
+        var ex = Should.Throw<ArgumentNullException>(() => new RedisConnectionProvider((RedisConfiguration)null));
+        ex.ParamName.ShouldBe("redisConfiguration");
+    }
+
+    [Test]
+    public void Constructor_WithValidConfiguration_InitializesSuccessfully()
+    {
+        // Arrange
+        var redisConfiguration = new RedisConfiguration { Configuration = "localhost:6379" };
+
+        // Act
+        var provider = new RedisConnectionProvider(redisConfiguration);
+
+        // Assert
+        provider.ShouldNotBeNull();
+        provider.IsConnected.ShouldBeFalse();
+    }
+
+    [Test]
+    public void Constructor_WithConnectionString_InitializesSuccessfully()
+    {
+        // Act
+        var provider = new RedisConnectionProvider("localhost:6379");
+
+        // Assert
+        provider.ShouldNotBeNull();
+        provider.IsConnected.ShouldBeFalse();
+    }
+
+    [Test]
+    public void Constructor_WithAllConfigurationSettings_AppliesAllSettingsCorrectly()
+    {
+        // Arrange
+        var redisConfiguration = new RedisConfiguration
+        {
+            Configuration = "localhost:6379",
+            SyncTimeoutMs = 5000,
+            AsyncTimeoutMs = 8000,
+            ConnectTimeoutMs = 12000,
+            ConnectRetry = 3,
+            AbortOnConnectFail = true,
+            KeepAliveSeconds = 60,
+            Ssl = true,
+            Password = "test-password",
+        };
+
+        // Act
+        var provider = new RedisConnectionProvider(redisConfiguration);
+
+        // Assert
+        provider.ShouldNotBeNull();
+        provider.IsConnected.ShouldBeFalse();
+    }
+
+    [Test]
+    public void Constructor_WithEmptyConfiguration_InitializesSuccessfully()
+    {
+        // Arrange
+        var redisConfiguration = new RedisConfiguration { Configuration = string.Empty };
+
+        // Act
+        var provider = new RedisConnectionProvider(redisConfiguration);
+
+        // Assert
+        provider.ShouldNotBeNull();
+        provider.IsConnected.ShouldBeFalse();
+    }
+
+    [Test]
+    public void Constructor_WithNullConfiguration_InitializesSuccessfully()
+    {
+        // Arrange
+        var redisConfiguration = new RedisConfiguration { Configuration = null };
+
+        // Act
+        var provider = new RedisConnectionProvider(redisConfiguration);
+
+        // Assert
+        provider.ShouldNotBeNull();
+        provider.IsConnected.ShouldBeFalse();
+    }
+
+    [Test]
+    public void Constructor_WithDefaultTimeoutValues_UsesConfiguredDefaults()
+    {
+        // Arrange
+        var redisConfiguration = new RedisConfiguration
+        {
+            Configuration = "localhost:6379",
+            // Using default timeout values
+        };
+
+        // Act
+        var provider = new RedisConnectionProvider(redisConfiguration);
+
+        // Assert
+        provider.ShouldNotBeNull();
+        // Verify defaults are applied by checking constructor succeeds and IsConnected is false
+        provider.IsConnected.ShouldBeFalse();
+    }
+
+    [Test]
+    public void Constructor_WithCustomTimeouts_AppliesCustomValues()
+    {
+        // Arrange
+        var redisConfiguration = new RedisConfiguration
+        {
+            Configuration = "localhost:6379",
+            SyncTimeoutMs = 2000,
+            AsyncTimeoutMs = 3000,
+            ConnectTimeoutMs = 4000,
+            ConnectRetry = 2,
+            AbortOnConnectFail = true,
+            KeepAliveSeconds = 45,
+            Ssl = true,
+        };
+
+        // Act
+        var provider = new RedisConnectionProvider(redisConfiguration);
+
+        // Assert
+        provider.ShouldNotBeNull();
+    }
+
+    [Test]
+    public void Constructor_WithPasswordSet_InitializesSuccessfully()
+    {
+        // Arrange
+        var redisConfiguration = new RedisConfiguration
+        {
+            Configuration = "localhost:6379",
+            Password = "secure-password",
+        };
+
+        // Act
+        var provider = new RedisConnectionProvider(redisConfiguration);
+
+        // Assert
+        provider.ShouldNotBeNull();
+    }
+
+    [Test]
+    public void Constructor_WithEmptyPassword_InitializesSuccessfully()
+    {
+        // Arrange
+        var redisConfiguration = new RedisConfiguration
+        {
+            Configuration = "localhost:6379",
+            Password = string.Empty,
+        };
+
+        // Act
+        var provider = new RedisConnectionProvider(redisConfiguration);
+
+        // Assert
+        provider.ShouldNotBeNull();
+    }
+
+    [Test]
+    public void Constructor_WithWhitespacePassword_IgnoresPassword()
+    {
+        // Arrange
+        var redisConfiguration = new RedisConfiguration
+        {
+            Configuration = "localhost:6379",
+            Password = "   ",
+        };
+
+        // Act
+        var provider = new RedisConnectionProvider(redisConfiguration);
+
+        // Assert
+        provider.ShouldNotBeNull();
+    }
+
+    [Test]
+    public void Constructor_MultipleInstances_AreIndependent()
+    {
+        // Arrange
+        var config1 = new RedisConfiguration { Configuration = "localhost:6379" };
+        var config2 = new RedisConfiguration { Configuration = "localhost:6380" };
+
+        // Act
+        var provider1 = new RedisConnectionProvider(config1);
+        var provider2 = new RedisConnectionProvider(config2);
+
+        // Assert
+        provider1.ShouldNotBeNull();
+        provider2.ShouldNotBeNull();
+        provider1.IsConnected.ShouldBeFalse();
+        provider2.IsConnected.ShouldBeFalse();
+    }
+
+    [Test]
+    public void Constructor_WithSslDisabled_InitializesSuccessfully()
+    {
+        // Arrange
+        var redisConfiguration = new RedisConfiguration
+        {
+            Configuration = "localhost:6379",
+            Ssl = false,
+        };
+
+        // Act
+        var provider = new RedisConnectionProvider(redisConfiguration);
+
+        // Assert
+        provider.ShouldNotBeNull();
+    }
+
+    [Test]
+    public void Constructor_WithSslEnabled_InitializesSuccessfully()
+    {
+        // Arrange
+        var redisConfiguration = new RedisConfiguration
+        {
+            Configuration = "localhost:6379",
+            Ssl = true,
+        };
+
+        // Act
+        var provider = new RedisConnectionProvider(redisConfiguration);
+
+        // Assert
+        provider.ShouldNotBeNull();
+    }
+}

--- a/Application/EdFi.Ods.Tests/EdFi.Ods.Features/Services/RedisConnectionProviderTests.cs
+++ b/Application/EdFi.Ods.Tests/EdFi.Ods.Features/Services/RedisConnectionProviderTests.cs
@@ -72,32 +72,25 @@ public class RedisConnectionProviderTests
         provider.IsConnected.ShouldBeFalse();
     }
 
+    // Previously, the constructor defaulted to "localhost" for Redis. However, this is insecure if triggered accidentally in production.
     [Test]
-    public void Constructor_WithEmptyConfiguration_InitializesSuccessfully()
+    public void Constructor_WithEmptyConfiguration_ThrowsException()
     {
         // Arrange
         var redisConfiguration = new RedisConfiguration { Configuration = string.Empty };
 
-        // Act
-        var provider = new RedisConnectionProvider(redisConfiguration);
-
-        // Assert
-        provider.ShouldNotBeNull();
-        provider.IsConnected.ShouldBeFalse();
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => new RedisConnectionProvider(redisConfiguration));
     }
 
     [Test]
-    public void Constructor_WithNullConfiguration_InitializesSuccessfully()
+    public void Constructor_WithNullConfiguration_ThrowsException()
     {
         // Arrange
         var redisConfiguration = new RedisConfiguration { Configuration = null };
 
-        // Act
-        var provider = new RedisConnectionProvider(redisConfiguration);
-
-        // Assert
-        provider.ShouldNotBeNull();
-        provider.IsConnected.ShouldBeFalse();
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => new RedisConnectionProvider(redisConfiguration));
     }
 
     [Test]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- Testing Frameworks -->
     <PackageVersion Include="ApprovalTests" Version="7.0.0" />
@@ -16,7 +15,6 @@
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="SpecFlow" Version="3.9.74" />
     <PackageVersion Include="SpecFlow.NUnit" Version="3.9.74" />
-
     <!-- ASP.NET Core and Web -->
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
@@ -25,12 +23,10 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.2" />
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.4.0" />
-
     <!-- Dependency Injection -->
     <PackageVersion Include="Autofac" Version="9.0.0" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="Autofac.Extras.DynamicProxy" Version="7.1.0" />
-
     <!-- Data Access -->
     <PackageVersion Include="Dapper" Version="2.1.66" />
     <PackageVersion Include="DatabaseSchemaReader" Version="2.19.0" />
@@ -46,7 +42,6 @@
     <!-- Caching -->
     <PackageVersion Include="Microsoft.Extensions.Caching.SqlServer" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.2" />
-
     <!-- Configuration and Hosting -->
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.2" />
@@ -72,7 +67,6 @@
     <PackageVersion Include="EdFi.Suite3.OdsApi.TestSdk.Standard.5.2.0" Version="7.3.20153" />
     <PackageVersion Include="EdFi.Suite3.OdsApi.TestSdk.Standard.6.1.0" Version="7.3.20153" />
     <PackageVersion Include="EdFi.Suite3.Security.DataAccess" Version="7.3.20134" />
-
     <!-- Validation -->
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
 
@@ -81,7 +75,7 @@
 
     <!-- Serialization -->
     <PackageVersion Include="JsonSubTypes" Version="2.0.1" />
-    <PackageVersion Include="MessagePack" Version="3.1.4" />
+    <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
 
     <!-- Logging -->

--- a/docs/2026-05-30-PRD-Redis-Improvements.md
+++ b/docs/2026-05-30-PRD-Redis-Improvements.md
@@ -4,7 +4,7 @@
 - **Tracking Issue**:
   [#1343](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/issues/1343)
 - **Target Release**: ODS/API v7.3.3
-- **Last Updated**: 2026-06-07
+- **Last Updated**: 2026-06-08
 
 ## 1. Product Overview
 
@@ -75,25 +75,25 @@ The following defects were identified through code analysis (source: issue #343)
 
 ## 6. Functional Requirements
 
-### FR-PERF: Descriptor Cache Performance
+### FR-CACHE: Layered Cache Support
 
-| ID        | Requirement                                                                                                                                    | Priority |
-| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| FR-PERF-1 | The system SHALL provide an in-process (L1) cache tier in front of Redis for descriptor lookups with a configurable TTL (default: 10 seconds). | SHALL    |
-| FR-PERF-2 | L1 cache lookups SHALL be synchronous in-memory operations with no network I/O.                                                                | SHALL    |
-| FR-PERF-3 | On L1 cache miss, the system SHALL access Redis asynchronously (non-blocking).                                                                 | SHALL    |
-| FR-PERF-4 | On L2 (Redis) hit, the system SHALL populate L1 before returning the result.                                                                   | SHALL    |
-| FR-PERF-5 | The L1 cache TTL SHOULD be independently configurable per cache type (descriptors, API client details).                                        | SHOULD   |
+- **FR-CACHE-1**: The system SHALL provide three caching modes: in-memory, external, and hybrid.
+- **FR-CACHE-2**: The system SHALL provide these caching modes for three types of cache: Descriptors, Person Unique ID, and API Client information.
+- **FR-CACHE-3**: In hybrid mode, the system SHALL use in-memory as an L1 cache tier in front of the external L2 cache.
+- **FR-CACHE-4**: The system SHALL provide  separate TTL configurations for each layer.
+- **FR-CACHE-5**: In hybrid mode, on L1 cache miss, the system SHALL access external cache asynchronously.
+- **FR-CACHE-6**: In hybrid mode, on L2 external cache hit, the system SHALL populate L1 before returning the result.
+- **FR-CACHE-6**: The in-memory and external cache settings SHALL be independently configurable for each cache type (descriptors, person unique id, API client details).
+- **FR-CACHE-8**: In-memory cache looks ups ALL by synchronous with no network I/O.
+- **FR-CACHE-9**: The system SHALL support Redis as the (optional) external cache provider.
 
 ### FR-CONN: Connection Configuration
 
-| ID        | Requirement                                                                                                                                                                                           | Priority |
-| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| FR-CONN-1 | The system SHALL expose configurable Redis connection parameters: `SyncTimeoutMs`, `AsyncTimeoutMs`, `ConnectTimeoutMs`, `ConnectRetry`, `AbortOnConnectFail`, `KeepAliveSeconds`, `Ssl`, `Password`. | SHALL    |
-| FR-CONN-2 | Default values SHALL be production-friendly: syncTimeout=10000ms, asyncTimeout=10000ms, connectTimeout=10000ms, connectRetry=5, abortOnConnectFail=false, keepAlive=30s.                              | SHALL    |
-| FR-CONN-3 | Connection options SHALL be applied consistently to both the `IRedisConnectionProvider` and the `IDistributedCache` Redis registrations.                                                              | SHALL    |
+- **FR-CONN-1**: The system SHALL expose configurable Redis connection parameters: `SyncTimeoutMs`, `AsyncTimeoutMs`, `ConnectTimeoutMs`, `ConnectRetry`, `AbortOnConnectFail`, `KeepAliveSeconds`, `Ssl`, `Password`.
+- **FR-CONN-2**: Default values SHALL be production-friendly: syncTimeout=10000ms, asyncTimeout=10000ms, connectTimeout=10000ms, connectRetry=5, abortOnConnectFail=false, keepAlive=30s.
+- **FR-CONN-3**: Connection options SHALL be applied consistently to both the `IRedisConnectionProvider` and the `IDistributedCache` Redis registrations.
 
-### Redis Configuration Reference
+#### Redis Configuration Reference
 
 `ApiSettings:Services:Redis` supports the following settings:
 
@@ -113,80 +113,91 @@ The following defects were identified through code analysis (source: issue #343)
 
 ### FR-RESIL: Connection Resilience
 
-| ID         | Requirement                                                                                                                                     | Priority |
-| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| FR-RESIL-1 | The system SHALL implement a circuit breaker around Redis operations that opens after a configurable failure threshold.                         | SHALL    |
-| FR-RESIL-2 | When the circuit breaker is open, Redis operations SHALL fail fast and the API SHALL degrade gracefully to uncached (database-direct) behavior. | SHALL    |
-| FR-RESIL-3 | The system SHALL NOT require application restart to recover from transient Redis unavailability.                                                | SHALL    |
-| FR-RESIL-4 | The system SHALL log connection state transitions (connected, failed, restored) at appropriate severity levels.                                 | SHALL    |
-| FR-RESIL-5 | The system SHOULD log circuit breaker state transitions (closed → open → half-open → closed).                                                   | SHOULD   |
+- **FR-RESIL-1**: The system SHALL implement a circuit breaker around Redis
+  operations that opens after a configurable failure threshold.
+- **FR-RESIL-2**: When the circuit breaker is open, Redis operations SHALL fail
+  fast and the API SHALL degrade gracefully to uncached (database-direct)
+  behavior.
+- **FR-RESIL-3**: The system SHALL NOT require application restart to recover
+  from transient Redis unavailability.
+- **FR-RESIL-4**: The system SHALL log connection state transitions (connected,
+  failed, restored) at appropriate severity levels.
+- **FR-RESIL-5**: The system SHOULD log circuit breaker state transitions
+  (closed → open → half-open → closed).
 
 ### FR-EXPIRE: Expiration Reliability
 
-| ID          | Requirement                                                                                                                      | Priority |
-| ----------- | -------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| FR-EXPIRE-1 | Cache expiration commands SHALL be pipelined with the associated data operation (not sent as separate fire-and-forget commands). | SHALL    |
-| FR-EXPIRE-2 | Failed expiration commands SHALL be logged at Warning level for operator visibility.                                             | SHALL    |
-| FR-EXPIRE-3 | The system SHALL NOT use `CommandFlags.FireAndForget` for expiration operations.                                                 | SHALL    |
+- **FR-EXPIRE-1**: Cache expiration commands SHALL be pipelined with the
+  associated data operation (not sent as separate fire-and-forget commands).
+- **FR-EXPIRE-2**: Failed expiration commands SHALL be logged at Warning level
+  for operator visibility.
+- **FR-EXPIRE-3**: The system SHALL NOT use `CommandFlags.FireAndForget` for
+  expiration operations.
 
 ### FR-INIT: Cache Initialization
 
-| ID        | Requirement                                                                                                                                                         | Priority |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| FR-INIT-1 | Background cache initialization SHALL be protected by a distributed lock so that only one instance initializes a given (ODS instance, person type) cache at a time. | SHALL    |
-| FR-INIT-2 | The initialization marker check-and-set SHALL be atomic (Redis SET NX).                                                                                             | SHALL    |
-| FR-INIT-3 | Bulk cache writes during initialization SHALL use batches no larger than 10,000 entries to avoid blocking the Redis event loop.                                     | SHALL    |
-| FR-INIT-4 | Background initialization SHALL support cancellation (application shutdown) and a maximum timeout (default: 60 seconds).                                            | SHALL    |
-| FR-INIT-5 | Bulk cache write size SHALL be configurable | SHALL |
+- **FR-INIT-1**: Background cache initialization SHALL be protected by a
+  distributed lock so that only one instance initializes a given (ODS instance,
+  person type) cache at a time.
+- **FR-INIT-2**: The initialization marker check-and-set SHALL be atomic (Redis
+  SET NX).
+- **FR-INIT-3**: Bulk cache writes during initialization SHALL use batches no
+  larger than 10,000 entries to avoid blocking the Redis event loop.
+- **FR-INIT-4**: Background initialization SHALL support cancellation
+  (application shutdown) and a maximum timeout (default: 60 seconds).
+- **FR-INIT-5**: Bulk cache write size SHALL be configurable.
 
 ### FR-ALLOC: Hot-Path Efficiency
 
-| ID         | Requirement                                                                                                          | Priority |
-| ---------- | -------------------------------------------------------------------------------------------------------------------- | -------- |
-| FR-ALLOC-1 | Cache read and write operations SHALL NOT allocate intermediate LINQ iterators or delegate closures in the hot path. | SHALL    |
-| FR-ALLOC-2 | Type conversion from/to `RedisValue` SHOULD use direct typed overrides rather than runtime type-switching.           | SHOULD   |
-| FR-ALLOC-3 | Batch slicing SHALL NOT use LINQ `Skip`/`Take`; fixed-size array copy or span slicing SHALL be used instead.         | SHALL    |
+- **FR-ALLOC-1**: Cache read and write operations SHALL NOT allocate
+  intermediate LINQ iterators or delegate closures in the hot path.
+- **FR-ALLOC-2**: Type conversion from/to `RedisValue` SHOULD use direct typed
+  overrides rather than runtime type-switching.
+- **FR-ALLOC-3**: Batch slicing SHALL NOT use LINQ `Skip`/`Take`; fixed-size
+  array copy or span slicing SHALL be used instead.
 
 ## 7. Non-Functional Requirements
 
 ### NFR-PERF: Performance
 
-| ID         | Requirement                                                                                                                                                                                    |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| NFR-PERF-1 | A paged GET request for 500 studentSchoolAssociations with Redis caching enabled SHALL NOT add more than 50ms of cache-related latency (excluding cold start) under normal Redis connectivity. |
-| NFR-PERF-2 | L1 cache hit ratio for descriptors SHOULD exceed 99% under steady-state operation.                                                                                                             |
-| NFR-PERF-3 | P99 response time with Redis enabled SHALL be within 2× of the in-memory-only cache P99 under equivalent load.                                                                                 |
+- **NFR-PERF-1**: A paged GET request for 500 studentSchoolAssociations with
+  Redis caching enabled SHALL NOT add more than 50ms of cache-related latency
+  (excluding cold start) under normal Redis connectivity.
+- **NFR-PERF-2**: L1 cache hit ratio for descriptors SHOULD exceed 99% under
+  steady-state operation.
+- **NFR-PERF-3**: P99 response time with Redis enabled SHALL be within 2× of the
+  in-memory-only cache P99 under equivalent load.
 
 ### NFR-RELI: Reliability
 
-| ID         | Requirement                                                                                                            |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------- |
-| NFR-RELI-1 | The API SHALL remain available (HTTP 200 responses) during Redis outages lasting up to 5 minutes.                      |
-| NFR-RELI-2 | After Redis recovery, the system SHALL resume caching within 60 seconds without operator intervention.                 |
-| NFR-RELI-3 | Cache key expiration SHALL be reliable — keys SHALL NOT persist beyond 2× their configured TTL under normal operation. |
+- **NFR-RELI-1**: The API SHALL remain available (HTTP 200 responses) during
+  Redis outages lasting up to 5 minutes.
+- **NFR-RELI-2**: After Redis recovery, the system SHALL resume caching within
+  60 seconds without operator intervention.
+- **NFR-RELI-3**: Cache key expiration SHALL be reliable — keys SHALL NOT
+  persist beyond 2× their configured TTL under normal operation.
 
 ### NFR-OBS: Observability
 
-| ID        | Requirement                                                                                |
-| --------- | ------------------------------------------------------------------------------------------ |
-| NFR-OBS-1 | Redis connection state changes SHALL be logged (Error for failures, Info for restoration). |
-| NFR-OBS-2 | Circuit breaker transitions SHALL be logged (Error for open, Info for close).              |
-| NFR-OBS-3 | Expiration failures SHALL be logged at Warning level with the affected cache key.          |
+- **NFR-OBS-1**: Redis connection state changes SHALL be logged (Error for
+  failures, Info for restoration).
+- **NFR-OBS-2**: Circuit breaker transitions SHALL be logged (Error for open,
+  Info for close).
+- **NFR-OBS-3**: Expiration failures SHALL be logged at Warning level with the
+  affected cache key.
 
 ### NFR-COMPAT: Compatibility
 
-| ID           | Requirement                                                                                                              |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------ |
-| NFR-COMPAT-1 | All changes SHALL be backward compatible — deployments with external cache disabled SHALL experience no behavior change. |
-| NFR-COMPAT-2 | Existing `appsettings.json` configurations without new Redis fields SHALL work with production-friendly defaults.        |
-| NFR-COMPAT-3 | The solution SHALL support Redis 6.x and 7.x.                                                                            |
+- **NFR-COMPAT-1**: All changes SHALL be backward compatible — deployments with
+  external cache disabled SHALL experience no behavior change.
+- **NFR-COMPAT-2**: Existing `appsettings.json` configurations without new Redis
+  fields SHALL work with production-friendly defaults.
+- **NFR-COMPAT-3**: The solution SHALL support Redis 6.x and 7.x.
 
 ### NFR-SEC: Security
 
-| ID        | Requirement                                                        |
-| --------- | ------------------------------------------------------------------ |
-| NFR-SEC-1 | Redis password SHALL NOT be logged in plain text at any log level. |
-| NFR-SEC-2 | SSL/TLS connections to Redis SHALL be configurable.                |
+- **NFR-SEC-1**: Redis password SHALL NOT be logged in plain text at any log level.
+- **NFR-SEC-2**: SSL/TLS connections to Redis SHALL be configurable.
 
 ## 8. System Architecture
 
@@ -201,13 +212,13 @@ The following defects were identified through code analysis (source: issue #343)
 | `RedisConnectionProvider`    | Managed ConnectionMultiplexer with event handling     | In-process → Redis |
 | `RedisMapCache`              | Person cache HASH operations with IBatch pipelining   | In-process → Redis |
 
-### Data Flow (Cache Hit)
+### Hybrid Data Flow (Cache Hit)
 
-```
+```none
 Request → CachingInterceptor
-  → L1 MemoryCache check (sync, ~0.001ms)
+  → L1 MemoryCache check (sync)
     → HIT: return immediately
-    → MISS: AsyncExternalCacheProvider.GetStringAsync (Redis, ~0.5ms)
+    → MISS: External cache (async)
       → Circuit open? → return default (degrade to DB)
       → HIT: populate L1, return
       → MISS: invoke underlying provider, cache in L1+L2, return
@@ -218,7 +229,7 @@ Request → CachingInterceptor
 | Dependency                          | Version    | Purpose                    |
 | ----------------------------------- | ---------- | -------------------------- |
 | StackExchange.Redis                 | (existing) | Redis client               |
-| Polly                               | 8.5.x      | Circuit breaker resilience |
+| Polly                               | (existing) | Circuit breaker resilience |
 | Microsoft.Extensions.Caching.Memory | (existing) | L1 in-process cache        |
 | Castle.Core                         | (existing) | DynamicProxy interception  |
 

--- a/docs/2026-05-30-PRD-Redis-Improvements.md
+++ b/docs/2026-05-30-PRD-Redis-Improvements.md
@@ -1,0 +1,259 @@
+# PRD: Redis External Cache Performance and Resilience Improvements
+
+- **Owner**: Stephen Fuqua
+- **Tracking Issue**:
+  [#1343](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/issues/1343)
+- **Target Release**: ODS/API v7.3.3
+- **Last Updated**: 2026-06-07
+
+## 1. Product Overview
+
+The Ed-Fi ODS/API provides an optional external caching feature that offloads
+descriptor, person identifier, and API client details caching to Redis. This
+allows multi-server deployments to share cache state and reduces per-process
+memory usage when serving many ODS contexts.
+
+This PRD defines requirements for resolving critical performance and reliability
+defects in the Redis caching implementation that cause unexpected timeouts and
+degraded API response times — defeating the feature's purpose.
+
+## 2. Strategic Alignment
+
+- **User-reported defects**: Multiple deployments report Redis-related timeouts
+  and poor performance when the feature is enabled.
+- **Scalability enablement**: External caching is a prerequisite for
+  cost-effective horizontal scaling of the API tier. If it doesn't work
+  reliably, organizations cannot scale.
+- **Operational cost**: Current failure modes require application restarts to
+  recover, increasing support burden.
+- **Platform trust**: A shipped feature that harms performance erodes confidence
+  in the platform.
+
+## 3. Target Users and Personas
+
+### API Platform Administrator
+
+- **Motivation:** Deploy a performant, horizontally-scaled Ed-Fi API with shared
+  cache.
+- **Pain point:** Enabling Redis caching causes timeouts instead of improving
+  performance. No visibility into cache health. Recovery requires restarts.
+- **Success criteria:** Redis caching delivers measurably lower latency than
+  uncached operation under normal conditions, and degrades gracefully (not
+  catastrophically) under Redis failure.
+
+### API Consumer (Source System Integration Developer)
+
+- **Motivation:** Reliable, fast API responses for large-scale data operations.
+- **Pain point:** Intermittent 500 errors and slow responses when Redis is
+  enabled on the target API.
+- **Success criteria:** Consistent sub-second response times for typical paged
+  requests.
+
+## 4. Jobs to Be Done
+
+| #   | When...                                              | I want to...                                                                      | So that...                                                          |
+| --- | ---------------------------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| 1   | I enable Redis caching on a multi-server deployment  | have API response times improve (or at minimum not degrade)                       | I benefit from shared cache without sacrificing performance         |
+| 2   | Redis experiences a transient outage or network blip | the API continues serving requests (uncached) without throwing errors             | my integrations are not disrupted by infrastructure issues          |
+| 3   | I configure Redis for my environment                 | tune connection timeouts, retries, and failure thresholds                         | the cache adapts to my network characteristics and SLA requirements |
+| 4   | the API cold-starts or the cache expires             | cache initialization proceeds without overwhelming Redis or the database          | other concurrent requests are not blocked or slowed                 |
+| 5   | I operate the API in production                      | have visibility into cache health, circuit breaker state, and expiration behavior | I can proactively diagnose issues before users are impacted         |
+
+## 5. Current State (Observed Defects)
+
+The following defects were identified through code analysis (source: issue #343):
+
+| ID  | Defect                                                                                                                             | Severity | Impact                                                               |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------------------------------------------------- |
+| D-1 | Descriptor cache uses synchronous `IDistributedCache.GetString()`, blocking threads. 3000+ blocking round-trips per paged request. | Critical | 1.5s+ latency per request; thread pool starvation under concurrency. |
+| D-2 | No configurable Redis connection timeouts. Default 5s `syncTimeout` hit under load.                                                | Critical | Direct cause of reported `RedisTimeoutException`.                    |
+| D-3 | Expiration (PEXPIRE) sent fire-and-forget; silent failures cause stale data or premature eviction.                                 | High     | Unbounded memory growth or thundering herd on re-initialization.     |
+| D-4 | Background cache initialization has no concurrency control. Race conditions trigger duplicate full-table scans.                    | High     | Database and Redis contention during cold start.                     |
+| D-5 | No connection resilience. Redis failure = every request throws until restart.                                                      | High     | Complete service disruption on transient Redis issues.               |
+| D-6 | LINQ allocations on every cache read/write in hot path.                                                                            | Medium   | GC pressure, increased P99 latency.                                  |
+| D-7 | No L1 cache tier; all-or-nothing architecture (memory vs. Redis).                                                                  | Medium   | Unnecessary Redis traffic for small, hot, rarely-changing data.      |
+
+## 6. Functional Requirements
+
+### FR-PERF: Descriptor Cache Performance
+
+| ID        | Requirement                                                                                                                                    | Priority |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| FR-PERF-1 | The system SHALL provide an in-process (L1) cache tier in front of Redis for descriptor lookups with a configurable TTL (default: 10 seconds). | SHALL    |
+| FR-PERF-2 | L1 cache lookups SHALL be synchronous in-memory operations with no network I/O.                                                                | SHALL    |
+| FR-PERF-3 | On L1 cache miss, the system SHALL access Redis asynchronously (non-blocking).                                                                 | SHALL    |
+| FR-PERF-4 | On L2 (Redis) hit, the system SHALL populate L1 before returning the result.                                                                   | SHALL    |
+| FR-PERF-5 | The L1 cache TTL SHOULD be independently configurable per cache type (descriptors, API client details).                                        | SHOULD   |
+
+### FR-CONN: Connection Configuration
+
+| ID        | Requirement                                                                                                                                                                                           | Priority |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| FR-CONN-1 | The system SHALL expose configurable Redis connection parameters: `SyncTimeoutMs`, `AsyncTimeoutMs`, `ConnectTimeoutMs`, `ConnectRetry`, `AbortOnConnectFail`, `KeepAliveSeconds`, `Ssl`, `Password`. | SHALL    |
+| FR-CONN-2 | Default values SHALL be production-friendly: syncTimeout=10000ms, asyncTimeout=10000ms, connectTimeout=10000ms, connectRetry=5, abortOnConnectFail=false, keepAlive=30s.                              | SHALL    |
+| FR-CONN-3 | Connection options SHALL be applied consistently to both the `IRedisConnectionProvider` and the `IDistributedCache` Redis registrations.                                                              | SHALL    |
+
+### Redis Configuration Reference
+
+`ApiSettings:Services:Redis` supports the following settings:
+
+```json
+"Redis": {
+  "Configuration": "",
+  "SyncTimeoutMs": 10000,
+  "AsyncTimeoutMs": 10000,
+  "ConnectTimeoutMs": 10000,
+  "ConnectRetry": 5,
+  "AbortOnConnectFail": false,
+  "KeepAliveSeconds": 30,
+  "Ssl": false,
+  "Password": ""
+}
+```
+
+### FR-RESIL: Connection Resilience
+
+| ID         | Requirement                                                                                                                                     | Priority |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| FR-RESIL-1 | The system SHALL implement a circuit breaker around Redis operations that opens after a configurable failure threshold.                         | SHALL    |
+| FR-RESIL-2 | When the circuit breaker is open, Redis operations SHALL fail fast and the API SHALL degrade gracefully to uncached (database-direct) behavior. | SHALL    |
+| FR-RESIL-3 | The system SHALL NOT require application restart to recover from transient Redis unavailability.                                                | SHALL    |
+| FR-RESIL-4 | The system SHALL log connection state transitions (connected, failed, restored) at appropriate severity levels.                                 | SHALL    |
+| FR-RESIL-5 | The system SHOULD log circuit breaker state transitions (closed → open → half-open → closed).                                                   | SHOULD   |
+
+### FR-EXPIRE: Expiration Reliability
+
+| ID          | Requirement                                                                                                                      | Priority |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| FR-EXPIRE-1 | Cache expiration commands SHALL be pipelined with the associated data operation (not sent as separate fire-and-forget commands). | SHALL    |
+| FR-EXPIRE-2 | Failed expiration commands SHALL be logged at Warning level for operator visibility.                                             | SHALL    |
+| FR-EXPIRE-3 | The system SHALL NOT use `CommandFlags.FireAndForget` for expiration operations.                                                 | SHALL    |
+
+### FR-INIT: Cache Initialization
+
+| ID        | Requirement                                                                                                                                                         | Priority |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| FR-INIT-1 | Background cache initialization SHALL be protected by a distributed lock so that only one instance initializes a given (ODS instance, person type) cache at a time. | SHALL    |
+| FR-INIT-2 | The initialization marker check-and-set SHALL be atomic (Redis SET NX).                                                                                             | SHALL    |
+| FR-INIT-3 | Bulk cache writes during initialization SHALL use batches no larger than 10,000 entries to avoid blocking the Redis event loop.                                     | SHALL    |
+| FR-INIT-4 | Background initialization SHALL support cancellation (application shutdown) and a maximum timeout (default: 60 seconds).                                            | SHALL    |
+| FR-INIT-5 | Bulk cache write size SHALL be configurable | SHALL |
+
+### FR-ALLOC: Hot-Path Efficiency
+
+| ID         | Requirement                                                                                                          | Priority |
+| ---------- | -------------------------------------------------------------------------------------------------------------------- | -------- |
+| FR-ALLOC-1 | Cache read and write operations SHALL NOT allocate intermediate LINQ iterators or delegate closures in the hot path. | SHALL    |
+| FR-ALLOC-2 | Type conversion from/to `RedisValue` SHOULD use direct typed overrides rather than runtime type-switching.           | SHOULD   |
+| FR-ALLOC-3 | Batch slicing SHALL NOT use LINQ `Skip`/`Take`; fixed-size array copy or span slicing SHALL be used instead.         | SHALL    |
+
+## 7. Non-Functional Requirements
+
+### NFR-PERF: Performance
+
+| ID         | Requirement                                                                                                                                                                                    |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| NFR-PERF-1 | A paged GET request for 500 studentSchoolAssociations with Redis caching enabled SHALL NOT add more than 50ms of cache-related latency (excluding cold start) under normal Redis connectivity. |
+| NFR-PERF-2 | L1 cache hit ratio for descriptors SHOULD exceed 99% under steady-state operation.                                                                                                             |
+| NFR-PERF-3 | P99 response time with Redis enabled SHALL be within 2× of the in-memory-only cache P99 under equivalent load.                                                                                 |
+
+### NFR-RELI: Reliability
+
+| ID         | Requirement                                                                                                            |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------- |
+| NFR-RELI-1 | The API SHALL remain available (HTTP 200 responses) during Redis outages lasting up to 5 minutes.                      |
+| NFR-RELI-2 | After Redis recovery, the system SHALL resume caching within 60 seconds without operator intervention.                 |
+| NFR-RELI-3 | Cache key expiration SHALL be reliable — keys SHALL NOT persist beyond 2× their configured TTL under normal operation. |
+
+### NFR-OBS: Observability
+
+| ID        | Requirement                                                                                |
+| --------- | ------------------------------------------------------------------------------------------ |
+| NFR-OBS-1 | Redis connection state changes SHALL be logged (Error for failures, Info for restoration). |
+| NFR-OBS-2 | Circuit breaker transitions SHALL be logged (Error for open, Info for close).              |
+| NFR-OBS-3 | Expiration failures SHALL be logged at Warning level with the affected cache key.          |
+
+### NFR-COMPAT: Compatibility
+
+| ID           | Requirement                                                                                                              |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| NFR-COMPAT-1 | All changes SHALL be backward compatible — deployments with external cache disabled SHALL experience no behavior change. |
+| NFR-COMPAT-2 | Existing `appsettings.json` configurations without new Redis fields SHALL work with production-friendly defaults.        |
+| NFR-COMPAT-3 | The solution SHALL support Redis 6.x and 7.x.                                                                            |
+
+### NFR-SEC: Security
+
+| ID        | Requirement                                                        |
+| --------- | ------------------------------------------------------------------ |
+| NFR-SEC-1 | Redis password SHALL NOT be logged in plain text at any log level. |
+| NFR-SEC-2 | SSL/TLS connections to Redis SHALL be configurable.                |
+
+## 8. System Architecture
+
+### Component Overview
+
+| Component                    | Responsibility                                        | Runtime            |
+| ---------------------------- | ----------------------------------------------------- | ------------------ |
+| `TieredCacheProvider`        | L1 (MemoryCache) + L2 (Redis) composition             | In-process         |
+| `AsyncExternalCacheProvider` | Async Redis access via IDistributedCache              | In-process → Redis |
+| `AsyncCachingInterceptor`    | DynamicProxy interceptor with sync L1 path + async L2 | In-process         |
+| `RedisCacheResilience`       | Polly circuit breaker wrapping Redis operations       | In-process         |
+| `RedisConnectionProvider`    | Managed ConnectionMultiplexer with event handling     | In-process → Redis |
+| `RedisMapCache`              | Person cache HASH operations with IBatch pipelining   | In-process → Redis |
+
+### Data Flow (Cache Hit)
+
+```
+Request → CachingInterceptor
+  → L1 MemoryCache check (sync, ~0.001ms)
+    → HIT: return immediately
+    → MISS: AsyncExternalCacheProvider.GetStringAsync (Redis, ~0.5ms)
+      → Circuit open? → return default (degrade to DB)
+      → HIT: populate L1, return
+      → MISS: invoke underlying provider, cache in L1+L2, return
+```
+
+### Dependencies
+
+| Dependency                          | Version    | Purpose                    |
+| ----------------------------------- | ---------- | -------------------------- |
+| StackExchange.Redis                 | (existing) | Redis client               |
+| Polly                               | 8.5.x      | Circuit breaker resilience |
+| Microsoft.Extensions.Caching.Memory | (existing) | L1 in-process cache        |
+| Castle.Core                         | (existing) | DynamicProxy interception  |
+
+## 9. Out of Scope
+
+| Item                                                 | Rationale                                                                 |
+| ---------------------------------------------------- | ------------------------------------------------------------------------- |
+| Redis Cluster/Sentinel replica-aware routing         | Future optimization; current fix focuses on correctness and resilience.   |
+| Cache value compression                              | Modest benefit for the data sizes involved; can be added later.           |
+| Distributed cache invalidation (pub/sub)             | L1 TTL-based expiration is sufficient for descriptor staleness tolerance. |
+| Metrics/telemetry export (Prometheus, OpenTelemetry) | Desirable but separate effort; logging provides interim visibility.       |
+| Migration to `IDistributedCache` for person caches   | Person caches use `IMapCache` (Redis HASH); different abstraction.        |
+| Load testing / benchmarking harness                  | Separate effort; this PRD defines expected characteristics.               |
+
+## 10. Glossary
+
+| Term                | Definition                                                                               |
+| ------------------- | ---------------------------------------------------------------------------------------- |
+| **L1 cache**        | Short-lived in-process `IMemoryCache` acting as first-tier cache.                        |
+| **L2 cache**        | Redis distributed cache acting as second-tier shared cache.                              |
+| **Circuit breaker** | Resilience pattern that stops calling a failing service after threshold breaches.        |
+| **Descriptor**      | A reference data value (e.g., grade level, subject) mapped from URI to ODS-specific ID.  |
+| **USI**             | Unique Student Identifier — the ODS surrogate key for a person.                          |
+| **UniqueId**        | The cross-system stable identifier for a person (e.g., state student ID).                |
+| **Map cache**       | A Redis HASH used to store key→value mappings for person identifier resolution.          |
+| **Fire-and-forget** | A Redis command flag that sends a command without waiting for or checking the response.  |
+| **IBatch**          | StackExchange.Redis API for pipelining multiple commands in a single network round-trip. |
+
+## 11. Release Criteria
+
+- [ ] All SHALL requirements implemented and passing unit tests.
+- [ ] Build succeeds with zero errors and zero new warnings.
+- [ ] Existing unit tests continue to pass (no regressions).
+- [ ] Manual smoke test: API serves requests during simulated Redis outage
+  (docker stop redis).
+- [ ] Manual smoke test: API resumes caching after Redis recovery without
+  restart.
+- [ ] Configuration documentation updated in Implementation repository.

--- a/tests/EdFi.Ods.Features.UnitTests/Notifications/Redis/RedisNotificationTests.cs
+++ b/tests/EdFi.Ods.Features.UnitTests/Notifications/Redis/RedisNotificationTests.cs
@@ -6,7 +6,6 @@
 using Autofac.Features.Indexed;
 using Castle.DynamicProxy;
 using EdFi.Ods.Common.Configuration;
-using EdFi.Ods.Common.Utils;
 using EdFi.Ods.Features.Notifications;
 using EdFi.Ods.Features.Notifications.Redis;
 using EdFi.Ods.Features.Services.Redis;
@@ -22,9 +21,11 @@ namespace EdFi.Ods.Features.UnitTests.Notifications.Redis;
 [TestFixture]
 public class RedisNotificationTests
 {
-    private const string RedisConfiguration = "localhost:6379";
+    private const string RedisConfigurationString = "localhost:6379";
 
-    private static readonly IRedisConnectionProvider _redisConnectionProvider = new RedisConnectionProvider(RedisConfiguration);
+    private static readonly IRedisConnectionProvider _redisConnectionProvider = new RedisConnectionProvider(
+        new RedisConfiguration { Configuration = RedisConfigurationString }
+    );
     private static readonly RedisNotificationSettings _redisNotificationSettings = new() { Channel = "test-notifications" };
 
     private readonly Dictionary<string, TimeSpan> _intervalsByNotificationType = new();
@@ -51,7 +52,7 @@ public class RedisNotificationTests
 
         var fakeInterceptorIndex = A.Fake<IIndex<string, IInterceptor>>();
         IInterceptor interceptorOutPlaceholder;
-        
+
         A.CallTo(() => fakeInterceptorIndex.TryGetValue("cache-security", out interceptorOutPlaceholder))
             .Returns(true)
             .AssignsOutAndRefParameters(interceptor);

--- a/tests/EdFi.Ods.Features.UnitTests/PersonMapCache/MapCacheTestHelper.cs
+++ b/tests/EdFi.Ods.Features.UnitTests/PersonMapCache/MapCacheTestHelper.cs
@@ -22,7 +22,7 @@ public static class MapCacheTestHelper
         new RedisConnectionProvider(new RedisConfiguration { Configuration = RedisConfiguration });
 
     public static IEnumerable<IMapCache<(ulong, string, PersonMapType), string, int>> GetUsiByUniqueIdMapCaches(
-        int absoluteExpirationMs, 
+        int absoluteExpirationMs,
         int slidingExpirationMs)
     {
         yield return new InMemoryMapCache<(ulong, string, PersonMapType), string, int>(
@@ -36,12 +36,13 @@ public static class MapCacheTestHelper
                 RedisConnectionProvider,
                 Resilience,
                 absoluteExpirationPeriod: TimeSpan.FromMilliseconds(absoluteExpirationMs),
-                slidingExpirationPeriod: TimeSpan.FromMilliseconds(slidingExpirationMs));
+                slidingExpirationPeriod: TimeSpan.FromMilliseconds(slidingExpirationMs),
+                batchSize: 210);
         }
     }
 
     public static IEnumerable<IMapCache<(ulong, string, PersonMapType), int, string>> GetUniqueIdByUsiMapCaches(
-        int absoluteExpirationMs, 
+        int absoluteExpirationMs,
         int slidingExpirationMs)
     {
         yield return new InMemoryMapCache<(ulong, string, PersonMapType), int, string>(
@@ -55,7 +56,8 @@ public static class MapCacheTestHelper
                 RedisConnectionProvider,
                 Resilience,
                 absoluteExpirationPeriod: TimeSpan.FromMilliseconds(absoluteExpirationMs),
-                slidingExpirationPeriod: TimeSpan.FromMilliseconds(slidingExpirationMs));
+                slidingExpirationPeriod: TimeSpan.FromMilliseconds(slidingExpirationMs),
+                batchSize: 310);
         }
     }
 

--- a/tests/EdFi.Ods.Features.UnitTests/PersonMapCache/MapCacheTestHelper.cs
+++ b/tests/EdFi.Ods.Features.UnitTests/PersonMapCache/MapCacheTestHelper.cs
@@ -5,6 +5,7 @@
 
 using EdFi.Ods.Api.Caching;
 using EdFi.Ods.Api.Caching.Person;
+using EdFi.Ods.Common.Configuration;
 using EdFi.Ods.Features.ExternalCache.Redis;
 using EdFi.Ods.Features.Services.Redis;
 using Microsoft.Extensions.Caching.Memory;
@@ -15,9 +16,10 @@ namespace EdFi.Ods.Features.UnitTests.PersonMapCache;
 public static class MapCacheTestHelper
 {
     private const string RedisConfiguration = "localhost:6379";
+    private static readonly RedisCacheResilience Resilience = new();
     private static bool? _isRedisAvailable;
-    private static IRedisConnectionProvider _redisConnectionProvider =
-        new RedisConnectionProvider(RedisConfiguration);
+    private static readonly IRedisConnectionProvider RedisConnectionProvider =
+        new RedisConnectionProvider(new RedisConfiguration { Configuration = RedisConfiguration });
 
     public static IEnumerable<IMapCache<(ulong, string, PersonMapType), string, int>> GetUsiByUniqueIdMapCaches(
         int absoluteExpirationMs, 
@@ -31,7 +33,8 @@ public static class MapCacheTestHelper
         if (IsRedisAvailable())
         {
             yield return new RedisUsiByUniqueIdMapCache(
-                _redisConnectionProvider,
+                RedisConnectionProvider,
+                Resilience,
                 absoluteExpirationPeriod: TimeSpan.FromMilliseconds(absoluteExpirationMs),
                 slidingExpirationPeriod: TimeSpan.FromMilliseconds(slidingExpirationMs));
         }
@@ -49,7 +52,8 @@ public static class MapCacheTestHelper
         if (IsRedisAvailable())
         {
             yield return new RedisUniqueIdByUsiMapCache(
-                _redisConnectionProvider,
+                RedisConnectionProvider,
+                Resilience,
                 absoluteExpirationPeriod: TimeSpan.FromMilliseconds(absoluteExpirationMs),
                 slidingExpirationPeriod: TimeSpan.FromMilliseconds(slidingExpirationMs));
         }


### PR DESCRIPTION
This PR attempts to reduce Redis timeout and performance problems by:

- Introducing a Level 1 (in memory) / Level 2 (external) caching paradigm
- Changing the Descriptor cache to run with full `async` support
- Exposing more cache configuration settings for system tuning
- Adding Polly-based resilience (retry, backoff, circuit breaker)

There are a few opportunistic refactorings for reducing code duplication and for improving use of modern C# syntax and formatting; however, this was not a key goal of the PR and it does not attempt to fix / reformat every touched file.

Addresses #1343 

Pairs with [Ed-Fi-ODS-Implementation PR 1387](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/pull/1387)