### PR TITLE
[DMS-1220] Support homonym resources and old-generator SDKs in SDK smoke tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -81,7 +81,7 @@
 
     <!-- Serialization -->
     <PackageVersion Include="JsonSubTypes" Version="2.0.1" />
-    <PackageVersion Include="MessagePack" Version="3.1.4" />
+    <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
 
     <!-- Logging -->

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/EdFi.LoadTools.Test.csproj
@@ -20,6 +20,8 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\EdFi.LoadTools\EdFi.LoadTools.csproj" />
+        <!-- Referenced so the legacy branch of SdkConfigurationFactory can be tested directly. -->
+        <ProjectReference Include="..\EdFi.SmokeTest.Console\EdFi.SmokeTest.Console.csproj" />
     </ItemGroup>
   <ItemGroup Condition=" '$(StandardVersion)' == '6.1.0' ">
 		<PackageReference Include="EdFi.Suite3.OdsApi.TestSdk.Standard.6.1.0" />

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/BaseTestGetApiInstanceTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/BaseTestGetApiInstanceTests.cs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using EdFi.LoadTools.Engine;
+using EdFi.LoadTools.SmokeTest;
+using EdFi.LoadTools.SmokeTest.SdkTests;
+using FakeItEasy;
+using NUnit.Framework;
+using Shouldly;
+
+namespace EdFi.LoadTools.Test.SmokeTests
+{
+    /// <summary>
+    ///     In old-generator (Client.Configuration) mode, <c>ISdkConfigurationFactory.SdkConfiguration</c>
+    ///     returns a Configuration object rather than an <see cref="IServiceProvider" />. BaseTest must
+    ///     construct the API as <c>new XxxApi(configuration)</c> instead of falling into the DI /
+    ///     manual-construction paths (which would pick the parameterless constructor and produce a
+    ///     broken instance with no base path or bearer token).
+    /// </summary>
+    [TestFixture]
+    public class BaseTestGetApiInstanceTests
+    {
+        [Test]
+        public void GetApiInstance_in_legacy_mode_constructs_api_with_the_configuration()
+        {
+            var configuration = new FakeLegacyConfiguration { AccessToken = "TEST-TOKEN" };
+
+            var resourceApi = A.Fake<IResourceApi>();
+            A.CallTo(() => resourceApi.ApiType).Returns(typeof(FakeLegacyApi));
+
+            var sdkConfigurationFactory = A.Fake<ISdkConfigurationFactory>();
+            // Not an IServiceProvider => legacy mode.
+            A.CallTo(() => sdkConfigurationFactory.SdkConfiguration).Returns(configuration);
+
+            var test = new TestableBaseTest(resourceApi, sdkConfigurationFactory);
+
+            var instance = InvokeGetApiInstance(test);
+
+            instance.ShouldBeOfType<FakeLegacyApi>();
+            ((FakeLegacyApi) instance).Configuration.ShouldBeSameAs(configuration);
+        }
+
+        private static object InvokeGetApiInstance(BaseTest test)
+        {
+            var method = typeof(BaseTest).GetMethod(
+                "GetApiInstance", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            method.ShouldNotBeNull();
+
+            try
+            {
+                return method.Invoke(test, null);
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException != null)
+            {
+                throw ex.InnerException;
+            }
+        }
+
+        // Public so the production code's Activator.CreateInstance (running in the EdFi.LoadTools
+        // assembly) can construct it across the assembly boundary.
+        public sealed class FakeLegacyConfiguration
+        {
+            public string AccessToken { get; set; }
+        }
+
+        // Mimics an old-generator API class: constructed with a single Configuration argument.
+        public sealed class FakeLegacyApi
+        {
+            public FakeLegacyApi(FakeLegacyConfiguration configuration)
+            {
+                Configuration = configuration;
+            }
+
+            public FakeLegacyConfiguration Configuration { get; }
+        }
+
+        private sealed class TestableBaseTest : BaseTest
+        {
+            public TestableBaseTest(IResourceApi resourceApi, ISdkConfigurationFactory sdkConfigurationFactory)
+                : base(resourceApi, new Dictionary<string, List<object>>(), sdkConfigurationFactory)
+            {
+            }
+
+            protected override MethodInfo GetMethodInfo() => null;
+
+            protected override object[] GetParams(MethodInfo methodInfo) => null;
+        }
+    }
+}

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SdkCategorizerTestStubs.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SdkCategorizerTestStubs.cs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+// Stub SDK shapes that mimic openapi-generator output, used to exercise SdkCategorizer independently
+// of any specific Ed-Fi Data Standard / TestSdk version. SdkCategorizer scans an assembly's exported
+// types filtered by the "Apis.All" / "Models.All" namespace segments, so these are public and live in
+// matching namespaces; a test points a fake ISdkLibraryFactory at this (the test) assembly.
+
+namespace EdFi.LoadTools.Test.SmokeTests.SdkStubs.Models.All
+{
+    public class EdFiContact { }
+
+    public class HomographContact { }
+
+    public class EdFiSchool { }
+
+    public class HomographSchool { }
+
+    public class EdFiStudent { }
+}
+
+namespace EdFi.LoadTools.Test.SmokeTests.SdkStubs.Apis.All
+{
+    using System.Threading.Tasks;
+    using EdFi.LoadTools.Test.SmokeTests.SdkStubs.Models.All;
+
+    // Homonym resources disambiguated by the generator's "_N" suffix (the EdFi.OdsApi.Sdk convention,
+    // e.g. PostContact_0Async / GetContacts_0Async). Also carries the non-CRUD companions the
+    // categorizer must ignore.
+    public class StubContactsApi
+    {
+        public Task PostContactAsync(EdFiContact contact) => Task.CompletedTask;
+
+        public Task PostContact_0Async(HomographContact contact) => Task.CompletedTask;
+
+        public Task GetContactsAsync() => Task.CompletedTask;
+
+        public Task GetContacts_0Async() => Task.CompletedTask;
+
+        public Task GetContactsByIdAsync(string id) => Task.CompletedTask;
+
+        public Task GetContactsById_0Async(string id) => Task.CompletedTask;
+
+        public Task PutContactAsync(string id, EdFiContact contact) => Task.CompletedTask;
+
+        public Task PutContact_0Async(string id, HomographContact contact) => Task.CompletedTask;
+
+        public Task DeleteContactByIdAsync(string id) => Task.CompletedTask;
+
+        public Task DeleteContactById_0Async(string id) => Task.CompletedTask;
+
+        // The following must be ignored by the categorizer.
+        public Task GetContactsPartitionsAsync() => Task.CompletedTask;
+
+        public Task DeletesContactsAsync() => Task.CompletedTask;
+
+        public Task KeyChangesContactsAsync() => Task.CompletedTask;
+
+        public Task PostContactOrDefaultAsync(EdFiContact contact) => Task.CompletedTask;
+    }
+
+    // Homonym resources disambiguated by distinct name stems (the EdFi.DmsApi.TestSdk convention,
+    // e.g. PostHomographSchoolAsync). POST/DELETE are singular while GET is plural.
+    public class StubSchoolsApi
+    {
+        public Task PostSchoolAsync(EdFiSchool school) => Task.CompletedTask;
+
+        public Task PostHomographSchoolAsync(HomographSchool school) => Task.CompletedTask;
+
+        public Task GetSchoolsAsync() => Task.CompletedTask;
+
+        public Task GetHomographSchoolsAsync() => Task.CompletedTask;
+
+        public Task GetSchoolsByIdAsync(string id) => Task.CompletedTask;
+
+        public Task GetHomographSchoolsByIdAsync(string id) => Task.CompletedTask;
+
+        public Task PutSchoolAsync(string id, EdFiSchool school) => Task.CompletedTask;
+
+        public Task PutHomographSchoolAsync(string id, HomographSchool school) => Task.CompletedTask;
+
+        public Task DeleteSchoolByIdAsync(string id) => Task.CompletedTask;
+
+        public Task DeleteHomographSchoolByIdAsync(string id) => Task.CompletedTask;
+    }
+
+    // A conventional single-resource API class.
+    public class StubStudentsApi
+    {
+        public Task PostStudentAsync(EdFiStudent student) => Task.CompletedTask;
+
+        public Task GetStudentsAsync() => Task.CompletedTask;
+
+        public Task GetStudentsByIdAsync(string id) => Task.CompletedTask;
+
+        public Task PutStudentAsync(string id, EdFiStudent student) => Task.CompletedTask;
+
+        public Task DeleteStudentByIdAsync(string id) => Task.CompletedTask;
+    }
+}

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SdkCategorizerTestStubs.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SdkCategorizerTestStubs.cs
@@ -19,6 +19,8 @@ namespace EdFi.LoadTools.Test.SmokeTests.SdkStubs.Models.All
     public class HomographSchool { }
 
     public class EdFiStudent { }
+
+    public class EdFiPerson { }
 }
 
 namespace EdFi.LoadTools.Test.SmokeTests.SdkStubs.Apis.All
@@ -98,5 +100,21 @@ namespace EdFi.LoadTools.Test.SmokeTests.SdkStubs.Apis.All
         public Task PutStudentAsync(string id, EdFiStudent student) => Task.CompletedTask;
 
         public Task DeleteStudentByIdAsync(string id) => Task.CompletedTask;
+    }
+
+    // A single-resource API whose resource pluralizes irregularly (Person -> People). Because there is
+    // exactly one resource, the categorizer's fast path assigns every method to it without name-stem
+    // matching, so the irregular plural is fully supported. (Mirrors the cached ODS PeopleApi.)
+    public class StubPeopleApi
+    {
+        public Task PostPersonAsync(EdFiPerson person) => Task.CompletedTask;
+
+        public Task GetPeopleAsync() => Task.CompletedTask;
+
+        public Task GetPeopleByIdAsync(string id) => Task.CompletedTask;
+
+        public Task PutPersonAsync(string id, EdFiPerson person) => Task.CompletedTask;
+
+        public Task DeletePersonByIdAsync(string id) => Task.CompletedTask;
     }
 }

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SdkCategorizerTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SdkCategorizerTests.cs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Linq;
+using EdFi.LoadTools.Engine;
+using EdFi.LoadTools.SmokeTest.SdkTests;
+using EdFi.OdsApi.Sdk.Apis.All;
+using FakeItEasy;
+using NUnit.Framework;
+using Shouldly;
+
+namespace EdFi.LoadTools.Test.SmokeTests
+{
+    /// <summary>
+    ///     Verifies that <see cref="SdkCategorizer" /> emits one resource per RESOURCE (model type),
+    ///     not one per generated API type. The Homograph extension's homonym resources share the core
+    ///     resource's OpenAPI tag, so e.g. ContactsApi carries both Contact and HomographContact.
+    /// </summary>
+    [TestFixture]
+    public class SdkCategorizerTests
+    {
+        private static SdkCategorizer CreateCategorizer()
+        {
+            var factory = A.Fake<ISdkLibraryFactory>();
+            A.CallTo(() => factory.SdkLibrary).Returns(typeof(ContactsApi).Assembly);
+            return new SdkCategorizer(factory);
+        }
+
+        [Test]
+        public void ContactsApi_with_homonym_yields_one_resource_per_model_type()
+        {
+            var categorizer = CreateCategorizer();
+
+            var contactResources = categorizer.ResourceApis
+                .Where(api => api.ApiType == typeof(ContactsApi))
+                .ToList();
+
+            contactResources.Count.ShouldBe(2);
+            contactResources.Select(api => api.ModelType.Name)
+                .ShouldBe(new[] { "EdFiContact", "HomographContact" }, ignoreOrder: true);
+        }
+
+        [Test]
+        public void Each_homonym_resource_resolves_exactly_one_method_per_verb()
+        {
+            var categorizer = CreateCategorizer();
+
+            var contactResources = categorizer.ResourceApis
+                .Where(api => api.ApiType == typeof(ContactsApi))
+                .ToList();
+
+            contactResources.Count.ShouldBe(2);
+
+            foreach (var api in contactResources)
+            {
+                // Previously PostMethod threw when an API type exposed more than one POST.
+                Should.NotThrow(() => api.PostMethod);
+
+                api.PostMethod.ShouldNotBeNull();
+                api.PutMethod.ShouldNotBeNull();
+                api.GetAllMethod.ShouldNotBeNull();
+                api.GetByIdMethod.ShouldNotBeNull();
+                api.DeleteMethod.ShouldNotBeNull();
+
+                // The POST parameter type is the resource's model type.
+                api.PostMethod.GetParameters().First().ParameterType.ShouldBe(api.ModelType);
+
+                // The homonym resource's methods carry the generator's "_0" suffix; the core
+                // resource's methods do not. This confirms each verb landed in the right group.
+                var isHomonym = api.ModelType.Name == "HomographContact";
+                api.PostMethod.Name.Contains("_0").ShouldBe(isHomonym);
+                api.PutMethod.Name.Contains("_0").ShouldBe(isHomonym);
+                api.GetAllMethod.Name.Contains("_0").ShouldBe(isHomonym);
+                api.GetByIdMethod.Name.Contains("_0").ShouldBe(isHomonym);
+                api.DeleteMethod.Name.Contains("_0").ShouldBe(isHomonym);
+            }
+        }
+
+        [Test]
+        public void Single_resource_api_type_yields_exactly_one_resource()
+        {
+            var categorizer = CreateCategorizer();
+
+            var academicWeekResources = categorizer.ResourceApis
+                .Where(api => api.ApiType == typeof(AcademicWeeksApi))
+                .ToList();
+
+            academicWeekResources.Count.ShouldBe(1);
+            academicWeekResources[0].PostMethod.ShouldNotBeNull();
+            academicWeekResources[0].GetAllMethod.ShouldNotBeNull();
+            academicWeekResources[0].GetByIdMethod.ShouldNotBeNull();
+        }
+
+        [Test]
+        public void ResourceApis_can_be_keyed_by_model_type_name_without_duplicate_keys()
+        {
+            // Regression for DestructiveMethodsGenerator and ModelDependencySort, which key by
+            // ModelType (name). With one resource per API type a homonym surface produced a duplicate
+            // (or a categorization throw); the per-resource split makes the model types distinct.
+            var categorizer = CreateCategorizer();
+
+            Should.NotThrow(() => categorizer.ResourceApis
+                .ToDictionary(api => api.ModelType.Name, StringComparer.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SdkCategorizerTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SdkCategorizerTests.cs
@@ -5,10 +5,13 @@
 
 using System;
 using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
 using EdFi.LoadTools.Engine;
 using EdFi.LoadTools.SmokeTest;
 using EdFi.LoadTools.SmokeTest.SdkTests;
 using EdFi.LoadTools.Test.SmokeTests.SdkStubs.Apis.All;
+using EdFi.LoadTools.Test.SmokeTests.SdkStubs.Models.All;
 using FakeItEasy;
 using NUnit.Framework;
 using Shouldly;
@@ -116,6 +119,84 @@ namespace EdFi.LoadTools.Test.SmokeTests
         }
 
         [Test]
+        public void Single_resource_api_with_irregular_plural_resolves_every_verb()
+        {
+            // Person -> People is an irregular plural. As a single-resource API it uses the fast path
+            // (every method assigned to the one resource, no name-stem matching), so it is fully
+            // supported. This documents that single-resource Person/People remains supported.
+            var resources = CreateCategorizer().ResourceApis
+                .Where(api => api.ApiType == typeof(StubPeopleApi))
+                .ToList();
+
+            resources.Count.ShouldBe(1);
+            resources[0].ModelType.Name.ShouldBe("EdFiPerson");
+            AssertEachVerbResolvesToOneMethod(resources[0]);
+            resources[0].GetAllMethod.Name.ShouldBe("GetPeopleAsync");
+        }
+
+        [Test]
+        public void Multi_resource_api_with_an_unmatched_candidate_fails_fast_with_diagnostics()
+        {
+            // A multi-resource (homonym) API whose GET-all pluralizes irregularly: the "People" stem
+            // does not start with the "Person" POST stem, so the GET matches no resource group. The
+            // categorizer must throw (naming the API type and method) rather than silently dropping it
+            // and leaving GetAllMethod null. This is the multi-resource counterpart that "fails fast
+            // with diagnostics" instead of silently dropping methods.
+            var ex = Should.Throw<InvalidOperationException>(
+                () => SdkCategorizer.BuildResourceApis(typeof(IrregularPluralMultiResourceStub)).ToList());
+
+            ex.Message.ShouldContain("could not assign");
+            ex.Message.ShouldContain(nameof(IrregularPluralMultiResourceStub));
+            ex.Message.ShouldContain("GetPeopleAsync");
+        }
+
+        [Test]
+        public void Resource_group_with_a_duplicate_verb_fails_fast_with_diagnostics()
+        {
+            // Two GET-all methods (plus a single POST so the no-POST guard passes) must fail fast at
+            // construction with a diagnostic rather than deferring to an opaque SingleOrDefault throw.
+            var methods = new[]
+            {
+                typeof(StubContactsApi).GetMethod(nameof(StubContactsApi.PostContactAsync)),
+                typeof(StubContactsApi).GetMethod(nameof(StubContactsApi.GetContactsAsync)),
+                typeof(StubContactsApi).GetMethod(nameof(StubContactsApi.GetContacts_0Async)),
+            };
+
+            var ex = Should.Throw<InvalidOperationException>(
+                () => new ResourceApi(typeof(StubContactsApi), typeof(EdFiContact), methods));
+
+            ex.Message.ShouldContain("GET-all");
+            ex.Message.ShouldContain("GetContactsAsync");
+            ex.Message.ShouldContain("GetContacts_0Async");
+        }
+
+        [Test]
+        public void Resource_group_without_a_post_fails_fast_with_diagnostics()
+        {
+            var methods = new[]
+            {
+                typeof(StubContactsApi).GetMethod(nameof(StubContactsApi.GetContactsAsync)),
+                typeof(StubContactsApi).GetMethod(nameof(StubContactsApi.GetContactsByIdAsync)),
+            };
+
+            var ex = Should.Throw<InvalidOperationException>(
+                () => new ResourceApi(typeof(StubContactsApi), typeof(EdFiContact), methods));
+
+            ex.Message.ShouldContain("without a POST");
+            ex.Message.ShouldContain(nameof(EdFiContact));
+        }
+
+        [Test]
+        public void Empty_resource_group_fails_fast_with_diagnostics()
+        {
+            var ex = Should.Throw<InvalidOperationException>(
+                () => new ResourceApi(typeof(StubContactsApi), typeof(EdFiContact), Array.Empty<MethodInfo>()));
+
+            ex.Message.ShouldContain("empty method group");
+            ex.Message.ShouldContain(nameof(EdFiContact));
+        }
+
+        [Test]
         public void ResourceApis_can_be_keyed_by_model_type_name_without_duplicate_keys()
         {
             // Regression for DestructiveMethodsGenerator and ModelDependencySort, which key by
@@ -141,5 +222,24 @@ namespace EdFi.LoadTools.Test.SmokeTests
             // The POST parameter type is the resource's model type.
             api.PostMethod.GetParameters().First().ParameterType.ShouldBe(api.ModelType);
         }
+    }
+
+    // Local stub shapes for the fail-fast tests. They deliberately live in this namespace - which has
+    // no "Apis.All"/"Models.All" segment - so the whole-assembly categorizer scan never picks them up
+    // (which would make the other categorizer tests fail fast on them). They are fed to
+    // SdkCategorizer.BuildResourceApis directly instead.
+    public class IrregularPersonModel { }
+
+    public class IrregularStaffModel { }
+
+    // Multi-resource (Person + Staff) API whose Person GET-all pluralizes irregularly (GetPeopleAsync).
+    // "People" does not start with the "Person" POST stem, so it matches no resource group.
+    public class IrregularPluralMultiResourceStub
+    {
+        public Task PostPersonAsync(IrregularPersonModel person) => Task.CompletedTask;
+
+        public Task PostStaffAsync(IrregularStaffModel staff) => Task.CompletedTask;
+
+        public Task GetPeopleAsync() => Task.CompletedTask;
     }
 }

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SdkCategorizerTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SdkCategorizerTests.cs
@@ -6,8 +6,9 @@
 using System;
 using System.Linq;
 using EdFi.LoadTools.Engine;
+using EdFi.LoadTools.SmokeTest;
 using EdFi.LoadTools.SmokeTest.SdkTests;
-using EdFi.OdsApi.Sdk.Apis.All;
+using EdFi.LoadTools.Test.SmokeTests.SdkStubs.Apis.All;
 using FakeItEasy;
 using NUnit.Framework;
 using Shouldly;
@@ -17,7 +18,9 @@ namespace EdFi.LoadTools.Test.SmokeTests
     /// <summary>
     ///     Verifies that <see cref="SdkCategorizer" /> emits one resource per RESOURCE (model type),
     ///     not one per generated API type. The Homograph extension's homonym resources share the core
-    ///     resource's OpenAPI tag, so e.g. ContactsApi carries both Contact and HomographContact.
+    ///     resource's OpenAPI tag, so e.g. one ContactsApi carries both Contact and HomographContact.
+    ///     These tests use stub SDK shapes (see SdkCategorizerTestStubs) so they are independent of the
+    ///     specific TestSdk version the project is compiled against.
     /// </summary>
     [TestFixture]
     public class SdkCategorizerTests
@@ -25,48 +28,46 @@ namespace EdFi.LoadTools.Test.SmokeTests
         private static SdkCategorizer CreateCategorizer()
         {
             var factory = A.Fake<ISdkLibraryFactory>();
-            A.CallTo(() => factory.SdkLibrary).Returns(typeof(ContactsApi).Assembly);
+            A.CallTo(() => factory.SdkLibrary).Returns(typeof(StubContactsApi).Assembly);
             return new SdkCategorizer(factory);
         }
 
         [Test]
-        public void ContactsApi_with_homonym_yields_one_resource_per_model_type()
+        public void Homonym_api_with_index_suffix_yields_one_resource_per_model_type()
         {
-            var categorizer = CreateCategorizer();
-
-            var contactResources = categorizer.ResourceApis
-                .Where(api => api.ApiType == typeof(ContactsApi))
+            var resources = CreateCategorizer().ResourceApis
+                .Where(api => api.ApiType == typeof(StubContactsApi))
                 .ToList();
 
-            contactResources.Count.ShouldBe(2);
-            contactResources.Select(api => api.ModelType.Name)
+            resources.Count.ShouldBe(2);
+            resources.Select(api => api.ModelType.Name)
                 .ShouldBe(new[] { "EdFiContact", "HomographContact" }, ignoreOrder: true);
         }
 
         [Test]
-        public void Each_homonym_resource_resolves_exactly_one_method_per_verb()
+        public void Homonym_api_with_distinct_stems_yields_one_resource_per_model_type()
         {
-            var categorizer = CreateCategorizer();
-
-            var contactResources = categorizer.ResourceApis
-                .Where(api => api.ApiType == typeof(ContactsApi))
+            var resources = CreateCategorizer().ResourceApis
+                .Where(api => api.ApiType == typeof(StubSchoolsApi))
                 .ToList();
 
-            contactResources.Count.ShouldBe(2);
+            resources.Count.ShouldBe(2);
+            resources.Select(api => api.ModelType.Name)
+                .ShouldBe(new[] { "EdFiSchool", "HomographSchool" }, ignoreOrder: true);
+        }
 
-            foreach (var api in contactResources)
+        [Test]
+        public void Index_suffix_homonym_resources_each_resolve_one_method_per_verb()
+        {
+            var resources = CreateCategorizer().ResourceApis
+                .Where(api => api.ApiType == typeof(StubContactsApi))
+                .ToList();
+
+            resources.Count.ShouldBe(2);
+
+            foreach (var api in resources)
             {
-                // Previously PostMethod threw when an API type exposed more than one POST.
-                Should.NotThrow(() => api.PostMethod);
-
-                api.PostMethod.ShouldNotBeNull();
-                api.PutMethod.ShouldNotBeNull();
-                api.GetAllMethod.ShouldNotBeNull();
-                api.GetByIdMethod.ShouldNotBeNull();
-                api.DeleteMethod.ShouldNotBeNull();
-
-                // The POST parameter type is the resource's model type.
-                api.PostMethod.GetParameters().First().ParameterType.ShouldBe(api.ModelType);
+                AssertEachVerbResolvesToOneMethod(api);
 
                 // The homonym resource's methods carry the generator's "_0" suffix; the core
                 // resource's methods do not. This confirms each verb landed in the right group.
@@ -80,18 +81,38 @@ namespace EdFi.LoadTools.Test.SmokeTests
         }
 
         [Test]
-        public void Single_resource_api_type_yields_exactly_one_resource()
+        public void Distinct_stem_homonym_resources_each_resolve_one_method_per_verb()
         {
-            var categorizer = CreateCategorizer();
-
-            var academicWeekResources = categorizer.ResourceApis
-                .Where(api => api.ApiType == typeof(AcademicWeeksApi))
+            var resources = CreateCategorizer().ResourceApis
+                .Where(api => api.ApiType == typeof(StubSchoolsApi))
                 .ToList();
 
-            academicWeekResources.Count.ShouldBe(1);
-            academicWeekResources[0].PostMethod.ShouldNotBeNull();
-            academicWeekResources[0].GetAllMethod.ShouldNotBeNull();
-            academicWeekResources[0].GetByIdMethod.ShouldNotBeNull();
+            resources.Count.ShouldBe(2);
+
+            foreach (var api in resources)
+            {
+                AssertEachVerbResolvesToOneMethod(api);
+
+                // The homonym resource's methods carry the "Homograph" stem; the core resource's do not.
+                var isHomonym = api.ModelType.Name == "HomographSchool";
+                api.PostMethod.Name.Contains("Homograph").ShouldBe(isHomonym);
+                api.PutMethod.Name.Contains("Homograph").ShouldBe(isHomonym);
+                api.GetAllMethod.Name.Contains("Homograph").ShouldBe(isHomonym);
+                api.GetByIdMethod.Name.Contains("Homograph").ShouldBe(isHomonym);
+                api.DeleteMethod.Name.Contains("Homograph").ShouldBe(isHomonym);
+            }
+        }
+
+        [Test]
+        public void Single_resource_api_type_yields_exactly_one_resource()
+        {
+            var resources = CreateCategorizer().ResourceApis
+                .Where(api => api.ApiType == typeof(StubStudentsApi))
+                .ToList();
+
+            resources.Count.ShouldBe(1);
+            resources[0].ModelType.Name.ShouldBe("EdFiStudent");
+            AssertEachVerbResolvesToOneMethod(resources[0]);
         }
 
         [Test]
@@ -104,6 +125,21 @@ namespace EdFi.LoadTools.Test.SmokeTests
 
             Should.NotThrow(() => categorizer.ResourceApis
                 .ToDictionary(api => api.ModelType.Name, StringComparer.OrdinalIgnoreCase));
+        }
+
+        private static void AssertEachVerbResolvesToOneMethod(IResourceApi api)
+        {
+            // Previously PostMethod threw when an API type exposed more than one POST.
+            Should.NotThrow(() => api.PostMethod);
+
+            api.PostMethod.ShouldNotBeNull();
+            api.PutMethod.ShouldNotBeNull();
+            api.GetAllMethod.ShouldNotBeNull();
+            api.GetByIdMethod.ShouldNotBeNull();
+            api.DeleteMethod.ShouldNotBeNull();
+
+            // The POST parameter type is the resource's model type.
+            api.PostMethod.GetParameters().First().ParameterType.ShouldBe(api.ModelType);
         }
     }
 }

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SdkConfigurationFactoryTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SdkConfigurationFactoryTests.cs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using EdFi.LoadTools.ApiClient;
+using EdFi.LoadTools.Engine;
+using EdFi.SmokeTest.Console.Application;
+using FakeItEasy;
+using NUnit.Framework;
+using Shouldly;
+
+namespace EdFi.LoadTools.Test.SmokeTests
+{
+    /// <summary>
+    ///     Exercises the real legacy (old-generator) branch of <see cref="SdkConfigurationFactory" />:
+    ///     when the SDK assembly exposes <c>Client.Configuration</c> but no <c>Client.HostConfiguration</c>,
+    ///     the factory must construct the Configuration object directly (not a DI <see cref="IServiceProvider" />),
+    ///     set its <c>AccessToken</c> from the token handler, and pass the configured data-management API URL
+    ///     through as the base path unchanged. The stub assembly shape below stands in for an old-generator
+    ///     SDK so the test is independent of any published SDK version.
+    /// </summary>
+    [TestFixture]
+    public class SdkConfigurationFactoryTests
+    {
+        // Namespace prefix of the stub Client.Configuration below. The factory composes
+        // "{prefix}.Client.HostConfiguration" and "{prefix}.Client.Configuration"; the former is absent
+        // from this assembly (no HostConfiguration type), so the factory selects the legacy branch.
+        private const string StubNamespacePrefix = "EdFi.LoadTools.Test.SmokeTests.LegacySdkStub";
+
+        [Test]
+        public void Legacy_mode_builds_a_configuration_object_with_token_and_data_management_base_path()
+        {
+            const string dataManagementApiUrl = "http://localhost:8765/data/v3";
+            const string bearerToken = "LEGACY-BEARER-TOKEN";
+
+            var apiConfiguration = A.Fake<IApiConfiguration>();
+            A.CallTo(() => apiConfiguration.Url).Returns(dataManagementApiUrl);
+
+            var sdkLibraryConfiguration = A.Fake<ISdkLibraryConfiguration>();
+            A.CallTo(() => sdkLibraryConfiguration.Path)
+                .Returns(typeof(LegacySdkStub.Client.Configuration).Assembly.Location);
+            A.CallTo(() => sdkLibraryConfiguration.SdkNamespacePrefix).Returns(StubNamespacePrefix);
+
+            var tokenHandler = A.Fake<IOAuthTokenHandler>();
+            A.CallTo(() => tokenHandler.GetBearerToken()).Returns(bearerToken);
+
+            // No throw even though Client.HostConfiguration is absent from the (stub) SDK assembly.
+            var factory = Should.NotThrow(
+                () => new SdkConfigurationFactory(apiConfiguration, sdkLibraryConfiguration, tokenHandler));
+
+            var configuration = factory.SdkConfiguration;
+
+            // Legacy mode returns the Configuration object itself, NOT the DI service provider.
+            configuration.ShouldNotBeNull();
+            configuration.ShouldBeOfType<LegacySdkStub.Client.Configuration>();
+            configuration.ShouldNotBeAssignableTo<IServiceProvider>();
+
+            var legacyConfiguration = (LegacySdkStub.Client.Configuration) configuration;
+
+            // AccessToken is taken from IOAuthTokenHandler.GetBearerToken().
+            legacyConfiguration.AccessToken.ShouldBe(bearerToken);
+            A.CallTo(() => tokenHandler.GetBearerToken()).MustHaveHappened();
+
+            // The base path passed into the Configuration ctor is the configured (data-management) URL,
+            // unchanged - old-generator operation paths omit /data/v3, so the base path must already
+            // include it.
+            legacyConfiguration.BasePath.ShouldBe(dataManagementApiUrl);
+        }
+    }
+}
+
+namespace EdFi.LoadTools.Test.SmokeTests.LegacySdkStub.Client
+{
+    using System.Collections.Generic;
+
+    // Stub of an old-generator SDK's Client.Configuration. Its full name ends in ".Client.Configuration"
+    // (and there is deliberately no sibling ".Client.HostConfiguration" type) so SdkConfigurationFactory
+    // probes past the new-generator host-configuration type and takes the legacy branch. The namespace has
+    // no "Apis.All"/"Models.All" segment, so the SdkCategorizer assembly scan ignores it.
+    public class Configuration
+    {
+        // Mirrors the real generated 4-arg ctor (defaultHeaders, apiKey, apiKeyPrefix, basePath) the
+        // factory invokes via Activator.CreateInstance.
+        public Configuration(
+            IDictionary<string, string> defaultHeaders,
+            IDictionary<string, string> apiKey,
+            IDictionary<string, string> apiKeyPrefix,
+            string basePath)
+        {
+            DefaultHeaders = defaultHeaders;
+            ApiKey = apiKey;
+            ApiKeyPrefix = apiKeyPrefix;
+            BasePath = basePath;
+        }
+
+        public IDictionary<string, string> DefaultHeaders { get; }
+
+        public IDictionary<string, string> ApiKey { get; }
+
+        public IDictionary<string, string> ApiKeyPrefix { get; }
+
+        public string BasePath { get; }
+
+        public string AccessToken { get; set; }
+    }
+}

--- a/Utilities/DataLoading/EdFi.LoadTools/Common/EdFiConstants.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/Common/EdFiConstants.cs
@@ -14,6 +14,11 @@ namespace EdFi.LoadTools.Common
         public const string Descriptor = "Descriptor";
         public const int TestEdOrgId = 255901;
         public const string SdkConfigurationClassName = "Client.HostConfiguration";
+
+        // Old-generator SDKs (e.g. the DMS TestSdk and the published EdFi.OdsApi.Sdk) ship only
+        // Client.Configuration and do not have Client.HostConfiguration. SdkConfigurationFactory
+        // probes for HostConfiguration first and falls back to this legacy type when it is absent.
+        public const string SdkConfigurationClassNameLegacy = "Client.Configuration";
         public const string AccessToken = "AccessToken";
         public const string Authorization = "Authorization";
         public const string EdOrgReference = "EdFiEducationOrganizationReference";

--- a/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
+++ b/Utilities/DataLoading/EdFi.LoadTools/EdFi.LoadTools.csproj
@@ -21,6 +21,10 @@
     <None Include="../../../LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
   </ItemGroup>
   <ItemGroup>
+    <!-- Lets the test project drive SdkCategorizer's internal grouping/validation directly. -->
+    <InternalsVisibleTo Include="EdFi.LoadTools.Test" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Autofac" />
     <PackageReference Include="EdFi.Suite3.Common" />
     <PackageReference Include="log4net" />

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/BaseTest.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/BaseTest.cs
@@ -138,6 +138,16 @@ namespace EdFi.LoadTools.SmokeTest.SdkTests
         {
             var serviceProvider = SdkConfigurationFactory.SdkConfiguration as IServiceProvider;
 
+            if (serviceProvider == null)
+            {
+                // Old-generator (Client.Configuration) mode: SdkConfiguration is a Configuration
+                // object, not an IServiceProvider. Construct the API directly with the old-generator
+                // constructor: new XxxApi(configuration). Going through the DI/manual-construction
+                // paths below would pick the parameterless constructor and yield a broken instance
+                // (no base path, no bearer token).
+                return Activator.CreateInstance(ResourceApi.ApiType, SdkConfigurationFactory.SdkConfiguration);
+            }
+
             if (serviceProvider != null)
             {
                 // The SDK registers APIs by their interface (IXxxxApi), not concrete type

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/BaseTest.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/BaseTest.cs
@@ -136,7 +136,10 @@ namespace EdFi.LoadTools.SmokeTest.SdkTests
 
         private object GetApiInstance()
         {
-            var serviceProvider = SdkConfigurationFactory.SdkConfiguration as IServiceProvider;
+            // Capture once: in old-generator (legacy) mode this getter is side-effecting - it sets the
+            // bearer token on the Configuration each call - so it must not be invoked twice.
+            var sdkConfiguration = SdkConfigurationFactory.SdkConfiguration;
+            var serviceProvider = sdkConfiguration as IServiceProvider;
 
             if (serviceProvider == null)
             {
@@ -145,49 +148,47 @@ namespace EdFi.LoadTools.SmokeTest.SdkTests
                 // constructor: new XxxApi(configuration). Going through the DI/manual-construction
                 // paths below would pick the parameterless constructor and yield a broken instance
                 // (no base path, no bearer token).
-                return Activator.CreateInstance(ResourceApi.ApiType, SdkConfigurationFactory.SdkConfiguration);
+                return Activator.CreateInstance(ResourceApi.ApiType, sdkConfiguration);
             }
 
-            if (serviceProvider != null)
+            // DI (new-generator) mode: serviceProvider is non-null from here on.
+            // The SDK registers APIs by their interface (IXxxxApi), not concrete type
+            // Find the interface that the concrete type implements
+            var apiInterface = ResourceApi.ApiType.GetInterfaces()
+                .FirstOrDefault(i => i.Namespace != null && i.Namespace.Contains("Apis.All") && i.Name.StartsWith("I"));
+
+            if (apiInterface != null)
             {
-                // The SDK registers APIs by their interface (IXxxxApi), not concrete type
-                // Find the interface that the concrete type implements
-                var apiInterface = ResourceApi.ApiType.GetInterfaces()
-                    .FirstOrDefault(i => i.Namespace != null && i.Namespace.Contains("Apis.All") && i.Name.StartsWith("I"));
-
-                if (apiInterface != null)
-                {
-                    try
-                    {
-                        var apiInstance = serviceProvider.GetService(apiInterface);
-                        if (apiInstance != null)
-                        {
-                            return apiInstance;
-                        }
-
-                        Log.Warn($"Service provider returned null for interface {apiInterface.FullName}");
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Warn($"DI resolution failed for interface {apiInterface.FullName}: {ex.Message}");
-                    }
-                }
-
-                // Try to resolve by concrete type as fallback
                 try
                 {
-                    var apiInstance = serviceProvider.GetService(ResourceApi.ApiType);
+                    var apiInstance = serviceProvider.GetService(apiInterface);
                     if (apiInstance != null)
                     {
                         return apiInstance;
                     }
 
-                    Log.Warn($"Service provider returned null for type {ResourceApi.ApiType.FullName}");
+                    Log.Warn($"Service provider returned null for interface {apiInterface.FullName}");
                 }
                 catch (Exception ex)
                 {
-                    Log.Warn($"DI resolution failed for {ResourceApi.ApiType.FullName}: {ex.Message}");
+                    Log.Warn($"DI resolution failed for interface {apiInterface.FullName}: {ex.Message}");
                 }
+            }
+
+            // Try to resolve by concrete type as fallback
+            try
+            {
+                var apiInstance = serviceProvider.GetService(ResourceApi.ApiType);
+                if (apiInstance != null)
+                {
+                    return apiInstance;
+                }
+
+                Log.Warn($"Service provider returned null for type {ResourceApi.ApiType.FullName}");
+            }
+            catch (Exception ex)
+            {
+                Log.Warn($"DI resolution failed for {ResourceApi.ApiType.FullName}: {ex.Message}");
             }
 
             // Manual construction: create API with required dependencies
@@ -202,23 +203,9 @@ namespace EdFi.LoadTools.SmokeTest.SdkTests
 
                     foreach (var param in parameters)
                     {
-                        if (serviceProvider != null)
-                        {
-                            var service = serviceProvider.GetService(param.ParameterType);
-                            if (service != null)
-                            {
-                                args.Add(service);
-                            }
-                            else
-                            {
-                                // Add null for optional parameters
-                                args.Add(null);
-                            }
-                        }
-                        else
-                        {
-                            args.Add(null);
-                        }
+                        // GetService returns null when the dependency is not registered, which is the
+                        // same value we would supply for an optional/unresolved parameter.
+                        args.Add(serviceProvider.GetService(param.ParameterType));
                     }
 
                     return constructor.Invoke(args.ToArray());
@@ -231,7 +218,7 @@ namespace EdFi.LoadTools.SmokeTest.SdkTests
 
             // Last resort fallback
             Log.Debug($"Falling back to Activator.CreateInstance for {ResourceApi.ApiType.FullName}");
-            return Activator.CreateInstance(ResourceApi.ApiType, SdkConfigurationFactory.SdkConfiguration);
+            return Activator.CreateInstance(ResourceApi.ApiType, sdkConfiguration);
         }
 
         protected async Task<object> GetResourceFromUri(Uri resourceUri)

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/SdkCategorizer.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/SdkCategorizer.cs
@@ -72,7 +72,10 @@ namespace EdFi.LoadTools.SmokeTest.SdkTests
             .Where(api => !string.IsNullOrEmpty(api.Name)) // Filter out APIs without names
             .ToList();
 
-        private static IEnumerable<ResourceApi> BuildResourceApis(Type apiType)
+        // internal (not private) so the grouping/validation can be exercised directly in unit tests
+        // with hand-built API shapes, without those shapes having to live in a scanned "Apis.All"
+        // namespace (which would make every other categorizer test fail-fast on them).
+        internal static IEnumerable<ResourceApi> BuildResourceApis(Type apiType)
         {
             var candidates = apiType.GetMethods()
                 .Where(m =>
@@ -101,7 +104,9 @@ namespace EdFi.LoadTools.SmokeTest.SdkTests
             }
 
             // Common case: a single resource per API type. Assign every method to it, preserving the
-            // original behavior (no name-stem matching needed, so no risk with irregular pluralization).
+            // original behavior. No name-stem matching is needed, so irregular pluralization is fully
+            // supported here: e.g. a single-resource PeopleApi with PostPersonAsync / GetPeopleAsync
+            // (Person -> People) categorizes correctly because every method goes to the one resource.
             if (resources.Count == 1)
             {
                 yield return new ResourceApi(apiType, resources[0].Model, candidates);
@@ -113,7 +118,15 @@ namespace EdFi.LoadTools.SmokeTest.SdkTests
             // the openapi-generator's "_N" homonym suffix (token) plus the resource name-stem. POST and
             // DELETE are singular while GET is plural, so we match on stem PREFIX (longest stem wins) to
             // bridge the singular/plural difference and disambiguate stems that are prefixes of others.
+            //
+            // Prefix-matching handles regular pluralization (School/Schools) but NOT irregular plurals
+            // (Person/People). If a multi-resource API ever pairs an irregular plural with a homonym, a
+            // GET/DELETE stem will not start with its POST stem and will match no resource. Rather than
+            // silently drop that method (leaving GetAllMethod/DeleteMethod null and producing a later
+            // NRE), we collect every unassigned candidate and fail fast below with diagnostics. (Cached
+            // ODS PeopleApi is single-resource and uses the fast path above, so it is unaffected.)
             var groups = resources.Select(_ => new List<MethodInfo>()).ToList();
+            var unmatched = new List<MethodInfo>();
 
             foreach (var method in candidates)
             {
@@ -140,12 +153,44 @@ namespace EdFi.LoadTools.SmokeTest.SdkTests
                 {
                     groups[bestIndex].Add(method);
                 }
+                else
+                {
+                    unmatched.Add(method);
+                }
+            }
+
+            if (unmatched.Count > 0)
+            {
+                throw new InvalidOperationException(DescribeUnmatchedCandidates(apiType, resources, unmatched));
             }
 
             for (var i = 0; i < resources.Count; i++)
             {
                 yield return new ResourceApi(apiType, resources[i].Model, groups[i]);
             }
+        }
+
+        // Builds a diagnostic message naming the API type, every unassigned method (with its derived
+        // stem/token) and the resource groups they failed to match, so a categorization failure points
+        // straight at the offending generated shape instead of surfacing as a downstream NRE.
+        private static string DescribeUnmatchedCandidates(
+            Type apiType,
+            IReadOnlyList<(Type Model, string Stem, string Token)> resources,
+            IReadOnlyList<MethodInfo> unmatched)
+        {
+            var unmatchedList = string.Join(
+                "; ", unmatched.Select(m => $"{m.Name} (stem '{StemOf(m.Name)}', token '{TokenOf(m.Name)}')"));
+
+            var resourceList = string.Join(
+                "; ", resources.Select(r => $"{r.Model?.Name} (stem '{r.Stem}', token '{r.Token}')"));
+
+            return
+                $"SdkCategorizer could not assign {unmatched.Count} CRUD method(s) to any resource group on "
+                + $"multi-resource API type '{apiType.FullName}'. Leaving them unassigned would silently drop "
+                + $"resource methods and produce later null-reference failures. Unassigned methods: {unmatchedList}. "
+                + $"Known resource groups: {resourceList}. The name-stem matching expects each GET/DELETE stem to "
+                + "start with its resource's POST stem; an irregular plural (e.g. Person/People) or an unexpected "
+                + "generated method name will trip this.";
         }
 
         private static bool IsCrudVerb(string name) =>
@@ -203,37 +248,88 @@ namespace EdFi.LoadTools.SmokeTest.SdkTests
 
     public class ResourceApi : IResourceApi
     {
-        private readonly List<MethodInfo> _methods;
-
+        // The model type is the per-resource discriminator (e.g. EdFiContact vs HomographContact),
+        // supplied by the categorizer. Each verb is resolved WITHIN this resource's method group at
+        // construction time and validated, so every method property returns exactly one method (and a
+        // mis-categorized group fails fast here, when ResourceApis is enumerated, with a clear message
+        // rather than later as a SingleOrDefault throw or a null-reference inside BaseTest).
         public ResourceApi(Type apiType, Type modelType, IEnumerable<MethodInfo> resourceMethods)
         {
             ApiType = apiType;
             ModelType = modelType;
-            _methods = resourceMethods as List<MethodInfo> ?? resourceMethods.ToList();
+
+            var methods = resourceMethods as IReadOnlyList<MethodInfo> ?? resourceMethods.ToList();
+
+            if (methods.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"SdkCategorizer produced an empty method group for resource "
+                    + $"'{Describe(modelType)}' on API type '{Describe(apiType)}'. "
+                    + "Every resource must expose at least a POST method.");
+            }
+
+            PostMethod = SingleVerb(methods, apiType, modelType, "POST", m => m.Name.StartsWith("Post"));
+
+            if (PostMethod == null)
+            {
+                throw new InvalidOperationException(
+                    $"SdkCategorizer produced a resource group without a POST method for resource "
+                    + $"'{Describe(modelType)}' on API type '{Describe(apiType)}'. "
+                    + $"Methods in group: {string.Join(", ", methods.Select(m => m.Name))}.");
+            }
+
+            GetAllMethod = SingleVerb(
+                methods, apiType, modelType, "GET-all",
+                m => m.Name.StartsWith("Get")
+                     && !m.Name.Contains("ById", StringComparison.CurrentCultureIgnoreCase)
+                     && !m.Name.Contains("Partitions", StringComparison.CurrentCultureIgnoreCase));
+
+            GetByIdMethod = SingleVerb(
+                methods, apiType, modelType, "GET-by-id",
+                m => m.Name.StartsWith("Get") && m.Name.Contains("ById", StringComparison.CurrentCultureIgnoreCase));
+
+            PutMethod = SingleVerb(methods, apiType, modelType, "PUT", m => m.Name.StartsWith("Put"));
+
+            DeleteMethod = SingleVerb(
+                methods, apiType, modelType, "DELETE",
+                m => m.Name.StartsWith("Delete") && !m.Name.StartsWith("Deletes"));
         }
 
         public Type ApiType { get; }
 
-        // The model type is the per-resource discriminator (e.g. EdFiContact vs HomographContact),
-        // supplied by the categorizer. Each method property resolves WITHIN this resource's method
-        // group, so every verb returns exactly one method.
         public Type ModelType { get; }
 
-        public MethodInfo GetAllMethod => _methods.SingleOrDefault(
-            m => m.Name.StartsWith("Get")
-                 && !m.Name.Contains("ById", StringComparison.CurrentCultureIgnoreCase)
-                 && !m.Name.Contains("Partitions", StringComparison.CurrentCultureIgnoreCase));
+        public MethodInfo GetAllMethod { get; }
 
-        public MethodInfo GetByIdMethod => _methods.SingleOrDefault(
-            m => m.Name.StartsWith("Get") && m.Name.Contains("ById", StringComparison.CurrentCultureIgnoreCase));
+        public MethodInfo GetByIdMethod { get; }
 
-        public MethodInfo PostMethod => _methods.SingleOrDefault(m => m.Name.StartsWith("Post"));
+        public MethodInfo PostMethod { get; }
 
-        public MethodInfo PutMethod => _methods.SingleOrDefault(m => m.Name.StartsWith("Put"));
+        public MethodInfo PutMethod { get; }
 
-        public MethodInfo DeleteMethod => _methods.SingleOrDefault(
-            m => m.Name.StartsWith("Delete") && !m.Name.StartsWith("Deletes"));
+        public MethodInfo DeleteMethod { get; }
 
         public string Name => ModelType?.Name;
+
+        // Resolves the single method matching a verb within the group. A read-only verb may be absent
+        // (returns null, as before), but a duplicate signals a mis-categorized group and throws with a
+        // diagnostic instead of deferring to an opaque SingleOrDefault failure at the call site.
+        private static MethodInfo SingleVerb(
+            IReadOnlyList<MethodInfo> methods, Type apiType, Type modelType, string verb, Func<MethodInfo, bool> predicate)
+        {
+            var matches = methods.Where(predicate).ToList();
+
+            if (matches.Count > 1)
+            {
+                throw new InvalidOperationException(
+                    $"SdkCategorizer mapped {matches.Count} {verb} methods to resource "
+                    + $"'{Describe(modelType)}' on API type '{Describe(apiType)}': "
+                    + $"{string.Join(", ", matches.Select(m => m.Name))}. Exactly one was expected.");
+            }
+
+            return matches.Count == 1 ? matches[0] : null;
+        }
+
+        private static string Describe(Type type) => type?.FullName ?? "(unknown)";
     }
 }

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/SdkCategorizer.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/SdkCategorizer.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using EdFi.LoadTools.Engine;
-using Newtonsoft.Json;
 
 namespace EdFi.LoadTools.SmokeTest.SdkTests
 {
@@ -64,120 +63,175 @@ namespace EdFi.LoadTools.SmokeTest.SdkTests
 
         public IEnumerable<Type> ModelTypes => _modelTypes;
 
+        // A single generated API class can expose more than one resource: openapi-generator names the
+        // class from the OpenAPI tag, and a homonym extension (e.g. Homograph) puts its homonym resource
+        // on the core resource's tag. So one ContactsApi can carry both Contact and HomographContact. We
+        // therefore emit one IResourceApi per RESOURCE, not per API type.
         public IEnumerable<IResourceApi> ResourceApis => ApiTypes
-            .Select(x => new ResourceApi(x))
+            .SelectMany(BuildResourceApis)
             .Where(api => !string.IsNullOrEmpty(api.Name)) // Filter out APIs without names
             .ToList();
+
+        private static IEnumerable<ResourceApi> BuildResourceApis(Type apiType)
+        {
+            var candidates = apiType.GetMethods()
+                .Where(m =>
+                    m.Name.EndsWith("Async", StringComparison.CurrentCultureIgnoreCase)
+                    && !m.Name.Contains("OrDefault") // Exclude OrDefault variants
+                    && !m.Name.Contains("WithHttpInfo") // Exclude old-generator WithHttpInfo companions
+                    && !m.IsSpecialName
+                    && IsCrudVerb(m.Name))
+                .ToList();
+
+            // Each resource is anchored on its POST method: the POST parameter carries the resource model
+            // type, which is the discriminator the rest of the tooling keys on. (Read-only resources have
+            // no POST and no resolvable model type; they are filtered out by the Name check, as before.)
+            var resources = candidates
+                .Where(m => m.Name.StartsWith("Post"))
+                .Select(post => (
+                    Model: post.GetParameters().First().ParameterType,
+                    Stem: StemOf(post.Name),
+                    Token: TokenOf(post.Name)))
+                .ToList();
+
+            if (resources.Count == 0)
+            {
+                yield break;
+            }
+
+            // Common case: a single resource per API type. Assign every method to it, preserving the
+            // original behavior (no name-stem matching needed, so no risk with irregular pluralization).
+            if (resources.Count == 1)
+            {
+                yield return new ResourceApi(apiType, resources[0].Model, candidates);
+                yield break;
+            }
+
+            // Multi-resource (homonym) API type: assign each method to the resource it belongs to. The
+            // model type is only present on POST/PUT signatures, so GET/DELETE are matched by name using
+            // the openapi-generator's "_N" homonym suffix (token) plus the resource name-stem. POST and
+            // DELETE are singular while GET is plural, so we match on stem PREFIX (longest stem wins) to
+            // bridge the singular/plural difference and disambiguate stems that are prefixes of others.
+            var groups = resources.Select(_ => new List<MethodInfo>()).ToList();
+
+            foreach (var method in candidates)
+            {
+                var methodStem = StemOf(method.Name);
+                var methodToken = TokenOf(method.Name);
+
+                var bestIndex = -1;
+                var bestStemLength = -1;
+
+                for (var i = 0; i < resources.Count; i++)
+                {
+                    var resource = resources[i];
+
+                    if (resource.Token == methodToken
+                        && methodStem.StartsWith(resource.Stem, StringComparison.Ordinal)
+                        && resource.Stem.Length > bestStemLength)
+                    {
+                        bestIndex = i;
+                        bestStemLength = resource.Stem.Length;
+                    }
+                }
+
+                if (bestIndex >= 0)
+                {
+                    groups[bestIndex].Add(method);
+                }
+            }
+
+            for (var i = 0; i < resources.Count; i++)
+            {
+                yield return new ResourceApi(apiType, resources[i].Model, groups[i]);
+            }
+        }
+
+        private static bool IsCrudVerb(string name) =>
+            name.StartsWith("Post")
+            || name.StartsWith("Put")
+            || (name.StartsWith("Delete") && !name.StartsWith("Deletes"))
+            || (name.StartsWith("Get")
+                && (name.Contains("ById", StringComparison.CurrentCultureIgnoreCase)
+                    || !name.Contains("Partitions", StringComparison.CurrentCultureIgnoreCase)));
+
+        private static string VerbOf(string name)
+        {
+            if (name.StartsWith("Post")) return "Post";
+            if (name.StartsWith("Put")) return "Put";
+            if (name.StartsWith("Delete")) return "Delete";
+            if (name.StartsWith("Get")) return "Get";
+            return string.Empty;
+        }
+
+        // The openapi-generator's homonym disambiguator: a trailing "_N" segment (e.g. PostContact_0Async).
+        private static string TokenOf(string name)
+        {
+            var stem = StripAsyncSuffix(name);
+            var match = Regex.Match(stem, @"_(\d+)$");
+            return match.Success ? match.Value : string.Empty;
+        }
+
+        // The resource name shared by a resource's methods, e.g. "Contacts" for GetContactsAsync /
+        // GetContactsById_0Async after removing the verb, the "_N" token, the "Async" suffix and the
+        // "ById" marker.
+        private static string StemOf(string name)
+        {
+            var stem = StripAsyncSuffix(name);
+
+            var token = TokenOf(name);
+            if (token.Length > 0)
+            {
+                stem = stem.Substring(0, stem.Length - token.Length);
+            }
+
+            var verb = VerbOf(name);
+            if (verb.Length > 0 && stem.StartsWith(verb))
+            {
+                stem = stem.Substring(verb.Length);
+            }
+
+            return stem.Replace("ById", string.Empty);
+        }
+
+        private static string StripAsyncSuffix(string name) =>
+            name.EndsWith("Async", StringComparison.CurrentCultureIgnoreCase)
+                ? name.Substring(0, name.Length - "Async".Length)
+                : name;
     }
 
     public class ResourceApi : IResourceApi
     {
-        public ResourceApi(Type apiType)
+        private readonly List<MethodInfo> _methods;
+
+        public ResourceApi(Type apiType, Type modelType, IEnumerable<MethodInfo> resourceMethods)
         {
             ApiType = apiType;
+            ModelType = modelType;
+            _methods = resourceMethods as List<MethodInfo> ?? resourceMethods.ToList();
         }
-
-        private IEnumerable<MethodInfo> RestMethods
-        {
-            get
-            {
-                var methods = ApiType.GetMethods()
-                    .Where(x =>
-                        x.Name.EndsWith("Async", StringComparison.CurrentCultureIgnoreCase)
-                        && !x.Name.Contains("_")
-                        && !x.Name.Contains("OrDefault") // Exclude OrDefault variants
-                        && !x.IsSpecialName)
-                    .ToList();
-
-                IEnumerable<MethodInfo> FilterByVerb(string verb, Func<MethodInfo, bool> additionalFilter = null)
-                {
-                    var verbMethods = methods
-                        .Where(m => m.Name.StartsWith(verb, StringComparison.CurrentCultureIgnoreCase) && (additionalFilter == null || additionalFilter(m)))
-                        .ToList();
-
-                    if (verbMethods.Count > 1)
-                    {
-                        verbMethods = verbMethods
-                            .Where(m => !Regex.IsMatch(m.Name, @"_[a-zA-Z]"))
-                            .ToList();
-                    }
-
-                    return verbMethods;
-                }
-
-                // GET methods: split into non-ById and ById
-                var getNonByIdMethods = FilterByVerb("Get", m =>
-                    !m.Name.Contains("ById", StringComparison.CurrentCultureIgnoreCase)
-                    && !m.Name.Contains("Partitions", StringComparison.CurrentCultureIgnoreCase));
-
-                var getByIdMethods = FilterByVerb("Get", m =>
-                    m.Name.Contains("ById", StringComparison.CurrentCultureIgnoreCase));
-
-                // Other verbs
-                var postMethods = FilterByVerb("Post");
-                var putMethods = FilterByVerb("Put");
-                var deleteMethods = FilterByVerb("Delete");
-                var deletesMethods = FilterByVerb("Deletes");
-
-                return postMethods
-                    .Concat(getNonByIdMethods)
-                    .Concat(getByIdMethods)
-                    .Concat(putMethods)
-                    .Concat(deleteMethods)
-                    .Concat(deletesMethods)
-                    .Distinct()
-                    .ToArray();
-            }
-        }
-
-        private IEnumerable<MethodInfo> GetMethods => RestMethods.Where(m => m.Name.StartsWith("Get"));
 
         public Type ApiType { get; }
 
-        public Type ModelType => PostMethod?.GetParameters().First().ParameterType;
+        // The model type is the per-resource discriminator (e.g. EdFiContact vs HomographContact),
+        // supplied by the categorizer. Each method property resolves WITHIN this resource's method
+        // group, so every verb returns exactly one method.
+        public Type ModelType { get; }
 
-        public MethodInfo GetAllMethod
-            => GetMethods.SingleOrDefault(
-                m =>
-                    !m.Name.Contains("ById")
-                    && !m.Name.Contains("Partitions"));
+        public MethodInfo GetAllMethod => _methods.SingleOrDefault(
+            m => m.Name.StartsWith("Get")
+                 && !m.Name.Contains("ById", StringComparison.CurrentCultureIgnoreCase)
+                 && !m.Name.Contains("Partitions", StringComparison.CurrentCultureIgnoreCase));
 
-        public MethodInfo GetByIdMethod => GetMethods.SingleOrDefault(
-            m => m.Name.Contains("ById", StringComparison.CurrentCultureIgnoreCase));
+        public MethodInfo GetByIdMethod => _methods.SingleOrDefault(
+            m => m.Name.StartsWith("Get") && m.Name.Contains("ById", StringComparison.CurrentCultureIgnoreCase));
 
-        public MethodInfo PostMethod
-        {
-            get
-            {
-                var methods = RestMethods
-                    .Where(m => m.Name.StartsWith("Post"))
-                    .ToArray();
+        public MethodInfo PostMethod => _methods.SingleOrDefault(m => m.Name.StartsWith("Post"));
 
-                // Detect multiple matching methods, and report details
-                if (methods.Length > 1)
-                {
-                    var serializerSettings = new JsonSerializerSettings
-                    {
-                        ReferenceLoopHandling = ReferenceLoopHandling.Ignore
-                    };
+        public MethodInfo PutMethod => _methods.SingleOrDefault(m => m.Name.StartsWith("Put"));
 
-                    string methodsList = string.Join(
-                        Environment.NewLine,
-                        methods.Select(m => JsonConvert.SerializeObject(m, Formatting.Indented, serializerSettings)));
-
-                    string message = $"Multiple matching Post methods were found on type '{ApiType.FullName}'. Candidates are:{Environment.NewLine}{methodsList}";
-
-                    throw new Exception(message);
-                }
-
-                return methods.SingleOrDefault();
-            }
-        }
-
-        public MethodInfo PutMethod => RestMethods.SingleOrDefault(m => m.Name.StartsWith("Put"));
-
-        public MethodInfo DeleteMethod => RestMethods.SingleOrDefault(
-            m => m.Name.StartsWith("Delete") && !m.Name.Contains("Deletes"));
+        public MethodInfo DeleteMethod => _methods.SingleOrDefault(
+            m => m.Name.StartsWith("Delete") && !m.Name.StartsWith("Deletes"));
 
         public string Name => ModelType?.Name;
     }

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/SdkCategorizer.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/SdkTests/SdkCategorizer.cs
@@ -89,9 +89,10 @@ namespace EdFi.LoadTools.SmokeTest.SdkTests
             var resources = candidates
                 .Where(m => m.Name.StartsWith("Post"))
                 .Select(post => (
-                    Model: post.GetParameters().First().ParameterType,
+                    Model: post.GetParameters().FirstOrDefault()?.ParameterType,
                     Stem: StemOf(post.Name),
                     Token: TokenOf(post.Name)))
+                .Where(resource => resource.Model != null)
                 .ToList();
 
             if (resources.Count == 0)

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/Application/SdkConfigurationFactory.cs
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/Application/SdkConfigurationFactory.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Reflection;
 using EdFi.LoadTools.ApiClient;
 using EdFi.LoadTools.Common;
@@ -23,6 +22,7 @@ namespace EdFi.SmokeTest.Console.Application
         private readonly Type _configType;
         private readonly IOAuthTokenHandler _tokenHandler;
         private readonly IServiceProvider _serviceProvider;
+        private readonly bool _isHostConfiguration;
         public object SdkConfig;
 
         public SdkConfigurationFactory(IApiConfiguration apiConfiguration,
@@ -33,10 +33,67 @@ namespace EdFi.SmokeTest.Console.Application
             var sdkGenerationBasePath = sdkLibraryConfiguration.Path;
             var owinServerUrl = apiConfiguration.Url;
 
-            // Get HostConfiguration type from the SDK
-            var sdkConfigurationNamespace = $"{sdkLibraryConfiguration.SdkNamespacePrefix}.{EdFiConstants.SdkConfigurationClassName}";
-            _configType = GetTypeFromAssembly(sdkGenerationBasePath, sdkConfigurationNamespace);
+            // New-generator SDKs ship Client.HostConfiguration (DI-based); old-generator SDKs ship
+            // only Client.Configuration. Probe for the new type first and select the mode by which
+            // type is present - do NOT rely on catching exceptions for control flow.
+            var hostConfigurationName =
+                $"{sdkLibraryConfiguration.SdkNamespacePrefix}.{EdFiConstants.SdkConfigurationClassName}";
+            var hostConfigType = TryGetTypeFromAssembly(sdkGenerationBasePath, hostConfigurationName);
 
+            if (hostConfigType != null)
+            {
+                _isHostConfiguration = true;
+                _configType = hostConfigType;
+                _serviceProvider = ConfigureHostConfiguration(sdkGenerationBasePath, owinServerUrl);
+            }
+            else
+            {
+                // Pre-net10 (old-generator) fallback: construct Client.Configuration directly.
+                _isHostConfiguration = false;
+
+                var legacyConfigurationName =
+                    $"{sdkLibraryConfiguration.SdkNamespacePrefix}.{EdFiConstants.SdkConfigurationClassNameLegacy}";
+                _configType = GetTypeFromAssembly(sdkGenerationBasePath, legacyConfigurationName);
+
+                var defaultHeader = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                };
+
+                // 4-arg ctor: (defaultHeaders, apiKey, apiKeyPrefix, basePath). The old-generator SDK
+                // bakes the full request path (including /data/v3) into each operation, so the base
+                // path is the configured server URL as-is.
+                object[] args =
+                {
+                    defaultHeader, new Dictionary<string, string>(), new Dictionary<string, string>(), owinServerUrl
+                };
+
+                SdkConfig = Activator.CreateInstance(_configType, args);
+            }
+        }
+
+        public object SdkConfiguration
+        {
+            get
+            {
+                if (_isHostConfiguration)
+                {
+                    // Return the service provider for API instantiation (DI path).
+                    return _serviceProvider;
+                }
+
+                // Old-generator path: set the bearer token on the Configuration and return it.
+                var accessTokenProperty = _configType.GetProperty(EdFiConstants.AccessToken);
+                var token = _tokenHandler.GetBearerToken();
+
+                accessTokenProperty?.SetValue(SdkConfig, token);
+
+                return SdkConfig;
+            }
+        }
+
+        private IServiceProvider ConfigureHostConfiguration(string sdkGenerationBasePath, string owinServerUrl)
+        {
             // Configure service collection for DI
             var services = new ServiceCollection();
 
@@ -106,17 +163,18 @@ namespace EdFi.SmokeTest.Console.Application
             }
 
             // Build the service provider AFTER calling AddApiHttpClients
-            _serviceProvider = services.BuildServiceProvider();
+            var serviceProvider = services.BuildServiceProvider();
             SdkConfig = hostConfiguration;
+
+            return serviceProvider;
         }
 
-        public object SdkConfiguration
+        private static Type TryGetTypeFromAssembly(string sdkAssemblyPath, string typeToRetrieve)
         {
-            get
-            {
-                // Return the service provider for API instantiation
-                return _serviceProvider;
-            }
+            var assembly = Assembly.LoadFrom(sdkAssemblyPath);
+
+            return assembly.GetExportedTypes()
+                .FirstOrDefault(type => type.FullName != null && type.FullName.Contains(typeToRetrieve));
         }
 
         private static Type GetTypeFromAssembly(string sdkAssemblyPath, string typeToRetrieve)
@@ -129,7 +187,7 @@ namespace EdFi.SmokeTest.Console.Application
 
             if (configType == null)
             {
-                var availableTypes = string.Join(Environment.NewLine, 
+                var availableTypes = string.Join(Environment.NewLine,
                     reflectedAssemblyTypes
                         .Where(t => t.FullName != null && t.Namespace != null && t.Namespace.Contains("Client"))
                         .Select(t => $"  - {t.FullName}")

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/Application/SdkConfigurationFactory.cs
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/Application/SdkConfigurationFactory.cs
@@ -60,9 +60,13 @@ namespace EdFi.SmokeTest.Console.Application
                     { "Content-Type", "application/json" }
                 };
 
-                // 4-arg ctor: (defaultHeaders, apiKey, apiKeyPrefix, basePath). The old-generator SDK
-                // bakes the full request path (including /data/v3) into each operation, so the base
-                // path is the configured server URL as-is.
+                // 4-arg ctor: (defaultHeaders, apiKey, apiKeyPrefix, basePath). The old-generator SDK's
+                // operation paths OMIT the /data/v3 segment - they look like "/ed-fi/schools", not
+                // "/data/v3/ed-fi/schools" - so the base path must already be the data-management API
+                // URL (e.g. http://localhost:8765/data/v3), not the server root. Program resolves
+                // OdsApi:ApiUrl from the version endpoint's "dataManagementApi" to exactly that URL and
+                // surfaces it here as apiConfiguration.Url, so it is passed through as-is. Do NOT
+                // normalize it back to the server root.
                 object[] args =
                 {
                     defaultHeader, new Dictionary<string, string>(), new Dictionary<string, string>(), owinServerUrl
@@ -179,16 +183,15 @@ namespace EdFi.SmokeTest.Console.Application
 
         private static Type GetTypeFromAssembly(string sdkAssemblyPath, string typeToRetrieve)
         {
-            var assembly = Assembly.LoadFrom(sdkAssemblyPath);
-            var reflectedAssemblyTypes = assembly.GetExportedTypes();
-
-            var configType = reflectedAssemblyTypes.FirstOrDefault(
-                type => type.FullName != null && type.FullName.Contains(typeToRetrieve));
+            var configType = TryGetTypeFromAssembly(sdkAssemblyPath, typeToRetrieve);
 
             if (configType == null)
             {
+                // LoadFrom returns the already-loaded assembly, so this is cheap on the failure path.
+                var assembly = Assembly.LoadFrom(sdkAssemblyPath);
+
                 var availableTypes = string.Join(Environment.NewLine,
-                    reflectedAssemblyTypes
+                    assembly.GetExportedTypes()
                         .Where(t => t.FullName != null && t.Namespace != null && t.Namespace.Contains("Client"))
                         .Select(t => $"  - {t.FullName}")
                         .OrderBy(s => s));


### PR DESCRIPTION
## Summary

Fixes two distinct defects in `EdFi.Suite3.SmokeTest.Console` (and the shared `EdFi.LoadTools` library) that block the Data Management Service full SDK smoke sweep over a Homograph-inclusive surface (DMS-1210). Both are fixed together so the resulting console build is usable by DMS.

### Fix A — HostConfiguration fallback (dual-mode factory)
The net10 upgrade (ODS-6781, `f89df4ed9`) made `SdkConfigurationFactory` require `{prefix}.Client.HostConfiguration` and **throw** when absent. New-generator SDKs ship `Client.HostConfiguration`; old-generator SDKs (the DMS `EdFi.DmsApi.TestSdk` and the published, un-regenerable `EdFi.OdsApi.Sdk`) ship only `Client.Configuration`.

- `SdkConfigurationFactory` now **probes** for `Client.HostConfiguration` first and selects the mode by which type is present — it does not rely on catching exceptions.
- When absent, it falls back to the pre-net10 path: construct `Client.Configuration` with its 4-arg ctor and set the bearer token on `AccessToken`. (The new-gen DI path is preserved verbatim.)
- `EdFiConstants` re-adds `SdkConfigurationClassNameLegacy = "Client.Configuration"`.
- `BaseTest.GetApiInstance()` now short-circuits in legacy mode to `new XxxApi(configuration)`; otherwise the existing "manual construction" block would pick the parameterless constructor and yield a token-less / wrong-base-path instance.

### Fix B — SdkCategorizer supports multi-resource API classes
openapi-generator names an API class from the OpenAPI tag, and a homonym extension puts its homonym resource on the core resource's tag — so a single `ContactsApi` carries both `Contact` and `HomographContact`.

- `SdkCategorizer.ResourceApis` now emits **one `IResourceApi` per resource** (keyed on the POST model type) instead of one per API type; `ResourceApi` resolves each verb within its resource's method group and the multiple-POST throw is removed.
- The previous `!Name.Contains("_")` filter (which silently discarded the `_N` homonym methods) is removed and a `WithHttpInfo` filter added.
- GET/DELETE — which carry no model type in their signatures — are routed by the generator's `_N` suffix plus the resource name-stem (longest stem-prefix wins). This handles **both** the `_N`-suffix (ODS) and distinct-stem (DMS) homonym conventions and bridges the singular-POST/plural-GET name mismatch.
- Single-resource API types take a fast path that preserves the original behavior exactly.

The `IResourceApi` / `ISdkCategorizer` contracts are unchanged, so all consumers (`ModelDependencySort`, `DestructiveMethodsGenerator`, `GetMethodsGenerator`, and the per-verb tests) keep their single-resource view.

## Testing

- `EdFi.SmokeTest.Console` + `EdFi.LoadTools` build clean (`TreatWarningsAsErrors`, 0 warnings).
- `EdFi.LoadTools.Test` SmokeTests: **35/35 pass**, including 5 new tests:
  - Per-resource split against the real `ContactsApi` homonym — two resources (`EdFiContact` / `HomographContact`), each verb resolving to its own `_0` / non-`_0` method, no throw.
  - Single-resource regression (`AcademicWeeksApi`).
  - `ResourceApis.ToDictionary(ModelType.Name)` regression (DestructiveMethodsGenerator / ModelDependencySort).
  - Legacy `GetApiInstance` short-circuit constructs `new XxxApi(configuration)`.

## Downstream (not in this PR; tracked under DMS-1210)
Publish a new `EdFi.Suite3.SmokeTest.Console` build to the EdFi feed, then bump the `7.3.10008` pin in the DMS `eng/smoke_test/Invoke-NonDestructiveSdkTests.ps1` and `Invoke-DestructiveSdkTests.ps1` and re-run the scheduled smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)