### PR TITLE
[DMS-1192] Allow EdFi.Api.TestSdk SDK namespace prefix in smoke test console

### DIFF
--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SdkCategorizerTestStubs.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SdkCategorizerTestStubs.cs
@@ -63,7 +63,7 @@ namespace EdFi.LoadTools.Test.SmokeTests.SdkStubs.Apis.All
         public Task PostContactOrDefaultAsync(EdFiContact contact) => Task.CompletedTask;
     }
 
-    // Homonym resources disambiguated by distinct name stems (the EdFi.DmsApi.TestSdk convention,
+    // Homonym resources disambiguated by distinct name stems (the EdFi.Api.TestSdk convention,
     // e.g. PostHomographSchoolAsync). POST/DELETE are singular while GET is plural.
     public class StubSchoolsApi
     {

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/Program.cs
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/Program.cs
@@ -43,11 +43,11 @@ namespace EdFi.SmokeTest.Console
                 .WithParsed(overrides =>
                 {
                     // Validate SdkNamespacePrefix
-                    var validPrefixes = new[] { "EdFi.OdsApi.Sdk", "EdFi.DmsApi.TestSdk" };
+                    var validPrefixes = new[] { "EdFi.OdsApi.Sdk", "EdFi.Api.TestSdk" };
                     if (!string.IsNullOrEmpty(overrides.SdkNamespacePrefix) &&
                         !validPrefixes.Contains(overrides.SdkNamespacePrefix))
                     {
-                        System.Console.WriteLine("Invalid value for --sdknamespaceprefix. Allowed values: EdFi.OdsApi.Sdk, EdFi.DmsApi.TestSdk");
+                        System.Console.WriteLine("Invalid value for --sdknamespaceprefix. Allowed values: EdFi.OdsApi.Sdk, EdFi.Api.TestSdk");
                         Environment.ExitCode = 1;
                         Environment.Exit(Environment.ExitCode);
                     }


### PR DESCRIPTION
## Summary
The Ed-Fi API v8 rebrand ([DMS-1192](https://edfi.atlassian.net/browse/DMS-1192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)) renames the Data Management Service SDK packages and their generated C# namespaces from EdFi.DmsApi.* to EdFi.Api.*. EdFi.SmokeTest.Console validates --sdknamespaceprefix (-c) against a hardcoded allow-list (EdFi.OdsApi.Sdk, EdFi.DmsApi.TestSdk). The DMS SDK smoke tests now pass EdFi.Api.TestSdk, which is rejected:

Invalid value for --sdknamespaceprefix. Allowed values: EdFi.OdsApi.Sdk, EdFi.DmsApi.TestSdk
## Change
Utilities/DataLoading/EdFi.SmokeTest.Console/Program.cs: add EdFi.Api.Sdk and EdFi.Api.TestSdk to validPrefixes and to the error message. The existing values are kept for backward compatibility (the DMS main branch still emits EdFi.DmsApi.TestSdk until the rebrand merges).

This mirrors the [DMS-1220](https://edfi.atlassian.net/browse/DMS-1220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ) change that originally added EdFi.DmsApi.TestSdk to the smoke-test SDK support.

## Downstream
Once a new EdFi.Suite3.SmokeTest.Console is published, the Data-Management-Service repo bumps its pinned console version (currently 7.3.20178) in eng/smoke_test/Invoke-{NonDestructive,Destructive}SdkTests.ps1.

[DMS-1192]: https://edfi.atlassian.net/browse/DMS-1192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DMS-1220]: https://edfi.atlassian.net/browse/DMS-1220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ