### PR TITLE
[DMS-1215] Prevent scalar properties from mapping into array targets in Bulk Load Client

### DIFF
--- a/Utilities/DataLoading/EdFi.LoadTools.Test/MappingFactories/ResourceToResourceMetadataMappingFactoryTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/MappingFactories/ResourceToResourceMetadataMappingFactoryTests.cs
@@ -106,4 +106,193 @@ namespace EdFi.LoadTools.Test.MappingFactories
             }
         }
     }
+
+    /// <summary>
+    ///     Regression tests for DMS-1215: a scalar source property must not be fuzzy-mapped onto a JSON
+    ///     property nested under an array unless the source is in a compatible array context. Scalar mapping
+    ///     strategies emit XML elements without the json:Array marker, so such a mapping serializes as a JSON
+    ///     object where the API expects an array, and the POST is rejected.
+    /// </summary>
+    [TestFixture]
+    public class ResourceToResourceArrayContextMappingTests
+    {
+        private static MetadataMapping GetSingleMapping(
+            List<XmlModelMetadata> xmlMetadata,
+            List<JsonModelMetadata> jsonMetadata)
+        {
+            var strategies = new List<IMetadataMapper>
+                             {
+                                 new ArrayMetadataMapper(), new DescriptorReferenceMetadataMapper(), new NameMatchingMetadataMapper()
+                             };
+
+            var factory = new ResourceToResourceMetadataMappingFactory(xmlMetadata, jsonMetadata, strategies);
+
+            return factory.GetMetadataMappings().Single();
+        }
+
+        [Test]
+        public void Should_not_map_student_program_reason_exited_to_sample_related_general_student_program_associations()
+        {
+            // DS 5.2 interchange metadata: ReasonExited is a scalar descriptor reference
+            var xmlMetadata = new List<XmlModelMetadata>
+                              {
+                                  new XmlModelMetadata
+                                  {
+                                      Model = "StudentProgramAssociation", Property = "BeginDate", Type = "Date"
+                                  },
+                                  new XmlModelMetadata
+                                  {
+                                      Model = "StudentProgramAssociation", Property = "ReasonExited", Type = "String",
+                                      TypeName = "ReasonExitedDescriptorReferenceType"
+                                  }
+                              };
+
+            // Sample-extended OpenAPI metadata: the Sample extension contributes the
+            // relatedGeneralStudentProgramAssociations collection to the program association resource
+            var jsonMetadata = new List<JsonModelMetadata>
+                               {
+                                   new JsonModelMetadata
+                                   {
+                                       Model = "edFi_studentProgramAssociation", Property = "beginDate", Type = "string", Format = "date"
+                                   },
+                                   new JsonModelMetadata
+                                   {
+                                       Model = "edFi_studentProgramAssociation", Property = "relatedGeneralStudentProgramAssociations",
+                                       Type = "sample_studentProgramAssociationRelatedGeneralStudentProgramAssociation", IsArray = true
+                                   },
+                                   new JsonModelMetadata
+                                   {
+                                       Model = "sample_studentProgramAssociationRelatedGeneralStudentProgramAssociation",
+                                       Property = "relatedGeneralStudentProgramAssociationReference",
+                                       Type = "edFi_generalStudentProgramAssociationReference"
+                                   },
+                                   new JsonModelMetadata
+                                   {
+                                       Model = "edFi_generalStudentProgramAssociationReference", Property = "programTypeDescriptor",
+                                       Type = "string"
+                                   }
+                               };
+
+            var mapping = GetSingleMapping(xmlMetadata, jsonMetadata);
+
+            var mappingsIntoSampleArray = mapping.Properties
+                                                 .Where(
+                                                      p => p.TargetName.StartsWith(
+                                                          "relatedGeneralStudentProgramAssociations/", StringComparison.Ordinal))
+                                                 .Select(p => $"{p.SourceName} -> {p.TargetName} ({p.MappingStrategy.GetType().Name})")
+                                                 .ToList();
+
+            Assert.That(
+                mappingsIntoSampleArray, Is.Empty,
+                "Scalar source properties must not be mapped to properties nested under the Sample extension array");
+        }
+
+        [Test]
+        public void Should_not_map_scalar_property_to_property_nested_under_array()
+        {
+            var xmlMetadata = new List<XmlModelMetadata>
+                              {
+                                  new XmlModelMetadata
+                                  {
+                                      Model = "Course", Property = "GradeLevel", Type = "String"
+                                  }
+                              };
+
+            var jsonMetadata = new List<JsonModelMetadata>
+                               {
+                                   new JsonModelMetadata
+                                   {
+                                       Model = "edFi_course", Property = "gradeLevels", Type = "edFi_courseGradeLevel", IsArray = true
+                                   },
+                                   new JsonModelMetadata
+                                   {
+                                       Model = "edFi_courseGradeLevel", Property = "gradeLevelDescriptor", Type = "string"
+                                   }
+                               };
+
+            var mapping = GetSingleMapping(xmlMetadata, jsonMetadata);
+
+            var mappingsIntoArray = mapping.Properties
+                                           .Where(p => p.TargetName.StartsWith("gradeLevels/", StringComparison.Ordinal))
+                                           .Select(p => $"{p.SourceName} -> {p.TargetName} ({p.MappingStrategy.GetType().Name})")
+                                           .ToList();
+
+            Assert.That(
+                mappingsIntoArray, Is.Empty,
+                "A scalar source property must not be mapped to a property nested under a target array");
+        }
+
+        [Test]
+        public void Should_map_array_descriptor_reference_to_descriptor_nested_under_array()
+        {
+            var xmlMetadata = new List<XmlModelMetadata>
+                              {
+                                  new XmlModelMetadata
+                                  {
+                                      Model = "Staff", Property = "Race", Type = "String",
+                                      TypeName = "RaceDescriptorReferenceType", IsArray = true
+                                  }
+                              };
+
+            var jsonMetadata = new List<JsonModelMetadata>
+                               {
+                                   new JsonModelMetadata
+                                   {
+                                       Model = "edFi_staff", Property = "races", Type = "edFi_staffRace", IsArray = true
+                                   },
+                                   new JsonModelMetadata
+                                   {
+                                       Model = "edFi_staffRace", Property = "raceDescriptor", Type = "string"
+                                   }
+                               };
+
+            var mapping = GetSingleMapping(xmlMetadata, jsonMetadata);
+
+            Assert.That(
+                mapping.Properties.Any(
+                    p => p.SourceName == "Race"
+                         && p.TargetName == "races/raceDescriptor"
+                         && p.MappingStrategy is DescriptorReferenceTypeToStringMappingStrategy),
+                Is.True,
+                "An array descriptor reference must still map to the descriptor property nested under the matching target array");
+        }
+
+        [Test]
+        public void Should_map_scalar_property_nested_under_array_to_property_nested_under_array()
+        {
+            var xmlMetadata = new List<XmlModelMetadata>
+                              {
+                                  new XmlModelMetadata
+                                  {
+                                      Model = "Staff", Property = "ElectronicMail", Type = "ElectronicMailType", IsArray = true
+                                  },
+                                  new XmlModelMetadata
+                                  {
+                                      Model = "ElectronicMailType", Property = "ElectronicMailAddress", Type = "String"
+                                  }
+                              };
+
+            var jsonMetadata = new List<JsonModelMetadata>
+                               {
+                                   new JsonModelMetadata
+                                   {
+                                       Model = "edFi_staff", Property = "electronicMails", Type = "edFi_staffElectronicMail", IsArray = true
+                                   },
+                                   new JsonModelMetadata
+                                   {
+                                       Model = "edFi_staffElectronicMail", Property = "electronicMailAddress", Type = "string"
+                                   }
+                               };
+
+            var mapping = GetSingleMapping(xmlMetadata, jsonMetadata);
+
+            Assert.That(
+                mapping.Properties.Any(
+                    p => p.SourceName == "ElectronicMail/ElectronicMailAddress"
+                         && p.TargetName == "electronicMails/electronicMailAddress"
+                         && p.MappingStrategy is CopySimplePropertyMappingStrategy),
+                Is.True,
+                "A scalar source property nested under an array must still map to the property nested under the matching target array");
+        }
+    }
 }

--- a/Utilities/DataLoading/EdFi.LoadTools/Engine/ExtensionMethods.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/Engine/ExtensionMethods.cs
@@ -8,11 +8,31 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using EdFi.LoadTools.ApiClient;
 
 namespace EdFi.LoadTools.Engine
 {
     public static class ExtensionMethods
     {
+        /// <summary>
+        ///     Gets the property paths of all array properties, with a trailing path separator, for use with
+        ///     <see cref="IsNestedUnderArray" />.
+        /// </summary>
+        public static List<string> GetArrayPathPrefixes(this IEnumerable<ModelMetadata> models)
+        {
+            return models.Where(m => m.IsArray)
+                         .Select(m => $"{m.PropertyPath}/")
+                         .ToList();
+        }
+
+        /// <summary>
+        ///     Indicates whether the property at the given path is nested under an array property.
+        /// </summary>
+        public static bool IsNestedUnderArray(this string propertyPath, IReadOnlyCollection<string> arrayPathPrefixes)
+        {
+            return arrayPathPrefixes.Any(prefix => propertyPath.StartsWith(prefix, StringComparison.Ordinal));
+        }
+
         public static string InitialUpperCase(this string text)
         {
             return text.Substring(0, 1).ToUpperInvariant() + text.Substring(1);

--- a/Utilities/DataLoading/EdFi.LoadTools/Engine/Mapping/DescriptorReferenceMetadataMapper.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/Engine/Mapping/DescriptorReferenceMetadataMapper.cs
@@ -32,6 +32,17 @@ namespace EdFi.LoadTools.Engine.Mapping
                     j.Property.EndsWith("descriptor", StringComparison.InvariantCultureIgnoreCase) &&
                     j.Type == Constants.JsonTypes.String).ToList();
 
+            var sourceArrayPathPrefixes = sourceModels.GetArrayPathPrefixes();
+            var targetArrayPathPrefixes = targetModels.GetArrayPathPrefixes();
+
+            // A target property nested under an array may only be mapped from a source property that is itself
+            // an array or nested under an array. Scalar mappings emit no json:Array marker, so the resulting
+            // JSON would contain an object where the API expects an array.
+            bool IsCompatibleArrayContext(ModelMetadata source, ModelMetadata target)
+                => !target.PropertyPath.IsNestedUnderArray(targetArrayPathPrefixes)
+                   || source.IsArray
+                   || source.PropertyPath.IsNestedUnderArray(sourceArrayPathPrefixes);
+
             var maps = xModels.SelectMany(
                     x => jModels.Select(
                         j =>
@@ -41,7 +52,7 @@ namespace EdFi.LoadTools.Engine.Mapping
                                 j,
                                 m = ExtensionMethods.PropertyPathPercentMatchTo(x.model.PropertyPath, j.PropertyPath)
                             }))
-                .Where(o => o.m > 0)
+                .Where(o => o.m > 0 && IsCompatibleArrayContext(o.x.model, o.j))
                 .OrderByDescending(o => o.m)
                 .ToList();
 

--- a/Utilities/DataLoading/EdFi.LoadTools/Engine/Mapping/NameMatchingMetadataMapper.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/Engine/Mapping/NameMatchingMetadataMapper.cs
@@ -22,6 +22,17 @@ namespace EdFi.LoadTools.Engine.Mapping
         {
             _logger.Debug($"mapping {mapping.RootName} from {mapping.SourceName} to {mapping.TargetName}");
 
+            var sourceArrayPathPrefixes = sourceModels.GetArrayPathPrefixes();
+            var targetArrayPathPrefixes = targetModels.GetArrayPathPrefixes();
+
+            // A target property nested under an array may only be mapped from a source property that is itself
+            // an array or nested under an array. Scalar mappings emit no json:Array marker, so the resulting
+            // JSON would contain an object where the API expects an array.
+            bool IsCompatibleArrayContext(ModelMetadata source, ModelMetadata target)
+                => !target.PropertyPath.IsNestedUnderArray(targetArrayPathPrefixes)
+                   || source.IsArray
+                   || source.PropertyPath.IsNestedUnderArray(sourceArrayPathPrefixes);
+
             var maps = sourceModels.SelectMany(
                 x => targetModels.Select(
                     j => new
@@ -30,7 +41,8 @@ namespace EdFi.LoadTools.Engine.Mapping
                         j,
                         m = x.IsSimpleType && j.IsSimpleType &&
                             (ExtensionMethods.AreMatchingSimpleTypes(j.Type, x.Type) ||
-                             ExtensionMethods.AreMatchingDateTypes(j.Format, x.Type))
+                             ExtensionMethods.AreMatchingDateTypes(j.Format, x.Type)) &&
+                            IsCompatibleArrayContext(x, j)
                             ? ExtensionMethods.PropertyPathPercentMatchTo(x.PropertyPath, j.PropertyPath)
                             : 0
                     })).Where(o => o.m > 0.001).OrderByDescending(o => o.m).ToList();


### PR DESCRIPTION
## Summary

Fixes [DMS-1215](https://edfi.atlassian.net/browse/DMS-1215): the Bulk Load Client could fuzzy-map DS 5.2 `StudentProgramAssociation/ReasonExited` into the Sample extension''s `relatedGeneralStudentProgramAssociations` array and serialize it as an object, causing DMS 400 responses on 29 of the 126 StudentProgramAssociation records in the DS 5.2 sample data.

## Root cause

- `PercentMatchTo` never returns 0 (it floors at 0.000001), so `DescriptorReferenceMetadataMapper`''s `score > 0` filter excluded nothing - every leftover descriptor reference was greedily paired with whatever descriptor-named target remained, however unrelated.
- Neither `DescriptorReferenceMetadataMapper` nor `NameMatchingMetadataMapper` checked whether the target path was nested under an `IsArray` property. Scalar mapping strategies build plain XML elements with no `json:Array` marker (only `ArrayToArrayMappingStrategy` adds it), so the mapped value serialized as a JSON object where the API expects an array.

## Fix (ticket''s defensive fix area)

A target property nested under an array may now only be mapped from a source property that is itself an array or nested under an array:

- `ExtensionMethods`: new `GetArrayPathPrefixes()` / `IsNestedUnderArray()` helpers
- `NameMatchingMetadataMapper` and `DescriptorReferenceMetadataMapper`: `IsCompatibleArrayContext` guard applied to candidate-pair selection

Legitimate array-context mappings (e.g. `Race` -> `races/raceDescriptor`, `ElectronicMail/ElectronicMailAddress` -> `electronicMails/electronicMailAddress`) are unaffected and pinned down by tests.

The ticket''s broader "primary fix area" (ownership-aware resource matching in `ResourceToResourceMetadataMappingFactory`) is intentionally not included; per the ticket it needs a DMS metadata capture to validate target selection, and this guard kills the malformed-output failure mode regardless of which target model is selected.

## Testing

- New self-contained `ResourceToResourceArrayContextMappingTests` fixture (no live API required), including the ticket-suggested `Should_not_map_student_program_reason_exited_to_sample_related_general_student_program_associations`. Both negative tests reproduced the exact bad mapping before the fix and pass after; two positive controls guard against over-blocking.
- Full `EdFi.LoadTools.Test` suite (excluding `RunManually`): 67/67 pass.
- `LoadTools.sln` builds with 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DMS-1215]: https://edfi.atlassian.net/browse/DMS-1215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ