### PR TITLE
[ODS-6844] Constrain SmokeTest default numeric range to common decimal caps

### DIFF
--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/PropertyBuilderTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/PropertyBuilderTests.cs
@@ -224,6 +224,8 @@ namespace EdFi.LoadTools.Test.SmokeTests
 
             public int? nullableProperty1 { get; set; }
 
+            public int? schoolId { get; set; }
+
             public DateTime dateTimeProperty1 { get; set; }
 
             public string startTime { get; set; }
@@ -455,5 +457,132 @@ namespace EdFi.LoadTools.Test.SmokeTests
             Assert.IsTrue(values.All(v => v <= 5));
         }
         #endregion
+
+#region EducationOrganizationIdBuilder tests
+
+        [Test]
+        public void EducationOrganizationIdBuilder_should_use_overridden_value_when_configured()
+        {
+            var obj = new Class1();
+            var propInfo = typeof(Class1).GetProperty("schoolId");
+
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+
+            var configuration = A.Fake<IDestructiveTestConfiguration>();
+            A.CallTo(() => configuration.EducationOrganizationIdOverrides)
+                .Returns(new Dictionary<string, int> { ["schoolId"] = 100000 });
+
+            var builder = new EducationOrganizationIdBuilder(lookup, configuration);
+
+            Assert.IsTrue(builder.BuildProperty(obj, propInfo));
+            Assert.AreEqual(100000, obj.schoolId);
+        }
+
+        [Test]
+        public void EducationOrganizationIdBuilder_should_use_edorg_safe_range_for_non_overridden_edorg_id()
+        {
+            var propInfo = typeof(Class1).GetProperty("schoolId");
+
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+            A.CallTo(() => lookup.GetMetadata(propInfo))
+                .Returns(new OpenApiParameter
+                {
+                    Required = true,
+                    Schema = new OpenApiSchema()
+                });
+
+            var configuration = A.Fake<IDestructiveTestConfiguration>();
+            A.CallTo(() => configuration.EducationOrganizationIdOverrides).Returns(new Dictionary<string, int>());
+
+            // A small generic max would put the generic 1..max fallback well below the EdOrg-safe range,
+            // so an EdOrg-safe value proves the EdOrg path, not the generic fallback, produced it.
+            A.CallTo(() => configuration.DefaultNumericFallbackMax).Returns(5);
+
+            var builder = new EducationOrganizationIdBuilder(lookup, configuration);
+
+            var values = Enumerable.Range(0, 3)
+                .Select(
+                    _ =>
+                    {
+                        var obj = new Class1();
+
+                        Assert.IsTrue(builder.BuildProperty(obj, propInfo));
+
+                        return obj.schoolId.Value;
+                    })
+                .ToArray();
+
+            Assert.AreEqual(
+                new[]
+                {
+                    DestructiveTestConfigurationDefaults.EducationOrganizationFallbackStart,
+                    DestructiveTestConfigurationDefaults.EducationOrganizationFallbackStart + 1,
+                    DestructiveTestConfigurationDefaults.EducationOrganizationFallbackStart + 2
+                },
+                values);
+            Assert.IsTrue(values.All(v => v >= DestructiveTestConfigurationDefaults.EducationOrganizationFallbackStart));
+        }
+
+        [Test]
+        public void EducationOrganizationIdBuilder_should_defer_when_non_overridden_edorg_id_publishes_bounds()
+        {
+            // If OpenAPI publishes numeric bounds for an EdOrg id, the EdOrg builder defers so SimplePropertyBuilder
+            // can honor those bounds instead of overriding them with the EdOrg-safe range.
+            var obj = new Class1();
+            var propInfo = typeof(Class1).GetProperty("schoolId");
+
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+            A.CallTo(() => lookup.GetMetadata(propInfo))
+                .Returns(new OpenApiParameter
+                {
+                    Required = true,
+                    Schema = new OpenApiSchema { Minimum = "1", Maximum = "10" }
+                });
+
+            var configuration = A.Fake<IDestructiveTestConfiguration>();
+            A.CallTo(() => configuration.EducationOrganizationIdOverrides).Returns(new Dictionary<string, int>());
+
+            var builder = new EducationOrganizationIdBuilder(lookup, configuration);
+
+            Assert.IsFalse(builder.BuildProperty(obj, propInfo));
+            Assert.IsFalse(obj.schoolId.HasValue);
+        }
+
+        [Test]
+        public void Builder_chain_should_resolve_non_overridden_edorg_id_through_education_organization_id_builder()
+        {
+            // SmokeTestsDestructiveSdkModule registers EducationOrganizationIdBuilder before SimplePropertyBuilder,
+            // and PostTest uses the first builder that handles the property (Any(...) short-circuits). The EdOrg
+            // builder must therefore claim a non-overridden EdOrg id so SimplePropertyBuilder never generates it
+            // from the generic 1..max range, which would reintroduce the populated-template collision risk.
+            var propInfo = typeof(Class1).GetProperty("schoolId");
+
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+            A.CallTo(() => lookup.GetMetadata(propInfo))
+                .Returns(new OpenApiParameter
+                {
+                    Required = true,
+                    Schema = new OpenApiSchema()
+                });
+
+            var configuration = A.Fake<IDestructiveTestConfiguration>();
+            A.CallTo(() => configuration.EducationOrganizationIdOverrides).Returns(new Dictionary<string, int>());
+            A.CallTo(() => configuration.DefaultNumericFallbackMax).Returns(5);
+            A.CallTo(() => configuration.UnifiedProperties).Returns(Array.Empty<string>());
+
+            var builders = new IPropertyBuilder[]
+            {
+                new EducationOrganizationIdBuilder(lookup, configuration),
+                new SimplePropertyBuilder(lookup, configuration)
+            };
+
+            var obj = new Class1();
+
+            Assert.IsTrue(builders.Any(b => b.BuildProperty(obj, propInfo)));
+            Assert.GreaterOrEqual(
+                obj.schoolId.Value, DestructiveTestConfigurationDefaults.EducationOrganizationFallbackStart);
+        }
+
+#endregion
     }
 }

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/PropertyBuilderTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/PropertyBuilderTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using EdFi.LoadTools.Engine;
 using EdFi.LoadTools.SmokeTest;
 using EdFi.LoadTools.SmokeTest.PropertyBuilders;
@@ -417,6 +418,41 @@ namespace EdFi.LoadTools.Test.SmokeTests
             var builder = new SimplePropertyBuilder(lookup, A.Fake<IDestructiveTestConfiguration>());
             Assert.IsTrue(builder.BuildProperty(obj, propInfo));
             Assert.AreNotEqual(default(int), obj.nullableProperty1);
+        }
+
+        [Test]
+        public void SimplePropertyBuilder_should_keep_no_bounds_numeric_fallback_within_configured_max()
+        {
+            var propInfo = typeof(Class1).GetProperty("nullableProperty1");
+
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+            A.CallTo(() => lookup.GetMetadata(propInfo))
+                .Returns(new OpenApiParameter
+                {
+                    Required = true,
+                    Schema = new OpenApiSchema()
+                });
+
+            var configuration = A.Fake<IDestructiveTestConfiguration>();
+            A.CallTo(() => configuration.DefaultNumericFallbackMax).Returns(5);
+            A.CallTo(() => configuration.UnifiedProperties).Returns(Array.Empty<string>());
+
+            var builder = new SimplePropertyBuilder(lookup, configuration);
+
+            var values = Enumerable.Range(0, 7)
+                .Select(
+                    _ =>
+                    {
+                        var obj = new Class1();
+
+                        Assert.IsTrue(builder.BuildProperty(obj, propInfo));
+
+                        return obj.nullableProperty1.Value;
+                    })
+                .ToArray();
+
+            Assert.AreEqual(new[] { 1, 2, 3, 4, 5, 1, 2 }, values);
+            Assert.IsTrue(values.All(v => v <= 5));
         }
         #endregion
     }

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/PropertyBuilderTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/PropertyBuilderTests.cs
@@ -616,9 +616,9 @@ namespace EdFi.LoadTools.Test.SmokeTests
         [Test]
         public void EducationOrganizationIdBuilder_should_honor_published_minimum_above_the_edorg_safe_start()
         {
-            // When a parseable minimum exceeds the EdOrg-safe start, the generated value must honor it while
-            // staying monotonic, i.e. max(nextEdOrgFallback, parsedMinimum).
-            var obj = new Class1();
+            // When a parseable minimum exceeds the EdOrg-safe start, generated values must honor it while staying
+            // monotonic across calls. A single call masks the bug; multiple EdOrg ids must not collide on the
+            // minimum, so consecutive values have to advance past it rather than repeat it.
             var propInfo = typeof(Class1).GetProperty("schoolId");
 
             const int publishedMinimum = DestructiveTestConfigurationDefaults.EducationOrganizationFallbackStart + 50000;
@@ -636,8 +636,20 @@ namespace EdFi.LoadTools.Test.SmokeTests
 
             var builder = new EducationOrganizationIdBuilder(lookup, configuration);
 
-            Assert.IsTrue(builder.BuildProperty(obj, propInfo));
-            Assert.AreEqual(publishedMinimum, obj.schoolId.Value);
+            var values = Enumerable.Range(0, 3)
+                .Select(
+                    _ =>
+                    {
+                        var obj = new Class1();
+
+                        Assert.IsTrue(builder.BuildProperty(obj, propInfo));
+
+                        return obj.schoolId.Value;
+                    })
+                .ToArray();
+
+            Assert.AreEqual(new[] { publishedMinimum, publishedMinimum + 1, publishedMinimum + 2 }, values);
+            Assert.IsTrue(values.All(v => v >= publishedMinimum));
         }
 
         [Test]
@@ -727,6 +739,72 @@ namespace EdFi.LoadTools.Test.SmokeTests
 
             Assert.IsTrue(builder.BuildProperty(obj, propInfo));
             Assert.AreEqual(255901d, obj.educationOrganizationId.Value);
+        }
+
+        [Test]
+        public void Builder_chain_should_set_nullable_long_edorg_id_when_deferred_with_published_maximum()
+        {
+            // A long? EdOrg id that publishes a parseable maximum defers to SimplePropertyBuilder, which must set
+            // the value as the property's underlying type rather than throwing on a boxed int.
+            var propInfo = typeof(Class1).GetProperty("localEducationAgencyId");
+
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+            A.CallTo(() => lookup.GetMetadata(propInfo))
+                .Returns(new OpenApiParameter
+                {
+                    Required = true,
+                    Schema = new OpenApiSchema { Maximum = "100" }
+                });
+
+            var configuration = A.Fake<IDestructiveTestConfiguration>();
+            A.CallTo(() => configuration.EducationOrganizationIdOverrides).Returns(new Dictionary<string, int>());
+            A.CallTo(() => configuration.DefaultNumericFallbackMax).Returns(5);
+            A.CallTo(() => configuration.UnifiedProperties).Returns(Array.Empty<string>());
+
+            var builders = new IPropertyBuilder[]
+            {
+                new EducationOrganizationIdBuilder(lookup, configuration),
+                new SimplePropertyBuilder(lookup, configuration)
+            };
+
+            var obj = new Class1();
+
+            Assert.IsTrue(builders.Any(b => b.BuildProperty(obj, propInfo)));
+            Assert.IsTrue(obj.localEducationAgencyId.HasValue);
+            Assert.AreEqual(100L, obj.localEducationAgencyId.Value);
+        }
+
+        [Test]
+        public void Builder_chain_should_set_nullable_double_edorg_id_when_deferred_with_published_maximum()
+        {
+            // A double? EdOrg id that publishes a parseable maximum defers to SimplePropertyBuilder, which must set
+            // the value as the property's underlying type rather than throwing on a boxed int.
+            var propInfo = typeof(Class1).GetProperty("educationOrganizationId");
+
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+            A.CallTo(() => lookup.GetMetadata(propInfo))
+                .Returns(new OpenApiParameter
+                {
+                    Required = true,
+                    Schema = new OpenApiSchema { Maximum = "100" }
+                });
+
+            var configuration = A.Fake<IDestructiveTestConfiguration>();
+            A.CallTo(() => configuration.EducationOrganizationIdOverrides).Returns(new Dictionary<string, int>());
+            A.CallTo(() => configuration.DefaultNumericFallbackMax).Returns(5);
+            A.CallTo(() => configuration.UnifiedProperties).Returns(Array.Empty<string>());
+
+            var builders = new IPropertyBuilder[]
+            {
+                new EducationOrganizationIdBuilder(lookup, configuration),
+                new SimplePropertyBuilder(lookup, configuration)
+            };
+
+            var obj = new Class1();
+
+            Assert.IsTrue(builders.Any(b => b.BuildProperty(obj, propInfo)));
+            Assert.IsTrue(obj.educationOrganizationId.HasValue);
+            Assert.AreEqual(100d, obj.educationOrganizationId.Value);
         }
 
 #endregion

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/PropertyBuilderTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/PropertyBuilderTests.cs
@@ -226,6 +226,10 @@ namespace EdFi.LoadTools.Test.SmokeTests
 
             public int? schoolId { get; set; }
 
+            public long? localEducationAgencyId { get; set; }
+
+            public double? educationOrganizationId { get; set; }
+
             public DateTime dateTimeProperty1 { get; set; }
 
             public string startTime { get; set; }
@@ -581,6 +585,148 @@ namespace EdFi.LoadTools.Test.SmokeTests
             Assert.IsTrue(builders.Any(b => b.BuildProperty(obj, propInfo)));
             Assert.GreaterOrEqual(
                 obj.schoolId.Value, DestructiveTestConfigurationDefaults.EducationOrganizationFallbackStart);
+        }
+
+        [Test]
+        public void EducationOrganizationIdBuilder_should_use_edorg_safe_range_when_only_minimum_is_published()
+        {
+            // A min-only bound gives SimplePropertyBuilder no maximum to honor, so it would fall back to the
+            // generic 1..max range. The EdOrg builder must keep the value in the EdOrg-safe range instead.
+            var obj = new Class1();
+            var propInfo = typeof(Class1).GetProperty("schoolId");
+
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+            A.CallTo(() => lookup.GetMetadata(propInfo))
+                .Returns(new OpenApiParameter
+                {
+                    Required = true,
+                    Schema = new OpenApiSchema { Minimum = "1" }
+                });
+
+            var configuration = A.Fake<IDestructiveTestConfiguration>();
+            A.CallTo(() => configuration.EducationOrganizationIdOverrides).Returns(new Dictionary<string, int>());
+
+            var builder = new EducationOrganizationIdBuilder(lookup, configuration);
+
+            Assert.IsTrue(builder.BuildProperty(obj, propInfo));
+            Assert.AreEqual(DestructiveTestConfigurationDefaults.EducationOrganizationFallbackStart, obj.schoolId.Value);
+            Assert.Greater(obj.schoolId.Value, DestructiveTestConfigurationDefaults.DefaultNumericFallbackMax);
+        }
+
+        [Test]
+        public void EducationOrganizationIdBuilder_should_honor_published_minimum_above_the_edorg_safe_start()
+        {
+            // When a parseable minimum exceeds the EdOrg-safe start, the generated value must honor it while
+            // staying monotonic, i.e. max(nextEdOrgFallback, parsedMinimum).
+            var obj = new Class1();
+            var propInfo = typeof(Class1).GetProperty("schoolId");
+
+            const int publishedMinimum = DestructiveTestConfigurationDefaults.EducationOrganizationFallbackStart + 50000;
+
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+            A.CallTo(() => lookup.GetMetadata(propInfo))
+                .Returns(new OpenApiParameter
+                {
+                    Required = true,
+                    Schema = new OpenApiSchema { Minimum = publishedMinimum.ToString() }
+                });
+
+            var configuration = A.Fake<IDestructiveTestConfiguration>();
+            A.CallTo(() => configuration.EducationOrganizationIdOverrides).Returns(new Dictionary<string, int>());
+
+            var builder = new EducationOrganizationIdBuilder(lookup, configuration);
+
+            Assert.IsTrue(builder.BuildProperty(obj, propInfo));
+            Assert.AreEqual(publishedMinimum, obj.schoolId.Value);
+        }
+
+        [Test]
+        public void EducationOrganizationIdBuilder_should_use_edorg_safe_range_when_bounds_are_unparseable()
+        {
+            // Unparseable bound strings are not usable by SimplePropertyBuilder, so they must not trigger deferral;
+            // the EdOrg-safe range still applies.
+            var obj = new Class1();
+            var propInfo = typeof(Class1).GetProperty("schoolId");
+
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+            A.CallTo(() => lookup.GetMetadata(propInfo))
+                .Returns(new OpenApiParameter
+                {
+                    Required = true,
+                    Schema = new OpenApiSchema { Minimum = "not-a-number", Maximum = "also-not-a-number" }
+                });
+
+            var configuration = A.Fake<IDestructiveTestConfiguration>();
+            A.CallTo(() => configuration.EducationOrganizationIdOverrides).Returns(new Dictionary<string, int>());
+
+            var builder = new EducationOrganizationIdBuilder(lookup, configuration);
+
+            Assert.IsTrue(builder.BuildProperty(obj, propInfo));
+            Assert.AreEqual(DestructiveTestConfigurationDefaults.EducationOrganizationFallbackStart, obj.schoolId.Value);
+        }
+
+        [Test]
+        public void EducationOrganizationIdBuilder_should_defer_when_only_maximum_is_published()
+        {
+            // A parseable maximum is a real ceiling SimplePropertyBuilder honors, so the EdOrg builder defers.
+            var obj = new Class1();
+            var propInfo = typeof(Class1).GetProperty("schoolId");
+
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+            A.CallTo(() => lookup.GetMetadata(propInfo))
+                .Returns(new OpenApiParameter
+                {
+                    Required = true,
+                    Schema = new OpenApiSchema { Maximum = "10" }
+                });
+
+            var configuration = A.Fake<IDestructiveTestConfiguration>();
+            A.CallTo(() => configuration.EducationOrganizationIdOverrides).Returns(new Dictionary<string, int>());
+
+            var builder = new EducationOrganizationIdBuilder(lookup, configuration);
+
+            Assert.IsFalse(builder.BuildProperty(obj, propInfo));
+            Assert.IsFalse(obj.schoolId.HasValue);
+        }
+
+        [Test]
+        public void EducationOrganizationIdBuilder_should_apply_override_to_nullable_long_property()
+        {
+            // The configured override is an int; a nullable long EdOrg id must accept it via type conversion
+            // rather than throwing on the boxed int.
+            var obj = new Class1();
+            var propInfo = typeof(Class1).GetProperty("localEducationAgencyId");
+
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+
+            var configuration = A.Fake<IDestructiveTestConfiguration>();
+            A.CallTo(() => configuration.EducationOrganizationIdOverrides)
+                .Returns(new Dictionary<string, int> { ["localEducationAgencyId"] = 255901 });
+
+            var builder = new EducationOrganizationIdBuilder(lookup, configuration);
+
+            Assert.IsTrue(builder.BuildProperty(obj, propInfo));
+            Assert.AreEqual(255901L, obj.localEducationAgencyId.Value);
+        }
+
+        [Test]
+        public void EducationOrganizationIdBuilder_should_apply_override_to_nullable_double_property()
+        {
+            // The configured override is an int; a nullable double EdOrg id must accept it via type conversion
+            // rather than throwing on the boxed int.
+            var obj = new Class1();
+            var propInfo = typeof(Class1).GetProperty("educationOrganizationId");
+
+            var lookup = A.Fake<IPropertyInfoMetadataLookup>();
+
+            var configuration = A.Fake<IDestructiveTestConfiguration>();
+            A.CallTo(() => configuration.EducationOrganizationIdOverrides)
+                .Returns(new Dictionary<string, int> { ["educationOrganizationId"] = 255901 });
+
+            var builder = new EducationOrganizationIdBuilder(lookup, configuration);
+
+            Assert.IsTrue(builder.BuildProperty(obj, propInfo));
+            Assert.AreEqual(255901d, obj.educationOrganizationId.Value);
         }
 
 #endregion

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SmokeTestsConfigurationTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SmokeTestsConfigurationTests.cs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Generic;
+using EdFi.LoadTools.SmokeTest;
+using EdFi.SmokeTest.Console.Application;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace EdFi.LoadTools.Test.SmokeTests
+{
+    [TestFixture]
+    public class SmokeTestsConfigurationTests
+    {
+        [Test]
+        public void Create_should_default_default_numeric_fallback_max_to_999()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                    new Dictionary<string, string>
+                    {
+                        ["TestSet"] = "DestructiveSdk"
+                    })
+                .Build();
+
+            var smokeTestsConfiguration = SmokeTestsConfiguration.Create(configuration);
+
+            Assert.AreEqual(999, smokeTestsConfiguration.DefaultNumericFallbackMax);
+        }
+
+        [Test]
+        public void Create_should_read_default_numeric_fallback_max_from_ods_api_configuration()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                    new Dictionary<string, string>
+                    {
+                        ["TestSet"] = "DestructiveSdk",
+                        ["OdsApi:DefaultNumericFallbackMax"] = "42"
+                    })
+                .Build();
+
+            var smokeTestsConfiguration = SmokeTestsConfiguration.Create(configuration);
+
+            Assert.AreEqual(42, smokeTestsConfiguration.DefaultNumericFallbackMax);
+        }
+
+        [Test]
+        public void Validator_should_reject_non_positive_default_numeric_fallback_max()
+        {
+            var configuration = new SmokeTestsConfiguration
+            {
+                ApiUrl = "http://localhost:54746/data/v3",
+                OAuthUrl = "http://localhost:54746/oauth/token",
+                MetadataUrl = "http://localhost:54746/metadata",
+                XsdMetadataUrl = "http://localhost:54746/metadata/xsd",
+                SdkLibraryPath = typeof(SmokeTestsConfigurationTests).Assembly.Location,
+                NamespacePrefix = "uri://ed-fi.org",
+                TestSet = TestSet.DestructiveSdk,
+                EducationOrganizationIdOverrides = new Dictionary<string, int>
+                {
+                    ["LocalEducationAgencyId"] = 100000
+                },
+                UnifiedProperties = new[] { "FiscalYear" },
+                DefaultNumericFallbackMax = 0
+            };
+
+            var validator = new SmokeTestConfigurationValidator(configuration);
+
+            Assert.IsFalse(validator.IsValid());
+            Assert.IsTrue(validator.ErrorText.Contains("OdsApi:DefaultNumericFallbackMax must be greater than zero."));
+        }
+    }
+}

--- a/Utilities/DataLoading/EdFi.LoadTools/Engine/DestructiveTestConfigurationDefaults.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/Engine/DestructiveTestConfigurationDefaults.cs
@@ -8,5 +8,10 @@ namespace EdFi.LoadTools.Engine
     public static class DestructiveTestConfigurationDefaults
     {
         public const int DefaultNumericFallbackMax = 999;
+
+        // Non-overridden EducationOrganization ids are generated starting here, well above the generic
+        // 1..DefaultNumericFallbackMax fallback range, so they do not collide with EdOrg ids that already
+        // exist when the smoke tests run against a populated template.
+        public const int EducationOrganizationFallbackStart = 1000;
     }
 }

--- a/Utilities/DataLoading/EdFi.LoadTools/Engine/DestructiveTestConfigurationDefaults.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/Engine/DestructiveTestConfigurationDefaults.cs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.LoadTools.Engine
+{
+    public static class DestructiveTestConfigurationDefaults
+    {
+        public const int DefaultNumericFallbackMax = 999;
+    }
+}

--- a/Utilities/DataLoading/EdFi.LoadTools/Engine/Interfaces.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/Engine/Interfaces.cs
@@ -45,6 +45,8 @@ namespace EdFi.LoadTools.Engine
         IReadOnlyDictionary<string, int> EducationOrganizationIdOverrides { get; }
 
         IEnumerable<string> UnifiedProperties { get; }
+
+        int DefaultNumericFallbackMax { get; }
     }
 
     public interface IHashCacheConfiguration

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/BaseBuilder.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/BaseBuilder.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
+using EdFi.LoadTools.Engine;
 using log4net;
 
 namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
@@ -15,15 +16,22 @@ namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
     public abstract class BaseBuilder : IPropertyBuilder
     {
         protected static readonly Random Random = new Random(1);
-        private int _counter = 1000; // Start at 1000 to avoid colliding with existing EdOrgIds if running on the populated template
+        private const int DefaultNumericFallbackStart = 1;
+        private int _defaultNumericFallbackValue = DefaultNumericFallbackStart;
+        private readonly int _defaultNumericFallbackMax;
         private readonly int _defaultStringLength = 7;
         private readonly IPropertyInfoMetadataLookup _metadataLookup;
 
         protected virtual ILog Log => LogManager.GetLogger(GetType().Name);
 
-        protected BaseBuilder(IPropertyInfoMetadataLookup metadataLookup)
+        protected BaseBuilder(
+            IPropertyInfoMetadataLookup metadataLookup,
+            int defaultNumericFallbackMax = DestructiveTestConfigurationDefaults.DefaultNumericFallbackMax)
         {
             _metadataLookup = metadataLookup;
+            _defaultNumericFallbackMax = defaultNumericFallbackMax > 0
+                ? defaultNumericFallbackMax
+                : DestructiveTestConfigurationDefaults.DefaultNumericFallbackMax;
         }
 
         bool IPropertyBuilder.BuildProperty(object obj, PropertyInfo propertyInfo)
@@ -109,7 +117,7 @@ namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
             }
             else if (hasMinimum)
             {
-                var min = decimal.Max(minValue, _counter++);
+                var min = decimal.Max(minValue, NextDefaultNumericFallback());
 
                 return (int)min;
             }
@@ -119,8 +127,19 @@ namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
             }
             else
             {
-                return _counter++;
+                return NextDefaultNumericFallback();
             }
+        }
+
+        private int NextDefaultNumericFallback()
+        {
+            var value = _defaultNumericFallbackValue;
+
+            _defaultNumericFallbackValue = _defaultNumericFallbackValue >= _defaultNumericFallbackMax
+                ? DefaultNumericFallbackStart
+                : _defaultNumericFallbackValue + 1;
+
+            return value;
         }
     }
 }

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/BaseBuilder.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/BaseBuilder.cs
@@ -98,6 +98,14 @@ namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
             return parameter.Required;
         }
 
+        protected bool HasPublishedNumericBounds(PropertyInfo propertyInfo)
+        {
+            var schema = _metadataLookup.GetMetadata(propertyInfo).Schema;
+
+            return schema != null &&
+                   (!string.IsNullOrEmpty(schema.Minimum) || !string.IsNullOrEmpty(schema.Maximum));
+        }
+
         protected int BuildRandomNumber(PropertyInfo propertyInfo)
         {
             var parameter = _metadataLookup.GetMetadata(propertyInfo);

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/BaseBuilder.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/BaseBuilder.cs
@@ -98,12 +98,41 @@ namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
             return parameter.Required;
         }
 
-        protected bool HasPublishedNumericBounds(PropertyInfo propertyInfo)
+        /// <summary>
+        ///     Returns true only when OpenAPI publishes a <c>Maximum</c> that actually parses. This mirrors what
+        ///     <see cref="BuildRandomNumber" /> can honor: a parseable maximum produces a bounded or max-only value,
+        ///     whereas a min-only, empty, or unparseable bound falls back to the generic numeric range. Callers that
+        ///     need to know whether deferring to the generic numeric builder will respect a real ceiling should use
+        ///     this rather than treating any non-empty bound string as published bounds.
+        /// </summary>
+        protected bool HasParseableMaximum(PropertyInfo propertyInfo)
         {
             var schema = _metadataLookup.GetMetadata(propertyInfo).Schema;
 
-            return schema != null &&
-                   (!string.IsNullOrEmpty(schema.Minimum) || !string.IsNullOrEmpty(schema.Maximum));
+            return schema != null
+                   && !string.IsNullOrEmpty(schema.Maximum)
+                   && decimal.TryParse(schema.Maximum, out _);
+        }
+
+        /// <summary>
+        ///     Attempts to read a published <c>Minimum</c> that parses, clamped to the int range used by the numeric
+        ///     builders. Returns false for empty or unparseable minimums so callers can fall back to their own range.
+        /// </summary>
+        protected bool TryGetParseableMinimum(PropertyInfo propertyInfo, out int minimum)
+        {
+            minimum = 0;
+
+            var schema = _metadataLookup.GetMetadata(propertyInfo).Schema;
+
+            if (schema == null
+                || string.IsNullOrEmpty(schema.Minimum)
+                || !decimal.TryParse(schema.Minimum, out var value))
+            {
+                return false;
+            }
+
+            minimum = (int)decimal.Max(decimal.Min(value, int.MaxValue), int.MinValue);
+            return true;
         }
 
         protected int BuildRandomNumber(PropertyInfo propertyInfo)

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/EducationOrganizationIdBuilder.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/EducationOrganizationIdBuilder.cs
@@ -48,7 +48,13 @@ namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
         {
             if (_educationOrganizationIdOverrides.ContainsKey(propertyInfo.Name))
             {
-                propertyInfo.SetValue(obj, _educationOrganizationIdOverrides[propertyInfo.Name]);
+                // Convert the configured (int) override to the property's underlying numeric type so nullable
+                // long/double EdOrg ids accept it instead of throwing on the boxed int, matching the
+                // non-overridden path below.
+                var overrideTargetType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? propertyInfo.PropertyType;
+
+                propertyInfo.SetValue(
+                    obj, Convert.ChangeType(_educationOrganizationIdOverrides[propertyInfo.Name], overrideTargetType));
                 return true;
             }
 
@@ -56,16 +62,29 @@ namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
             // colliding with EdOrg ids that already exist on a populated template. Generate them from the
             // dedicated EdOrg-safe range here rather than letting them fall through to the generic
             // 1..DefaultNumericFallbackMax fallback in SimplePropertyBuilder, which is sized for capped decimals.
-            // When OpenAPI actually publishes numeric bounds for the id, defer to SimplePropertyBuilder so the
-            // published bounds are honored.
             if (IsRequired(propertyInfo)
                 && IsEducationOrganizationId(propertyInfo.Name)
-                && !HasPublishedNumericBounds(propertyInfo)
                 && (IsTypeMatch<int>(propertyInfo) || IsTypeMatch<long>(propertyInfo) || IsTypeMatch<double>(propertyInfo)))
             {
-                var targetType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? propertyInfo.PropertyType;
+                // Defer to SimplePropertyBuilder only when OpenAPI publishes a parseable maximum (a bounded or
+                // max-only range) it can actually honor. A min-only bound, or an unparseable Minimum/Maximum
+                // string, leaves SimplePropertyBuilder with the generic 1..DefaultNumericFallbackMax range, which
+                // would reintroduce the populated-template collision risk for EdOrg ids, so those cases stay here.
+                if (HasParseableMaximum(propertyInfo))
+                {
+                    return false;
+                }
 
-                propertyInfo.SetValue(obj, Convert.ChangeType(_educationOrganizationFallbackValue++, targetType));
+                var targetType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? propertyInfo.PropertyType;
+                var value = _educationOrganizationFallbackValue++;
+
+                // Honor a published, parseable minimum while keeping values monotonic within the EdOrg-safe range.
+                if (TryGetParseableMinimum(propertyInfo, out var minimum))
+                {
+                    value = Math.Max(value, minimum);
+                }
+
+                propertyInfo.SetValue(obj, Convert.ChangeType(value, targetType));
                 return true;
             }
 

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/EducationOrganizationIdBuilder.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/EducationOrganizationIdBuilder.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using EdFi.LoadTools.Engine;
 
@@ -12,7 +13,27 @@ namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
 {
     public class EducationOrganizationIdBuilder : BaseBuilder
     {
+        // EducationOrganization identifier names (and their subtype-specific variants) recognized so that
+        // non-overridden EdOrg ids are generated from an EdOrg-safe range instead of the generic numeric
+        // fallback. Matched as suffixes (case-insensitive) so prefixed forms such as ResponsibilitySchoolId
+        // are also covered.
+        private static readonly string[] EducationOrganizationIdSuffixes =
+        {
+            "EducationOrganizationId",
+            "StateEducationAgencyId",
+            "LocalEducationAgencyId",
+            "EducationServiceCenterId",
+            "SchoolId",
+            "CommunityProviderId",
+            "CommunityOrganizationId",
+            "EducationOrganizationNetworkId",
+            "PostSecondaryInstitutionId",
+            "OrganizationDepartmentId"
+        };
+
         private readonly IReadOnlyDictionary<string, int> _educationOrganizationIdOverrides;
+        private int _educationOrganizationFallbackValue =
+            DestructiveTestConfigurationDefaults.EducationOrganizationFallbackStart;
 
         public EducationOrganizationIdBuilder(
             IPropertyInfoMetadataLookup metadataLookup,
@@ -25,14 +46,34 @@ namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
 
         public override bool BuildProperty(object obj, PropertyInfo propertyInfo)
         {
-            if (!_educationOrganizationIdOverrides.ContainsKey(propertyInfo.Name))
+            if (_educationOrganizationIdOverrides.ContainsKey(propertyInfo.Name))
             {
-                // EdOrg ids that aren't relevant for authorization are initialized in the SimplePropertyBuilder
-                return false;
+                propertyInfo.SetValue(obj, _educationOrganizationIdOverrides[propertyInfo.Name]);
+                return true;
             }
 
-            propertyInfo.SetValue(obj, _educationOrganizationIdOverrides[propertyInfo.Name]);
-            return true;
+            // Non-overridden EdOrg ids are not relevant for authorization, but they still must avoid
+            // colliding with EdOrg ids that already exist on a populated template. Generate them from the
+            // dedicated EdOrg-safe range here rather than letting them fall through to the generic
+            // 1..DefaultNumericFallbackMax fallback in SimplePropertyBuilder, which is sized for capped decimals.
+            // When OpenAPI actually publishes numeric bounds for the id, defer to SimplePropertyBuilder so the
+            // published bounds are honored.
+            if (IsRequired(propertyInfo)
+                && IsEducationOrganizationId(propertyInfo.Name)
+                && !HasPublishedNumericBounds(propertyInfo)
+                && (IsTypeMatch<int>(propertyInfo) || IsTypeMatch<long>(propertyInfo) || IsTypeMatch<double>(propertyInfo)))
+            {
+                var targetType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? propertyInfo.PropertyType;
+
+                propertyInfo.SetValue(obj, Convert.ChangeType(_educationOrganizationFallbackValue++, targetType));
+                return true;
+            }
+
+            return false;
         }
+
+        private static bool IsEducationOrganizationId(string propertyName)
+            => EducationOrganizationIdSuffixes.Any(
+                suffix => propertyName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/EducationOrganizationIdBuilder.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/EducationOrganizationIdBuilder.cs
@@ -76,13 +76,17 @@ namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
                 }
 
                 var targetType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? propertyInfo.PropertyType;
-                var value = _educationOrganizationFallbackValue++;
 
-                // Honor a published, parseable minimum while keeping values monotonic within the EdOrg-safe range.
-                if (TryGetParseableMinimum(propertyInfo, out var minimum))
+                // Honor a published, parseable minimum by advancing the shared counter up to it, so generated
+                // values stay both at-or-above the minimum and monotonic. Clamping each value with Math.Max would
+                // instead return the same minimum on every call until the counter caught up, colliding EdOrg ids.
+                if (TryGetParseableMinimum(propertyInfo, out var minimum)
+                    && _educationOrganizationFallbackValue < minimum)
                 {
-                    value = Math.Max(value, minimum);
+                    _educationOrganizationFallbackValue = minimum;
                 }
+
+                var value = _educationOrganizationFallbackValue++;
 
                 propertyInfo.SetValue(obj, Convert.ChangeType(value, targetType));
                 return true;

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/SimplePropertyBuilder.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/SimplePropertyBuilder.cs
@@ -39,7 +39,12 @@ namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
             {
                 if (IsRequired(propertyInfo))
                 {
-                    propertyInfo.SetValue(obj, GetOrAdd(propertyInfo.Name, BuildRandomNumber(propertyInfo)));
+                    // BuildRandomNumber yields an int; convert it to the property's underlying numeric type so
+                    // nullable long/double properties accept it instead of throwing on the boxed int.
+                    var targetType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? propertyInfo.PropertyType;
+
+                    propertyInfo.SetValue(
+                        obj, Convert.ChangeType(GetOrAdd(propertyInfo.Name, BuildRandomNumber(propertyInfo)), targetType));
                 }
 
                 return true;

--- a/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/SimplePropertyBuilder.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools/SmokeTest/PropertyBuilders/SimplePropertyBuilder.cs
@@ -20,7 +20,7 @@ namespace EdFi.LoadTools.SmokeTest.PropertyBuilders
         private readonly Dictionary<string, object> _unifiedKeyValue;
 
         public SimplePropertyBuilder(IPropertyInfoMetadataLookup metadataLookup, IDestructiveTestConfiguration configuration)
-            : base(metadataLookup)
+            : base(metadataLookup, configuration.DefaultNumericFallbackMax)
         {
             _unifiedKeyValue = new(
                 configuration.UnifiedProperties.Distinct(StringComparer.OrdinalIgnoreCase)

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/Application/CommandLineOverrides.cs
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/Application/CommandLineOverrides.cs
@@ -48,6 +48,11 @@ namespace EdFi.SmokeTest.Console.Application
         [Option('c', "sdknamespaceprefix", Required = false, HelpText = "The Test SDK Configuration Namespace Prefix")]
         public string SdkNamespacePrefix { get; set; }
 
+        [Option(
+            "defaultNumericFallbackMax", Required = false,
+            HelpText = "Maximum value used for required numeric properties when OpenAPI does not publish minimum or maximum bounds.")]
+        public int? DefaultNumericFallbackMax { get; set; }
+
         public static IDictionary<string, string> SwitchingMapping()
             => new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
             {
@@ -72,7 +77,8 @@ namespace EdFi.SmokeTest.Console.Application
                 {"--secret", "OdsApi:Secret"},
                 {"--testset", "TestSet"},
                 {"--baseurl", "OdsApi:Url"},
-                {"--sdkNamespacePrefix", "SdkNamespacePrefix"}
+                {"--sdkNamespacePrefix", "SdkNamespacePrefix"},
+                {"--defaultNumericFallbackMax", "OdsApi:DefaultNumericFallbackMax"}
             };
     }
 }

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/Application/SmokeTestConfigurationValidator.cs
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/Application/SmokeTestConfigurationValidator.cs
@@ -68,12 +68,18 @@ namespace EdFi.SmokeTest.Console.Application
                    (_configuration.UnifiedProperties != null && _configuration.UnifiedProperties.Any());
         }
 
+        private bool ValidDefaultNumericFallbackMax
+        {
+            get => _configuration.DefaultNumericFallbackMax > 0;
+        }
+
         public string ErrorText { get; private set; }
 
         public bool IsValid()
         {
             var isValid = ValidApiUrl && ValidOAuthUrl && ValidMetadataUrl && ValidXsdMetadataUrl && ValidSdkLibraryPath &&
-                          ValidNamespacePrefix && ValidEducationOrganizationIdOverrides && ValidUnifiedProperties;
+                          ValidNamespacePrefix && ValidEducationOrganizationIdOverrides && ValidUnifiedProperties &&
+                          ValidDefaultNumericFallbackMax;
 
             if (!isValid)
             {
@@ -125,6 +131,11 @@ namespace EdFi.SmokeTest.Console.Application
             if (!ValidUnifiedProperties)
             {
                 sb.AppendLine("UnifiedProperties is required");
+            }
+
+            if (!ValidDefaultNumericFallbackMax)
+            {
+                sb.AppendLine("OdsApi:DefaultNumericFallbackMax must be greater than zero.");
             }
 
             return sb.ToString();

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/Application/SmokeTestsConfiguration.cs
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/Application/SmokeTestsConfiguration.cs
@@ -82,6 +82,8 @@ namespace EdFi.SmokeTest.Console.Application
 
         public IEnumerable<string> UnifiedProperties { get; set; }
 
+        public int DefaultNumericFallbackMax { get; set; }
+
         string IOAuthSessionToken.SessionToken { get; set; }
 
         // IOAuthTokenConfiguration
@@ -137,6 +139,9 @@ namespace EdFi.SmokeTest.Console.Application
                 EducationOrganizationIdOverrides =
                     configuration.GetSection("EducationOrganizationIdOverrides").Get<IReadOnlyDictionary<string, int>>(),
                 UnifiedProperties = configuration.GetSection("UnifiedProperties").Get<IEnumerable<string>>(),
+                DefaultNumericFallbackMax = configuration.GetValue(
+                    "OdsApi:DefaultNumericFallbackMax",
+                    DestructiveTestConfigurationDefaults.DefaultNumericFallbackMax),
                 SdkLibraryPath = configuration.GetValue<string>("SdkLibraryPath"),
                 TestSet = testSet
             };

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
@@ -12,7 +12,7 @@
     <Authors>Ed-Fi Alliance</Authors>
     <Company>Ed-Fi Alliance</Company>
     <Product>Ed-Fi Smoke Test Console</Product>
-    <Description>Smoke Test utility for the Ed-Fi ODS/API solution.</Description>
+    <Description>Smoke Test utility for the Ed-Fi ODS/API solution. Destructive SDK tests use OdsApi:DefaultNumericFallbackMax to bound generated values for required numeric fields whose OpenAPI metadata omits numeric constraints.</Description>
     <PackageProjectUrl>https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackAsTool>true</PackAsTool>

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/appsettings.json
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/appsettings.json
@@ -13,7 +13,8 @@
     "MetadataUrl": "",
     "OAuthUrl": "",
     "DependenciesUrl": "",
-    "Url": ""
+    "Url": "",
+    "DefaultNumericFallbackMax": 999
   },
   "NamespacePrefix": "uri://ed-fi.org",
   "SdkNamespacePrefix": "EdFi.OdsApi.Sdk",

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/readme.md
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/readme.md
@@ -12,3 +12,23 @@ To disable authorization you can run this query on the EdFi_Security database
   update [EdFi_Security].[dbo].[ResourceClaimAuthorizationMetadatas] set AuthorizationStrategy_AuthorizationStrategyId = 1
 
 Deleting the EdFi_Security database will cause it to be rebuilt with the default claims
+
+## destructive SDK numeric fallback
+
+When OpenAPI omits `minimum` and `maximum` for a required numeric property, destructive SDK tests generate integer values from `1` through `OdsApi:DefaultNumericFallbackMax`, then repeat from `1`. The default is `999`, which keeps generated values inside common decimal precision caps such as `999.99` for fields like `hoursPerWeek`.
+
+Override the maximum in `appsettings.json`:
+
+```json
+{
+  "OdsApi": {
+    "DefaultNumericFallbackMax": 999
+  }
+}
+```
+
+Override the maximum from the command line:
+
+```powershell
+dotnet run --project EdFi.SmokeTest.Console.csproj -- --defaultNumericFallbackMax 999
+```

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/readme.md
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/readme.md
@@ -15,7 +15,24 @@ Deleting the EdFi_Security database will cause it to be rebuilt with the default
 
 ## destructive SDK numeric fallback
 
-When OpenAPI omits `minimum` and `maximum` for a required numeric property, destructive SDK tests generate integer values from `1` through `OdsApi:DefaultNumericFallbackMax`, then repeat from `1`. The default is `999`, which keeps generated values inside common decimal precision caps such as `999.99` for fields like `hoursPerWeek`.
+When OpenAPI omits `minimum` and `maximum` for a required numeric property, destructive SDK tests generate
+integer values from `1` through `OdsApi:DefaultNumericFallbackMax` and then repeat from `1`. Because the values
+wrap, they are **not** guaranteed to be unique once more than `DefaultNumericFallbackMax` no-bounds numeric
+properties have been generated.
+
+The default of `999` is a heuristic: it keeps generated values inside common decimal precision caps such as
+`999.99` for fields like `hoursPerWeek`. It is not derived from the server's actual constraints, so a resource
+with a tighter unpublished cap (for example a `decimal(4,2)` field capped at `99.99`) may still reject the
+generated value. In that case lower `DefaultNumericFallbackMax` to fit the strictest required field under test.
+
+This generic fallback does **not** preserve identity or EducationOrganization (EdOrg) semantics. EdOrg id safety
+is provided by the dedicated EdOrg path in `EducationOrganizationIdBuilder`, not by this fallback:
+
+- EdOrg ids listed in `EducationOrganizationIdOverrides` use their configured values.
+- Non-overridden EdOrg ids are generated from a separate range starting at
+  `DestructiveTestConfigurationDefaults.EducationOrganizationFallbackStart` (`1000`), well above the generic
+  `1..DefaultNumericFallbackMax` range, so they do not collide with EdOrg ids that already exist on a populated
+  template.
 
 Override the maximum in `appsettings.json`:
 


### PR DESCRIPTION
## Summary

EdFi.LoadTools destructive SDK smoke tests previously generated default values for required numeric properties starting at `1000` whenever OpenAPI omitted `minimum`/`maximum`. The server enforces decimal precision with an effective cap (e.g. `999.99` for `hoursPerWeek`), so these POSTs received 400 validation errors for fields such as `Sample.BusRoute` and `Sample.StudentGraduationPlanAssociation`.

This change replaces the unbounded counter in `BaseBuilder` with a bounded `1..max` fallback that wraps back to `1`. The maximum is configurable via `OdsApi:DefaultNumericFallbackMax` (default `999`), with a `--defaultNumericFallbackMax` command-line override and validation that rejects non-positive values.

This is **client-side only**. No server-side OpenAPI generation, decimal metadata publication, skip lists, or `multipleOf` handling was touched.

### Generic numeric fallback is bounded and repeating

For required numeric properties with **no** published `minimum`/`maximum`, generated values run `1..DefaultNumericFallbackMax` and then **repeat from `1`** — they are not unique once more than `DefaultNumericFallbackMax` such values have been generated. The default `999` is a **heuristic** that fits common decimal precision caps (`999.99`); it is not derived from the server's real constraints, so a resource with a tighter, unpublished cap may still require lowering `DefaultNumericFallbackMax`.

### Identity / EdOrg fallback is preserved through the dedicated EdOrg path

The original `1000+` counter existed to keep generated EducationOrganization (EdOrg) ids from colliding with EdOrg ids that already exist on a populated template. The first revision of this PR routed **all** no-bounds numerics (including non-overridden EdOrg ids) through the new `1..999` generic fallback, which unintentionally reintroduced that collision risk — so the earlier "identity behavior is unchanged" claim was too broad.

EdOrg safety is now provided **only** by the dedicated EdOrg path in `EducationOrganizationIdBuilder` (registered before `SimplePropertyBuilder`), not by the generic fallback:

- EdOrg ids in `EducationOrganizationIdOverrides` use their configured values (unchanged).
- **Non-overridden** EdOrg ids are now claimed by `EducationOrganizationIdBuilder` and generated from a separate range starting at `DestructiveTestConfigurationDefaults.EducationOrganizationFallbackStart` (`1000`), preserving the original collision-avoidance behavior. When OpenAPI actually publishes bounds for such an id, the EdOrg builder defers so `SimplePropertyBuilder` honors them.

`UniqueIdPropertyBuilder` continues to generate strings, so string identity uniqueness is unaffected.

## Changes

- **New** `DestructiveTestConfigurationDefaults` — shared `DefaultNumericFallbackMax = 999` and `EducationOrganizationFallbackStart = 1000`.
- `IDestructiveTestConfiguration` — exposes `DefaultNumericFallbackMax`.
- `BaseBuilder` — bounded, wrapping generic numeric fallback; configurable max (guards non-positive input); adds `HasPublishedNumericBounds` helper.
- `EducationOrganizationIdBuilder` — claims non-overridden EdOrg-like numeric ids and generates them from the EdOrg-safe `1000+` range (deferring when bounds are published).
- `SimplePropertyBuilder` — passes the configured max into the base builder.
- `SmokeTestsConfiguration` — binds `OdsApi:DefaultNumericFallbackMax` (default 999).
- `SmokeTestConfigurationValidator` — rejects non-positive values.
- `CommandLineOverrides` — adds `--defaultNumericFallbackMax`.
- `appsettings.json`, `readme.md`, `.csproj` description — documentation.

## Testing

- `PropertyBuilderTests` — pass, including:
  - generic no-bounds fallback wraps within the configured max (`1,2,3,4,5,1,2` at max 5);
  - a non-overridden EdOrg-like id (`schoolId`) uses the EdOrg-safe `1000+` range, not the generic `1..max` range;
  - the EdOrg builder wins over `SimplePropertyBuilder` in registration order (`Any(...)` short-circuit);
  - the EdOrg builder defers when an EdOrg id publishes bounds.
- `SmokeTestsConfigurationTests` — pass: default 999, override binding, non-positive rejection.
- `dotnet build LoadTools.sln` — builds clean.
- Pre-existing environment-dependent test failures (XSD retrieval, mapping factories, live-API tests) reproduce identically on a clean baseline and are unrelated to this change.
- Manual destructive SDK smoke run against a live ODS was **not run** — no local ODS reachable at `:54746` in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
