### PR TITLE
[ODS-6843] Make /data/v3 SDK base-path injection configurable in EdFi.SmokeTest.Console

### DIFF
--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SdkConfigurationFactoryTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SdkConfigurationFactoryTests.cs
@@ -43,12 +43,16 @@ namespace EdFi.LoadTools.Test.SmokeTests
                 .Returns(typeof(LegacySdkStub.Client.Configuration).Assembly.Location);
             A.CallTo(() => sdkLibraryConfiguration.SdkNamespacePrefix).Returns(StubNamespacePrefix);
 
+            // Legacy branch does not inject a data path; the value is irrelevant here.
+            var sdkDataPathConfiguration = A.Fake<ISdkDataPathConfiguration>();
+
             var tokenHandler = A.Fake<IOAuthTokenHandler>();
             A.CallTo(() => tokenHandler.GetBearerToken()).Returns(bearerToken);
 
             // No throw even though Client.HostConfiguration is absent from the (stub) SDK assembly.
             var factory = Should.NotThrow(
-                () => new SdkConfigurationFactory(apiConfiguration, sdkLibraryConfiguration, tokenHandler));
+                () => new SdkConfigurationFactory(
+                    apiConfiguration, sdkLibraryConfiguration, sdkDataPathConfiguration, tokenHandler));
 
             var configuration = factory.SdkConfiguration;
 
@@ -67,6 +71,59 @@ namespace EdFi.LoadTools.Test.SmokeTests
             // unchanged - old-generator operation paths omit /data/v3, so the base path must already
             // include it.
             legacyConfiguration.BasePath.ShouldBe(dataManagementApiUrl);
+        }
+    }
+
+    /// <summary>
+    ///     Exercises <see cref="SdkConfigurationFactory.ComposeSdkBaseAddress" />, the pure URL-composition
+    ///     used by the new-generator (host-configuration) SDK path to build the HttpClient BaseAddress from
+    ///     the server URL and the configured data-path suffix. The SDK concatenates BaseAddress.AbsolutePath
+    ///     with operation paths like "/ed-fi/...", so the base address must carry the data path with no
+    ///     trailing slash.
+    /// </summary>
+    [TestFixture]
+    public class SdkConfigurationFactoryBaseAddressTests
+    {
+        [Test]
+        public void Default_data_path_is_injected_into_a_root_base_url()
+        {
+            SdkConfigurationFactory.ComposeSdkBaseAddress("http://localhost:8765/", "/data/v3")
+                .AbsoluteUri.ShouldBe("http://localhost:8765/data/v3");
+        }
+
+        [Test]
+        public void Configured_data_path_override_is_used_instead_of_data_v3()
+        {
+            SdkConfigurationFactory.ComposeSdkBaseAddress("http://localhost:8765/", "/data")
+                .AbsoluteUri.ShouldBe("http://localhost:8765/data");
+        }
+
+        [Test]
+        public void Empty_data_path_leaves_the_base_url_path_as_is_trimming_trailing_slash()
+        {
+            SdkConfigurationFactory.ComposeSdkBaseAddress("http://localhost:8765/data/", "")
+                .AbsoluteUri.ShouldBe("http://localhost:8765/data");
+        }
+
+        [Test]
+        public void Slash_data_path_leaves_the_base_url_path_as_is_trimming_trailing_slash()
+        {
+            SdkConfigurationFactory.ComposeSdkBaseAddress("http://localhost:8765/data/", "/")
+                .AbsoluteUri.ShouldBe("http://localhost:8765/data");
+        }
+
+        [Test]
+        public void Already_present_data_path_is_not_duplicated_and_trailing_slash_is_removed()
+        {
+            SdkConfigurationFactory.ComposeSdkBaseAddress("http://localhost:8765/data/v3/", "/data/v3")
+                .AbsoluteUri.ShouldBe("http://localhost:8765/data/v3");
+        }
+
+        [Test]
+        public void Data_path_is_normalized_to_leading_slash_and_no_trailing_slash()
+        {
+            SdkConfigurationFactory.ComposeSdkBaseAddress("http://localhost:8765/", "data/v3/")
+                .AbsoluteUri.ShouldBe("http://localhost:8765/data/v3");
         }
     }
 }

--- a/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SmokeTestsConfigurationTests.cs
+++ b/Utilities/DataLoading/EdFi.LoadTools.Test/SmokeTests/SmokeTestsConfigurationTests.cs
@@ -32,6 +32,39 @@ namespace EdFi.LoadTools.Test.SmokeTests
         }
 
         [Test]
+        public void Create_should_default_data_path_to_data_v3()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                    new Dictionary<string, string>
+                    {
+                        ["TestSet"] = "DestructiveSdk"
+                    })
+                .Build();
+
+            var smokeTestsConfiguration = SmokeTestsConfiguration.Create(configuration);
+
+            Assert.AreEqual("/data/v3", smokeTestsConfiguration.DataPath);
+        }
+
+        [Test]
+        public void Create_should_read_data_path_from_ods_api_configuration()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                    new Dictionary<string, string>
+                    {
+                        ["TestSet"] = "DestructiveSdk",
+                        ["OdsApi:DataPath"] = "/data"
+                    })
+                .Build();
+
+            var smokeTestsConfiguration = SmokeTestsConfiguration.Create(configuration);
+
+            Assert.AreEqual("/data", smokeTestsConfiguration.DataPath);
+        }
+
+        [Test]
         public void Create_should_read_default_numeric_fallback_max_from_ods_api_configuration()
         {
             var configuration = new ConfigurationBuilder()

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/Application/CommandLineOverrides.cs
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/Application/CommandLineOverrides.cs
@@ -49,6 +49,11 @@ namespace EdFi.SmokeTest.Console.Application
         public string SdkNamespacePrefix { get; set; }
 
         [Option(
+            'd', "data-path", Required = false,
+            HelpText = "The data-management path segment injected into the new-generator SDK base address (default /data/v3). Use /data for DMS.")]
+        public string DataPath { get; set; }
+
+        [Option(
             "defaultNumericFallbackMax", Required = false,
             HelpText = "Maximum value used for required numeric properties when OpenAPI does not publish minimum or maximum bounds.")]
         public int? DefaultNumericFallbackMax { get; set; }
@@ -67,6 +72,7 @@ namespace EdFi.SmokeTest.Console.Application
                 {"-s", "OdsApi:Secret"},
                 {"-t", "TestSet"},
                 {"-c", "SdkNamespacePrefix"},
+                {"-d", "OdsApi:DataPath"},
                 {"--apiurl", "OdsApi:ApiUrl"},
                 {"--key", "OdsApi:Key"},
                 {"--library", "SdkLibraryPath"},
@@ -78,7 +84,8 @@ namespace EdFi.SmokeTest.Console.Application
                 {"--testset", "TestSet"},
                 {"--baseurl", "OdsApi:Url"},
                 {"--sdkNamespacePrefix", "SdkNamespacePrefix"},
-                {"--defaultNumericFallbackMax", "OdsApi:DefaultNumericFallbackMax"}
+                {"--defaultNumericFallbackMax", "OdsApi:DefaultNumericFallbackMax"},
+                {"--data-path", "OdsApi:DataPath"}
             };
     }
 }

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/Application/ISdkDataPathConfiguration.cs
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/Application/ISdkDataPathConfiguration.cs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.SmokeTest.Console.Application
+{
+    /// <summary>
+    ///     Supplies the data-management path segment (OdsApi:DataPath) injected into the new-generator SDK's
+    ///     HttpClient BaseAddress. This is intentionally a console-local interface rather than a member on the
+    ///     packaged <c>EdFi.LoadTools.Engine.ISdkLibraryConfiguration</c>, to avoid a compatibility break for
+    ///     external implementers of that published interface.
+    /// </summary>
+    public interface ISdkDataPathConfiguration
+    {
+        string DataPath { get; }
+    }
+}

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/Application/SdkConfigurationFactory.cs
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/Application/SdkConfigurationFactory.cs
@@ -26,12 +26,15 @@ namespace EdFi.SmokeTest.Console.Application
         public object SdkConfig;
 
         public SdkConfigurationFactory(IApiConfiguration apiConfiguration,
-                                       ISdkLibraryConfiguration sdkLibraryConfiguration, IOAuthTokenHandler tokenHandler)
+                                       ISdkLibraryConfiguration sdkLibraryConfiguration,
+                                       ISdkDataPathConfiguration sdkDataPathConfiguration,
+                                       IOAuthTokenHandler tokenHandler)
         {
             _tokenHandler = tokenHandler;
 
             var sdkGenerationBasePath = sdkLibraryConfiguration.Path;
             var owinServerUrl = apiConfiguration.Url;
+            var dataPath = sdkDataPathConfiguration.DataPath;
 
             // New-generator SDKs ship Client.HostConfiguration (DI-based); old-generator SDKs ship
             // only Client.Configuration. Probe for the new type first and select the mode by which
@@ -44,7 +47,7 @@ namespace EdFi.SmokeTest.Console.Application
             {
                 _isHostConfiguration = true;
                 _configType = hostConfigType;
-                _serviceProvider = ConfigureHostConfiguration(sdkGenerationBasePath, owinServerUrl);
+                _serviceProvider = ConfigureHostConfiguration(sdkGenerationBasePath, owinServerUrl, dataPath);
             }
             else
             {
@@ -96,7 +99,7 @@ namespace EdFi.SmokeTest.Console.Application
             }
         }
 
-        private IServiceProvider ConfigureHostConfiguration(string sdkGenerationBasePath, string owinServerUrl)
+        private IServiceProvider ConfigureHostConfiguration(string sdkGenerationBasePath, string owinServerUrl, string dataPath)
         {
             // Configure service collection for DI
             var services = new ServiceCollection();
@@ -129,33 +132,11 @@ namespace EdFi.SmokeTest.Console.Application
             var addApiHttpClientsMethod = _configType.GetMethod("AddApiHttpClients");
             if (addApiHttpClientsMethod != null)
             {
-                // Create delegate for configuring HttpClient
+                // Create delegate for configuring HttpClient. The data-path suffix injected into the
+                // BaseAddress is configurable (OdsApi:DataPath, default "/data/v3"); see ComposeSdkBaseAddress.
                 Action<HttpClient> configureClient = (client) =>
                 {
-                    // CRITICAL: The SDK constructs URLs by concatenating BaseAddress.AbsolutePath + "/ed-fi/..."
-                    // So we need to include /data/v3 in the base address WITHOUT a trailing slash
-                    // to avoid double slashes: /data/v3//ed-fi/...
-                    var baseUri = new Uri(owinServerUrl);
-
-                    // If the base URL doesn't have /data/v3, add it
-                    if (!baseUri.AbsolutePath.Contains("/data/v3"))
-                    {
-                        var uriBuilder = new UriBuilder(baseUri)
-                        {
-                            Path = "/data/v3"  // No trailing slash
-                        };
-                        client.BaseAddress = uriBuilder.Uri;
-                    }
-                    else
-                    {
-                        // Remove trailing slash if present
-                        var path = baseUri.AbsolutePath.TrimEnd('/');
-                        var uriBuilder = new UriBuilder(baseUri)
-                        {
-                            Path = path
-                        };
-                        client.BaseAddress = uriBuilder.Uri;
-                    }
+                    client.BaseAddress = ComposeSdkBaseAddress(owinServerUrl, dataPath);
                 };
 
                 // Call AddApiHttpClients(configureClient, null)
@@ -171,6 +152,44 @@ namespace EdFi.SmokeTest.Console.Application
             SdkConfig = hostConfiguration;
 
             return serviceProvider;
+        }
+
+        /// <summary>
+        ///     Composes the new-generator SDK's HttpClient BaseAddress from the server URL and the configured
+        ///     data-path suffix. The SDK constructs request URLs by concatenating BaseAddress.AbsolutePath with
+        ///     operation paths like "/ed-fi/...", so the base address must carry the data path WITHOUT a trailing
+        ///     slash (otherwise "/data/v3//ed-fi/..."). Behavior:
+        ///     <list type="bullet">
+        ///         <item>Empty/whitespace/"/" data path: no segment is injected; the base URL path is kept, only
+        ///         its trailing slash trimmed.</item>
+        ///         <item>Otherwise the data path is normalized to a leading slash and no trailing slash.</item>
+        ///         <item>If the base URL path already contains the (normalized) data path, it is not appended
+        ///         again (escape hatch); the trailing slash is still trimmed.</item>
+        ///     </list>
+        /// </summary>
+        public static Uri ComposeSdkBaseAddress(string owinServerUrl, string dataPath)
+        {
+            var baseUri = new Uri(owinServerUrl);
+            var normalizedDataPath = NormalizeDataPath(dataPath);
+
+            // No injection (empty/"/" data path) OR the base URL already carries the data path (escape hatch):
+            // keep the base URL's own path, trimming only a trailing slash.
+            var path = string.IsNullOrEmpty(normalizedDataPath) || baseUri.AbsolutePath.Contains(normalizedDataPath)
+                ? baseUri.AbsolutePath.TrimEnd('/')
+                : normalizedDataPath;
+
+            return new UriBuilder(baseUri) { Path = path }.Uri;
+        }
+
+        // Normalizes a configured data path to a leading slash with no trailing slash (e.g. "data/v3/" ->
+        // "/data/v3"). Returns empty string for null/whitespace/"/" to signal "do not inject a segment".
+        private static string NormalizeDataPath(string dataPath)
+        {
+            var trimmed = dataPath?.Trim().Trim('/');
+
+            return string.IsNullOrEmpty(trimmed)
+                ? string.Empty
+                : $"/{trimmed}";
         }
 
         private static Type TryGetTypeFromAssembly(string sdkAssemblyPath, string typeToRetrieve)

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/Application/SmokeTestsConfiguration.cs
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/Application/SmokeTestsConfiguration.cs
@@ -14,8 +14,12 @@ using Microsoft.Extensions.Configuration;
 namespace EdFi.SmokeTest.Console.Application
 {
     public class SmokeTestsConfiguration : IApiConfiguration, IApiMetadataConfiguration, IOAuthTokenConfiguration,
-        IOAuthSessionToken, ISdkLibraryConfiguration, IDestructiveTestConfiguration
+        IOAuthSessionToken, ISdkLibraryConfiguration, ISdkDataPathConfiguration, IDestructiveTestConfiguration
     {
+        // Default data-management path segment injected into the new-generator SDK HttpClient.BaseAddress.
+        // Preserves historical ODS behavior when OdsApi:DataPath is not configured.
+        public const string DefaultDataPath = "/data/v3";
+
         public string ApiUrl { get; set; }
 
         public string OAuthKey { get; set; }
@@ -29,6 +33,8 @@ namespace EdFi.SmokeTest.Console.Application
         public string XsdMetadataUrl { get; set; }
 
         public string SdkLibraryPath { get; set; }
+
+        public string DataPath { get; set; }
 
         public TestSet TestSet { get; set; }
 
@@ -143,6 +149,7 @@ namespace EdFi.SmokeTest.Console.Application
                     "OdsApi:DefaultNumericFallbackMax",
                     DestructiveTestConfigurationDefaults.DefaultNumericFallbackMax),
                 SdkLibraryPath = configuration.GetValue<string>("SdkLibraryPath"),
+                DataPath = configuration.GetValue("OdsApi:DataPath", DefaultDataPath),
                 TestSet = testSet
             };
 

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/EdFi.SmokeTest.Console.csproj
@@ -43,6 +43,7 @@
     <PackageReference Include="EdFi.Suite3.Common" />
     <PackageReference Include="log4net" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/Program.cs
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/Program.cs
@@ -74,6 +74,7 @@ namespace EdFi.SmokeTest.Console
                 var configRoot = new ConfigurationBuilder()
                     .SetBasePath(Directory.GetParent(AppContext.BaseDirectory).FullName)
                     .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                    .AddEnvironmentVariables()
                     .AddCommandLine(args, CommandLineOverrides.SwitchingMapping())
                     .AddUserSecrets<CommandLineOverrides>()
                     .Build();
@@ -127,6 +128,7 @@ namespace EdFi.SmokeTest.Console
                     .As<IOAuthTokenConfiguration>()
                     .As<IOAuthSessionToken>()
                     .As<ISdkLibraryConfiguration>()
+                    .As<ISdkDataPathConfiguration>()
                     .As<IDestructiveTestConfiguration>()
                     .AsSelf()
                     .SingleInstance();

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/appsettings.json
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/appsettings.json
@@ -14,6 +14,7 @@
     "OAuthUrl": "",
     "DependenciesUrl": "",
     "Url": "",
+    "DataPath": "/data/v3",
     "DefaultNumericFallbackMax": 999
   },
   "NamespacePrefix": "uri://ed-fi.org",

--- a/Utilities/DataLoading/EdFi.SmokeTest.Console/readme.md
+++ b/Utilities/DataLoading/EdFi.SmokeTest.Console/readme.md
@@ -13,6 +13,47 @@ To disable authorization you can run this query on the EdFi_Security database
 
 Deleting the EdFi_Security database will cause it to be rebuilt with the default claims
 
+## SDK data path
+
+For SDK test sets the tool builds the new-generator SDK's `HttpClient.BaseAddress` by injecting a
+data-management path segment onto the API server URL. This segment defaults to `/data/v3`, which matches
+the standard ODS convention, so ordinary ODS runs need no change. APIs that serve data routes under a
+different path can override it &mdash; for example DMS serves data under `/data`.
+
+Behavior of the configured value (`OdsApi:DataPath`):
+
+- Non-empty values are normalized to a leading slash with no trailing slash (`data/v3/` becomes `/data/v3`).
+- Empty, whitespace, or `/` injects no segment; the server URL's own path is used (trailing slash trimmed).
+- If the server URL already contains the configured data path, it is not appended again (the check is a
+  simple substring match, preserved from earlier behavior); the trailing slash is still trimmed.
+
+Override in `appsettings.json`:
+
+```json
+{
+  "OdsApi": {
+    "DataPath": "/data"
+  }
+}
+```
+
+Override with an environment variable (standard .NET double-underscore section separator):
+
+```powershell
+$env:OdsApi__DataPath = "/data"
+```
+
+Override from the command line:
+
+```powershell
+dotnet run --project EdFi.SmokeTest.Console.csproj -- --data-path /data
+```
+
+The `-d` short form is equivalent to `--data-path`.
+
+Configuration sources are applied in this order, with later sources overriding earlier ones:
+`appsettings.json` < environment variables < command-line arguments < user secrets.
+
 ## destructive SDK numeric fallback
 
 When OpenAPI omits `minimum` and `maximum` for a required numeric property, destructive SDK tests generate


### PR DESCRIPTION
## Summary

`EdFi.SmokeTest.Console` hardcoded the `/data/v3` data-management path segment into the new-generator SDK's `HttpClient.BaseAddress`, blocking use against APIs (e.g. DMS) that serve data routes under a different path such as `/data`. This introduces a configurable data-path suffix (default `/data/v3`) with CLI / appsettings / env-var parity, preserving unchanged behavior for ordinary ODS users.

## Changes

- **New `OdsApi:DataPath` setting** (default `/data/v3`), read in `SmokeTestsConfiguration.Create`.
- **`SdkConfigurationFactory.ComposeSdkBaseAddress`** replaces the hardcoded `/data/v3`:
  - normalizes the value to a leading slash / no trailing slash (`data/v3/` → `/data/v3`);
  - treats empty / whitespace / `/` as "no injection" — keeps the base URL path, trimming only a trailing slash;
  - preserves the existing escape hatch (if the base URL already contains the configured path it is not appended again; still trims trailing slash).
- **CLI**: `-d` / `--data-path` mapped to `OdsApi:DataPath`.
- **Env var**: `.AddEnvironmentVariables()` added to the config builder so `OdsApi__DataPath=/data` works. Precedence: `appsettings.json < environment variables < command-line arguments < user secrets`.
- **Docs**: readme section covering the default and the appsettings/env/CLI override options.

## Compatibility

The packaged `EdFi.LoadTools.Engine.ISdkLibraryConfiguration` interface is **left unchanged**. The setting flows through a new console-local `ISdkDataPathConfiguration` (in `EdFi.SmokeTest.Console.Application`) to avoid a source/binary compatibility break for external implementers of the published interface. The legacy `Client.Configuration` path is unchanged.

## Testing

- `SmokeTestsConfigurationTests`: `Create` defaults `DataPath` to `/data/v3`; reads `OdsApi:DataPath`.
- `SdkConfigurationFactoryBaseAddressTests`: 6 cases covering default injection, `/data` override, empty/`/` no-injection, already-present de-duplication, and normalization.
- Existing legacy `Client.Configuration` passthrough test retained as a regression guard.
- **90/90 SmokeTests pass**; console builds with 0 warnings under `TreatWarningsAsErrors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
